### PR TITLE
Disable UCXX endpoint error handling

### DIFF
--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -118,7 +118,7 @@ class SharedResources {
     std::mutex futures_mutex_{};
     std::mutex listener_mutex_{};
     std::mutex delayed_progress_callbacks_mutex_{};
-    bool enable_endpoint_error_handling_{false
+    bool endpoint_error_handling_{false
     };  ///< Whether to request UCX endpoint error handling. This is currently disabled
         ///< as it impacts performance very negatively.
         ///< See https://github.com/rapidsai/rapids-multi-gpu/issues/140.
@@ -425,8 +425,8 @@ class SharedResources {
      *
      * @return `true` if endpoint error handling should be enabled, `false` otherwise.
      */
-    bool enable_endpoint_error_handling() {
-        return enable_endpoint_error_handling_;
+    bool endpoint_error_handling() {
+        return endpoint_error_handling_;
     }
 };
 
@@ -676,7 +676,7 @@ void control_unpack(
             );
             auto endpoint =
                 shared_resources->get_worker()->createEndpointFromWorkerAddress(
-                    worker_address, shared_resources->enable_endpoint_error_handling()
+                    worker_address, shared_resources->endpoint_error_handling()
                 );
             shared_resources->register_endpoint(client_rank, endpoint);
 
@@ -772,7 +772,7 @@ void listener_callback(ucp_conn_request_h conn_request, void* arg) {
         );
 
     auto endpoint = shared_resources->get_listener()->createEndpointFromConnRequest(
-        conn_request, shared_resources->enable_endpoint_error_handling()
+        conn_request, shared_resources->endpoint_error_handling()
     );
 
     if (shared_resources->rank() == 0) {
@@ -867,14 +867,13 @@ std::unique_ptr<rapidsmp::ucxx::InitializedRank> init(
                     return shared_resources->get_worker()->createEndpointFromHostname(
                         remote_address.first,
                         remote_address.second,
-                        shared_resources->enable_endpoint_error_handling()
+                        shared_resources->endpoint_error_handling()
                     );
                 } else if constexpr (std::is_same_v<T, std::shared_ptr<::ucxx::Address>>)
                 {
                     auto root_endpoint =
                         shared_resources->get_worker()->createEndpointFromWorkerAddress(
-                            remote_address,
-                            shared_resources->enable_endpoint_error_handling()
+                            remote_address, shared_resources->endpoint_error_handling()
                         );
 
                     auto packed_listener_address_rank = control_pack(
@@ -1033,14 +1032,13 @@ std::shared_ptr<::ucxx::Endpoint> UCXX::get_endpoint(Rank rank) {
                     return shared_resources_->get_worker()->createEndpointFromHostname(
                         remote_address.first,
                         remote_address.second,
-                        shared_resources_->enable_endpoint_error_handling()
+                        shared_resources_->endpoint_error_handling()
                     );
                 } else if constexpr (std::is_same_v<T, std::shared_ptr<::ucxx::Address>>)
                 {
                     return shared_resources_->get_worker()
                         ->createEndpointFromWorkerAddress(
-                            remote_address,
-                            shared_resources_->enable_endpoint_error_handling()
+                            remote_address, shared_resources_->endpoint_error_handling()
                         );
                 } else {
                     RAPIDSMP_EXPECTS(false, "Unknown argument type");


### PR DESCRIPTION
As described in #140 , requesting endpoint error handling currently disables `cma` which is detrimental to performance on workloads that require spilling. This change disables it by default with a hardcoded attribute that we may use to revisit later should `cma` add endpoint error handling support or in case we see critical issues due to disabling endpoint error handling.

Fixes #124 .