### PR TITLE
Avoid printing null-terminators

### DIFF
--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -223,14 +223,12 @@ int main(int argc, char** argv) {
         );
         cudaDeviceProp properties;
         CUDF_CUDA_TRY(cudaGetDeviceProperties(&properties, 0));
-        ss << "Hardware setup:" << std::endl;
-        ss << "  GPU (" << properties.name << "):" << std::endl;
-        ss << "    Device number: " << cur_dev << std::endl;
-        ss << "    PCI Bus ID: " << pci_bus_id.substr(0, pci_bus_id.find('\0'))
-           << std::endl;
-        ss << "    Total Memory: " << format_nbytes(properties.totalGlobalMem, 0)
-           << std::endl;
-        ss << "  Comm: " << *comm << std::endl;
+        ss << "Hardware setup: \n";
+        ss << "  GPU (" << properties.name << "): \n";
+        ss << "    Device number: " << cur_dev << "\n";
+        ss << "    PCI Bus ID: " << pci_bus_id.substr(0, pci_bus_id.find('\0')) << "\n";
+        ss << "    Total Memory: " << format_nbytes(properties.totalGlobalMem, 0) << "\n";
+        ss << "  Comm: " << *comm << "\n";
         log.info(ss.str());
     }
 

--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -325,14 +325,13 @@ int main(int argc, char** argv) {
         );
         cudaDeviceProp properties;
         CUDF_CUDA_TRY(cudaGetDeviceProperties(&properties, 0));
-        ss << "Hardware setup:" << std::endl;
-        ss << "  GPU (" << properties.name << "):" << std::endl;
-        ss << "    Device number: " << cur_dev << std::endl;
-        ss << "    PCI Bus ID: " << pci_bus_id.substr(0, pci_bus_id.find('\0'))
-           << std::endl;
+        ss << "Hardware setup: \n";
+        ss << "  GPU (" << properties.name << "): \n";
+        ss << "    Device number: " << cur_dev << "\n";
+        ss << "    PCI Bus ID: " << pci_bus_id.substr(0, pci_bus_id.find('\0')) << "\n";
         ss << "    Total Memory: "
-           << rapidsmp::format_nbytes(properties.totalGlobalMem, 0) << std::endl;
-        ss << "  Comm: " << *comm << std::endl;
+           << rapidsmp::format_nbytes(properties.totalGlobalMem, 0) << "\n";
+        ss << "  Comm: " << *comm << "\n";
         log.info(ss.str());
     }
 


### PR DESCRIPTION
The PCI bus ID is retrieved by passing a pre-allocated string that will be overwritten but null-terminators will remain, when the `std::string` is redirected to a `std::stringstream` the null-terminators are treated as regular characters and printed as such. Those are most of the time invisible, but when the output is redirected to a file or another program such as `grep` it may be a identified as a binary file due to the presence of null-terminators. This change ensures only valid characters are redirected to the `std::stringstream`.

Additionally, replace the use of `"\n"` line breaks with the C++ `std::endl` instead.