### PR TITLE
Ensure downloading rapids-cmake is retried

### DIFF
--- a/cmake/download_with_retry.cmake
+++ b/cmake/download_with_retry.cmake
@@ -1,0 +1,90 @@
+#=============================================================================
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+#=============================================================================
+
+#[=======================================================================[.rst:
+rapids_download_with_retry
+--------------------------
+
+.. versionadded:: v25.06.00
+
+Downloads a file from a URL with retry logic for handling network issues.
+
+  .. code-block:: cmake
+
+    rapids_download_with_retry(url output_file [max_retries] [retry_delay])
+
+This function will attempt to download the file multiple times if network issues occur.
+It verifies the download by checking that the file exists, has content, and contains
+the expected text. If all retries fail, it will raise a fatal error.
+
+``url``
+  The URL to download from.
+
+``output_file``
+  The path where the downloaded file should be saved.
+
+``max_retries``
+  Maximum number of retry attempts. Defaults to 3.
+
+``retry_delay``
+  Delay between retries in seconds. Defaults to 5.
+
+#]=======================================================================]
+function(rapids_download_with_retry url output_file)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cmake.download_with_retry")
+
+  set(options)
+  set(one_value MAX_RETRIES RETRY_DELAY)
+  set(multi_value)
+  cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
+
+  # Set default values for optional arguments
+  if(NOT DEFINED _RAPIDS_MAX_RETRIES)
+    set(_RAPIDS_MAX_RETRIES 3)
+  endif()
+  if(NOT DEFINED _RAPIDS_RETRY_DELAY)
+    set(_RAPIDS_RETRY_DELAY 5)
+  endif()
+
+  # Set up retry parameters
+  set(current_retry 0)
+  set(download_success FALSE)
+
+  while(NOT download_success AND current_retry LESS ${_RAPIDS_MAX_RETRIES})
+    if(current_retry GREATER 0)
+      message(STATUS "Retrying download (attempt ${current_retry} of ${_RAPIDS_MAX_RETRIES}) after ${_RAPIDS_RETRY_DELAY} seconds..."
+      )
+      execute_process(COMMAND ${CMAKE_COMMAND} -E sleep ${_RAPIDS_RETRY_DELAY})
+    endif()
+
+    # Remove any existing file to ensure clean download
+    if(EXISTS "${output_file}")
+      file(REMOVE "${output_file}")
+    endif()
+
+    file(DOWNLOAD "${url}" "${output_file}" LOG download_log)
+
+    # Check if file exists and has content
+    if(EXISTS "${output_file}")
+      file(SIZE "${output_file}" file_size)
+      if(file_size GREATER 0)
+        set(download_success TRUE)
+      else()
+        message(WARNING "Downloaded file is empty")
+        file(REMOVE "${output_file}")
+      endif()
+    endif()
+
+    if(NOT download_success)
+      math(EXPR current_retry "${current_retry} + 1")
+      if(current_retry LESS ${_RAPIDS_MAX_RETRIES})
+        message(WARNING "Failed to download file. Will retry. Download log:\n${download_log}")
+      else()
+        message(FATAL_ERROR "Failed to download file after ${_RAPIDS_MAX_RETRIES} attempts. Download log:\n${download_log}"
+        )
+      endif()
+    endif()
+  endwhile()
+endfunction()

--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # =================================================================================
 
+set(rapids-cmake-url
+    "https://github.com/pentschev/rapids-cmake/archive/refs/heads/download-retry.zip"
+)
+include("../cmake/download_with_retry.cmake")
+
 file(READ "${CMAKE_CURRENT_LIST_DIR}/../VERSION" _rapids_version)
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")
@@ -19,8 +24,7 @@ else()
 endif()
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/RAPIDSMP_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
-  file(
-    DOWNLOAD
+  rapids_download_with_retry(
     "https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION_MAJOR_MINOR}/RAPIDS.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/RAPIDSMP_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake"
   )


### PR DESCRIPTION
In some networks there may be instabilities causing the build to fail while downloading rapids-cmake or its components, this makes use https://github.com/rapidsai/rapids-cmake/pull/809 to address that but requires a copy of `rapids_download_with_retry` to ensure downloading rapids-cmake itself has a better chance of success.