### PR TITLE
Bulk MPI Shuffle - Print elapsed time on all ranks

### DIFF
--- a/python/rapidsmp/rapidsmp/examples/bulk_mpi_shuffle.py
+++ b/python/rapidsmp/rapidsmp/examples/bulk_mpi_shuffle.py
@@ -308,11 +308,10 @@ Shuffle:
     elapsed_time = MPI.Wtime() - start_time
     MPI.COMM_WORLD.barrier()
 
-    if comm.rank == 0:
-        mem_peak = format_bytes(mr.allocation_counts.peak_bytes)
-        comm.logger.info(
-            f"elapsed: {elapsed_time:.2f} sec | rmm device memory peak: {mem_peak}"
-        )
+    mem_peak = format_bytes(mr.allocation_counts.peak_bytes)
+    comm.logger.info(
+        f"elapsed: {elapsed_time:.2f} sec | rmm device memory peak: {mem_peak}"
+    )
     if stats.enabled:
         comm.logger.info(stats.report())
 


### PR DESCRIPTION
Coming out of some testing during #124 where the elapsed time for some ranks can be 20-30s longer than rank0 which is usually the faster rank.