### PR TITLE
Add missing `unordered_map` include

### DIFF
--- a/cpp/include/rapidsmpf/shuffler/partition.hpp
+++ b/cpp/include/rapidsmpf/shuffler/partition.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include <cudf/contiguous_split.hpp>


### PR DESCRIPTION
Fix missing `unordered_map` include that caused nightly CI build to fail.