### PR TITLE
Fix `cudf_polars` imports

### DIFF
--- a/python/rapidsmp/rapidsmp/integrations/dask/__init__.py
+++ b/python/rapidsmp/rapidsmp/integrations/dask/__init__.py
@@ -1,3 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """RAPIDSMP Dask Integrations."""
+
+from __future__ import annotations
+
+from rapidsmp.integrations.dask.core import bootstrap_dask_cluster
+from rapidsmp.integrations.dask.shuffler import rapidsmp_shuffle_graph
+
+__all__: list[str] = [
+    "bootstrap_dask_cluster",
+    "rapidsmp_shuffle_graph",
+]


### PR DESCRIPTION
Follow-up to https://github.com/rapidsai/rapids-multi-gpu/pull/174

Allows us to avoid changes in `cudf_polars` (as mentioned in https://github.com/rapidsai/rapids-multi-gpu/pull/174#issuecomment-2773454136). If we don't want to add these imports to `rapidsmp/integrations/dask/__init__.py`, we just need to update the import paths in `cudf_polars`.