### PR TITLE
Add nightly GHA workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ on:
         type: string
       build_type:
         type: string
-        default: nightly
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nightly-pipeline.yaml
+++ b/.github/workflows/nightly-pipeline.yaml
@@ -16,7 +16,7 @@ on:
         type: string
       build_type:
         type: string
-        default: nightly
+        default: branch
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ on:
         type: string
       build_type:
         type: string
-        default: nightly
+        required: true
 
 jobs:
   conda-cpp-tests:


### PR DESCRIPTION
Add nightly GHA workflow to run every night at 5am UTC, [like other RAPIDS workflows](https://github.com/rapidsai/workflows/blob/b2b6aa1f4220c6a0bf8323fffa9ced429f723855/.github/workflows/nightly-pipeline-trigger.yaml#L5-L6).