### PR TITLE
Use GCC 13 / glibc 2.28

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -28,6 +28,6 @@ dependencies:
 - rmm==25.2.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - spdlog
-- sysroot_linux-aarch64=2.17
+- sysroot_linux-aarch64=2.28
 - valgrind
 name: all_cuda-118_arch-aarch64

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -28,6 +28,6 @@ dependencies:
 - rmm==25.2.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - spdlog
-- sysroot_linux-64=2.17
+- sysroot_linux-64=2.28
 - valgrind
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-125_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-125_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
-- gcc_linux-aarch64=11.*
+- gcc_linux-aarch64=13.*
 - libcudf==25.2.*,>=0.0.0a0
 - mpi4py
 - ninja
@@ -30,6 +30,6 @@ dependencies:
 - rmm==25.2.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - spdlog
-- sysroot_linux-aarch64=2.17
+- sysroot_linux-aarch64=2.28
 - valgrind
 name: all_cuda-125_arch-aarch64

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cxx-compiler
 - cython>=3.0.3
 - doxygen=1.9.1
-- gcc_linux-64=11.*
+- gcc_linux-64=13.*
 - libcudf==25.2.*,>=0.0.0a0
 - mpi4py
 - ninja
@@ -30,6 +30,6 @@ dependencies:
 - rmm==25.2.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - spdlog
-- sysroot_linux-64=2.17
+- sysroot_linux-64=2.28
 - valgrind
 name: all_cuda-125_arch-x86_64

--- a/conda/recipes/librapidsmp/conda_build_config.yaml
+++ b/conda/recipes/librapidsmp/conda_build_config.yaml
@@ -1,20 +1,20 @@
 c_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cxx_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+
+cuda_compiler:
+  - cuda-nvcc  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - nvcc  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cmake_version:
   - ">=3.26.4,!=3.30.0"
-
-cuda_compiler:
-  - cuda-nvcc
-
-cuda11_compiler:
-  - nvcc
 
 c_stdlib:
   - sysroot
 
 c_stdlib_version:
-  - "2.17"
+  - "2.28"

--- a/conda/recipes/librapidsmp/meta.yaml
+++ b/conda/recipes/librapidsmp/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
 {% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
@@ -36,7 +36,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }} ={{ cuda_version }}
+    - {{ compiler('cuda') }} ={{ cuda_version }}
     {% else %}
     - {{ compiler('cuda') }}
     {% endif %}
@@ -65,10 +65,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage("librapidsmp", max_pin="x.x") }}
       ignore_run_exports_from:
-        {% if cuda_major == "11" %}
-        - {{ compiler('cuda11') }}
-        {% else %}
         - {{ compiler('cuda') }}
+        {% if cuda_major != "11" %}
         - cuda-cudart-dev
         {% endif %}
     requirements:
@@ -105,10 +103,8 @@ outputs:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
-        {% if cuda_major == "11" %}
-        - {{ compiler('cuda11') }}
-        {% else %}
         - {{ compiler('cuda') }}
+        {% if cuda_major != "11" %}
         - cuda-cudart-dev
         {% endif %}
     requirements:

--- a/conda/recipes/rapidsmp/conda_build_config.yaml
+++ b/conda/recipes/rapidsmp/conda_build_config.yaml
@@ -1,20 +1,20 @@
 c_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cxx_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+
+cuda_compiler:
+  - cuda-nvcc  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - nvcc  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cmake_version:
   - ">=3.26.4,!=3.30.0"
-
-cuda_compiler:
-  - cuda-nvcc
-
-cuda11_compiler:
-  - nvcc
 
 c_stdlib:
   - sysroot
 
 c_stdlib_version:
-  - "2.17"
+  - "2.28"

--- a/conda/recipes/rapidsmp/meta.yaml
+++ b/conda/recipes/rapidsmp/meta.yaml
@@ -34,10 +34,8 @@ build:
     - SCCACHE_S3_USE_SSL
     - SCCACHE_S3_NO_CREDENTIALS
   ignore_run_exports_from:
-    {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }}
-    {% else %}
     - {{ compiler('cuda') }}
+    {% if cuda_major != "11" %}
     - cuda-cudart-dev
     {% endif %}
 
@@ -46,7 +44,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }} ={{ cuda_version }}
+    - {{ compiler('cuda') }} ={{ cuda_version }}
     {% else %}
     - {{ compiler('cuda') }}
     {% endif %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,14 +68,28 @@ dependencies:
         matrices:
           - matrix:
               arch: x86_64
+              cuda: "11.*"
             packages:
               - gcc_linux-64=11.*
-              - sysroot_linux-64=2.17
+              - sysroot_linux-64=2.28
           - matrix:
               arch: aarch64
+              cuda: "11.*"
             packages:
               - gcc_linux-aarch64=11.*
-              - sysroot_linux-aarch64=2.17
+              - sysroot_linux-aarch64=2.28
+          - matrix:
+              arch: x86_64
+              cuda: "12.*"
+            packages:
+              - gcc_linux-64=13.*
+              - sysroot_linux-64=2.28
+          - matrix:
+              arch: aarch64
+              cuda: "12.*"
+            packages:
+              - gcc_linux-aarch64=13.*
+              - sysroot_linux-aarch64=2.28
       - output_types: conda
         matrices:
           - matrix:


### PR DESCRIPTION
## Description
conda-forge is using GCC 13 for CUDA 12 builds. This PR updates CUDA 12 conda builds to use GCC 13, for alignment.

See https://github.com/rapidsai/build-planning/issues/129 for details.
