### PR TITLE
ci pytest: increase timeout 5m -> 10m

### DIFF
--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -18,7 +18,7 @@ run_mpirun_test() {
     local nrank="$2"   # Number of ranks
     echo "Running pytest with $nrank ranks"
     timeout -v "$timeout" mpirun --map-by node --bind-to none -np "$nrank" \
-        python -m pytest --cache-clear --verbose $EXTRA_ARGS tests
+        python -m pytest --cache-clear --verbose --durations=10 $EXTRA_ARGS tests
 }
 
 # Note, we run with many different number of ranks, which we can do as long as


### PR DESCRIPTION
I think we need to increase the timeout of the pytest tests to avoids fails like: https://github.com/rapidsai/rapids-multi-gpu/actions/runs/14381096440/job/40325775568?pr=198