### PR TITLE
Add pytest fixture to initialize/shutdown Ray cluster

### DIFF
--- a/python/rapidsmp/rapidsmp/tests/test_ray.py
+++ b/python/rapidsmp/rapidsmp/tests/test_ray.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import pynvml
 import toolz
@@ -13,6 +14,9 @@ os.environ["RAY_IGNORE_UNHANDLED_ERRORS"] = "1"
 import pytest
 
 ray = pytest.importorskip("ray")
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 from rapidsmp.examples.ray.ray_shuffle_example import (  # noqa: E402
     ShufflingActor,
@@ -44,8 +48,13 @@ pytestmark = pytest.mark.skipif(
     reason="Ray tests should not run with more than one MPI process",
 )
 
-# initialize ray with 4 cpu processes
-ray.init(num_cpus=4)
+
+@pytest.fixture(scope="module")
+def ray_cluster() -> Generator[None, None, None]:
+    """Initialize Ray cluster for all tests in this module."""
+    ray.init(num_cpus=4)
+    yield
+    ray.shutdown()
 
 
 @ray.remote(num_cpus=1)
@@ -60,7 +69,7 @@ class DummyActor(RapidsMPActor):
 
 
 @pytest.mark.parametrize("num_workers", [1, 2, 4])
-def test_ray_ucxx_cluster(num_workers: int) -> None:
+def test_ray_ucxx_cluster(ray_cluster: None, num_workers: int) -> None:
     # setup the UCXX cluster using DummyActors
     gpu_actors = setup_ray_ucxx_cluster(DummyActor, num_workers)
 
@@ -79,7 +88,7 @@ def test_ray_ucxx_cluster(num_workers: int) -> None:
 
 
 @pytest.mark.parametrize("num_workers", [1, 2, 4])
-def test_ray_ucxx_cluster_not_initialized(num_workers: int) -> None:
+def test_ray_ucxx_cluster_not_initialized(ray_cluster: None, num_workers: int) -> None:
     # setup the UCXX cluster using DummyActors
     # there's some fancy monkeypatching in ray making `DummyActor.remote` available
     gpu_actors = [DummyActor.remote(num_workers) for _ in range(num_workers)]  # type: ignore[attr-defined]
@@ -97,7 +106,7 @@ def test_ray_ucxx_cluster_not_initialized(num_workers: int) -> None:
             ray.kill(actor)
 
 
-def test_disallowed_classes() -> None:
+def test_disallowed_classes(ray_cluster: None) -> None:
     # class that doesnt extend RapidsMPActor or ray actor
     class NonActor: ...
 
@@ -130,7 +139,7 @@ def get_gpu_count() -> int:
 @pytest.mark.parametrize("batch_size", [-1, 10])
 @pytest.mark.parametrize("total_num_partitions", [1, 10])
 def test_ray_shuffle_actor(
-    num_workers: int, batch_size: int, total_num_partitions: int
+    ray_cluster: None, num_workers: int, batch_size: int, total_num_partitions: int
 ) -> None:
     gpu_count = get_gpu_count()
 


### PR DESCRIPTION
Pytests have currently been deadlocking on shutdown when running in CI. With changes from #162 we were able to capture the stack of the process before it times out. The captured stack reveals that there are dozens of Ray threads still alive, for example:

```python
2025-04-13T05:28:18.2216987Z Thread 22 (Thread 0x7f38198b9700 (LWP 8842) "python"):
2025-04-13T05:28:18.2217912Z Traceback (most recent call first):
2025-04-13T05:28:18.2219417Z   File "/opt/conda/envs/test/lib/python3.11/site-packages/ray/_private/worker.py", line 2228, in listen_error_messages
2025-04-13T05:28:18.2220987Z     _, error_data = worker.gcs_error_subscriber.poll()
2025-04-13T05:28:18.2222169Z   File "/opt/conda/envs/test/lib/python3.11/threading.py", line 982, in run
2025-04-13T05:28:18.2223317Z     self._target(*self._args, **self._kwargs)
2025-04-13T05:28:18.2224571Z   File "/opt/conda/envs/test/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
2025-04-13T05:28:18.2225747Z     self.run()
2025-04-13T05:28:18.2227988Z   File "/opt/conda/envs/test/lib/python3.11/threading.py", line 1002, in _bootstrap
2025-04-13T05:28:18.2229167Z     self._bootstrap_inner()
2025-04-13T05:28:18.2229709Z
2025-04-13T05:28:18.2230198Z Thread 21 (Thread 0x7f38190b8700 (LWP 8848) "python"):
2025-04-13T05:28:18.2231108Z Traceback (most recent call first):
2025-04-13T05:28:18.2231913Z   Waiting for the GIL
2025-04-13T05:28:18.2233142Z   File "/opt/conda/envs/test/lib/python3.11/site-packages/ray/_private/worker.py", line 957, in print_logs
2025-04-13T05:28:18.2234662Z     data = subscriber.poll()
2025-04-13T05:28:18.2235718Z   File "/opt/conda/envs/test/lib/python3.11/threading.py", line 982, in run
2025-04-13T05:28:18.2237296Z     self._target(*self._args, **self._kwargs)
2025-04-13T05:28:18.2238508Z   File "/opt/conda/envs/test/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
2025-04-13T05:28:18.2239668Z     self.run()
2025-04-13T05:28:18.2240643Z   File "/opt/conda/envs/test/lib/python3.11/threading.py", line 1002, in _bootstrap
2025-04-13T05:28:18.2241799Z     self._bootstrap_inner()
```

It is difficult to determine if Ray is responsible for blocking shutdown and thus cause tests to timeout, but it is nevertheless good practice to ensure resources created for the scope of tests are properly shutdown and thus reduce chances of those resources becoming a problem.