### PR TITLE
Fix build errors

### DIFF
--- a/cpp/src/buffer/spill_manager.cpp
+++ b/cpp/src/buffer/spill_manager.cpp
@@ -81,7 +81,7 @@ std::size_t SpillManager::spill_to_make_headroom(std::int64_t headroom) {
     if (headroom <= available) {
         return 0;
     }
-    return spill(headroom - available);
+    return spill(static_cast<std::size_t>(headroom - available));
 }
 
 }  // namespace rapidsmp

--- a/cpp/tests/test_spill_manager.cpp
+++ b/cpp/tests/test_spill_manager.cpp
@@ -101,9 +101,8 @@ TEST(SpillManager, PeriodicSpillCheck) {
 
     // Spill function that increases `mem` for each call.
     std::int64_t num_calls = 0;
-    SpillManager::SpillFunction func = [&num_calls](std::size_t amount) -> std::size_t {
-        return ++num_calls;
-    };
+    SpillManager::SpillFunction func =
+        [&num_calls](std::size_t /* amount */) -> std::size_t { return ++num_calls; };
     br.spill_manager().add_spill_function(func, 0);
 
     std::this_thread::sleep_for(period * 100);


### PR DESCRIPTION
Fix build errors that were introduced because https://github.com/rapidsai/rapids-multi-gpu/pull/146 was merged before https://github.com/rapidsai/rapids-multi-gpu/pull/158 , without the latter having updated the branch.