### PR TITLE
Move Buffer::overloaded dispatch helper to top level

### DIFF
--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -26,6 +26,18 @@ enum class MemoryType : int {
 /// @brief Array of all the different memory types.
 constexpr std::array<MemoryType, 2> MEMORY_TYPES{{MemoryType::DEVICE, MemoryType::HOST}};
 
+namespace {
+/// @brief Helper for overloaded lambdas using std::visit.
+template <class... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+/// @brief Explicit deduction guide
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+}  // namespace
+
 /**
  * @brief Buffer representing device or host memory.
  *
@@ -47,15 +59,6 @@ class Buffer {
      * @brief  Storage type in Buffer, which could be either host or device memory.
      */
     using StorageT = std::variant<DeviceStorageT, HostStorageT>;
-
-    /// @brief Helper for overloaded lambdas for Storage types in StorageT
-    template <class... Ts>
-    struct overloaded : Ts... {
-        using Ts::operator()...;
-    };
-    /// @brief Explicit deduction guide
-    template <class... Ts>
-    overloaded(Ts...) -> overloaded<Ts...>;
 
     /**
      * @brief Access the underlying host memory buffer (const).
@@ -112,7 +115,7 @@ class Buffer {
      *
      * @throws std::logic_error if the buffer is not initialized.
      */
-    MemoryType constexpr mem_type() const {
+    [[nodiscard]] MemoryType constexpr mem_type() const {
         return std::visit(
             overloaded{
                 [](const HostStorageT&) -> MemoryType { return MemoryType::HOST; },


### PR DESCRIPTION
GCC versions prior to v12.0 had a bug in class template argument deduction rules: they were incorrectly required to live at namespace scope.

For example, the following definition

    struct Foo {
      template <typename... Ts> struct overloaded : Ts... {
        using Ts::operator()...;
      };
      template <typename... Ts>
      overloaded(Ts...) -> overloaded<Ts...>;
    };

Produces the compile error

    error: deduction guide 'Foo::overloaded(Ts ...) -> Foo::overloaded<Ts ...>' must be declared at namespace scope
        6 |   overloaded(Ts...) -> overloaded<Ts...>;
          |   ^~~~~~~~~~

In contrast, both clang, and later versions of GCC, correctly accept this definition. See
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79501 and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100983 for details.

Since we still advertise support for GCC 11, and pip-based devcontainer builds use GCC 11, work around this bug by moving the overloaded dispatch helper (used in methods that visit the variant storage) to a top-level anonymous namespace.