### PR TITLE
Increase timeout of C++ MPI tests and make timeouts verbose

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -17,7 +17,7 @@ run_mpirun_test() {
     local nrank="$2"   # Number of ranks
     local test="$3"    # Test name
     echo "Running ctest with $nrank ranks"
-    timeout "$timeout" mpirun --map-by node --bind-to none -np "$nrank" \
+    timeout -v "$timeout" mpirun --map-by node --bind-to none -np "$nrank" \
         ctest --verbose --no-tests=error --output-on-failure -R "$test" $EXTRA_ARGS
 }
 

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -16,7 +16,7 @@ run_mpirun_test() {
     local timeout="$1" # Timeout
     local nrank="$2"   # Number of ranks
     echo "Running pytest with $nrank ranks"
-    timeout "$timeout" mpirun --map-by node --bind-to none -np "$nrank" \
+    timeout -v "$timeout" mpirun --map-by node --bind-to none -np "$nrank" \
         python -m pytest --cache-clear --verbose $EXTRA_ARGS tests
 }
 


### PR DESCRIPTION
Increase timeout of C++ MPI tests that have timed out for the first time tonight, which is probably the same as https://github.com/rapidsai/rapids-multi-gpu/issues/75 . Additionally add verbose flag to `timeout` command so that it clearly prints the timeout occurred.