### PR TITLE
Install spdlog in environment

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -19,6 +19,7 @@ dependencies:
 - openmpi
 - pre-commit
 - python>=3.10,<3.13
+- spdlog
 - sysroot_linux-aarch64=2.17
 - valgrind
 name: all_cuda-118_arch-aarch64

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -19,6 +19,7 @@ dependencies:
 - openmpi
 - pre-commit
 - python>=3.10,<3.13
+- spdlog
 - sysroot_linux-64=2.17
 - valgrind
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -21,6 +21,7 @@ dependencies:
 - openmpi
 - pre-commit
 - python>=3.10,<3.13
+- spdlog
 - sysroot_linux-aarch64=2.17
 - valgrind
 name: all_cuda-125_arch-aarch64

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -21,6 +21,7 @@ dependencies:
 - openmpi
 - pre-commit
 - python>=3.10,<3.13
+- spdlog
 - sysroot_linux-64=2.17
 - valgrind
 name: all_cuda-125_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -51,6 +51,7 @@ dependencies:
           - cxx-compiler
           - &cudf_unsuffixed libcudf==25.02.*,>=0.0.0a0
           - openmpi  # See <https://github.com/rapidsai/rapids-multi-gpu/issues/17>
+          - spdlog
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
cudf was not finding spdlog, resulting in other downstream errors from cudf-dependencies.cmake. Install spdlog.