### PR TITLE
Ensure data are ready for comms libraries with events

### DIFF
--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <unordered_map>
@@ -15,6 +16,7 @@
 
 #include <rapidsmpf/buffer/buffer.hpp>
 #include <rapidsmpf/buffer/spill_manager.hpp>
+#include <rapidsmpf/cuda_event.hpp>
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/statistics.hpp>
 #include <rapidsmpf/utils.hpp>
@@ -256,9 +258,12 @@ class BufferResource {
      * @brief Move device buffer data into a Buffer.
      *
      * @param data A unique pointer to the device buffer.
+     * @param event Event tracking all stream-ordered work populating `data`.
      * @return A unique pointer to the resulting Buffer.
      */
-    std::unique_ptr<Buffer> move(std::unique_ptr<rmm::device_buffer> data);
+    std::unique_ptr<Buffer> move(
+        std::unique_ptr<rmm::device_buffer> data, std::shared_ptr<Event> event
+    );
 
     /**
      * @brief Move a Buffer to the specified memory type.

--- a/cpp/include/rapidsmpf/cuda_event.hpp
+++ b/cpp/include/rapidsmpf/cuda_event.hpp
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <atomic>
+
+#include <cuda_runtime_api.h>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <rapidsmpf/error.hpp>
+
+namespace rapidsmpf {
+
+/**
+ * @brief Wrapper for cudaEvent_t
+ */
+class Event {
+  public:
+    Event();
+    ~Event();
+    Event(const Event&) = delete;
+    Event& operator=(const Event&) = delete;
+    Event(Event&&) noexcept = delete;
+    Event& operator=(Event&&) noexcept = delete;
+
+    /**
+     * @brief record the work on `stream` in the event.
+     *
+     * @param stream The stream to record.
+     */
+    void record(rmm::cuda_stream_view stream) const;
+
+    /**
+     * @brief Get the wrapped event.
+     *
+     * @return cudaEvent_t the underlying event.
+     */
+    [[nodiscard]] cudaEvent_t value() const noexcept;
+
+    /**
+     * @brief Check if the all the work recorded in the event is complete.
+     *
+     * @return true if the work is complete.
+     */
+    [[nodiscard]] bool query() const;
+
+  private:
+    mutable std::atomic<bool> done_{false};
+    cudaEvent_t event_{nullptr};
+};
+}  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/shuffler/postbox.hpp
+++ b/cpp/include/rapidsmpf/shuffler/postbox.hpp
@@ -90,6 +90,13 @@ class PostBox {
     std::vector<Chunk> extract_all();
 
     /**
+     * @brief Extracts all ready chunks from the PostBox.
+     *
+     * @return A vector of all ready chunks in the PostBox.
+     */
+    std::vector<Chunk> extract_all_ready();
+
+    /**
      * @brief Checks if the PostBox is empty.
      *
      * @return `true` if the PostBox is empty, `false` otherwise.

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -90,8 +90,8 @@ std::unique_ptr<Buffer> BufferResource::allocate(
     case MemoryType::HOST:
         // TODO: use pinned memory, maybe use rmm::mr::pinned_memory_resource and
         // std::pmr::vector?
-        ret = std::make_unique<Buffer>(
-            Buffer{std::make_unique<std::vector<uint8_t>>(size), this, nullptr}
+        ret = std::unique_ptr<Buffer>(
+            new Buffer{std::make_unique<std::vector<uint8_t>>(size), this, nullptr}
         );
         break;
     case MemoryType::DEVICE:
@@ -100,7 +100,8 @@ std::unique_ptr<Buffer> BufferResource::allocate(
             auto buf = std::make_unique<rmm::device_buffer>(size, stream, device_mr_);
             event->record(stream);
             ret =
-                std::make_unique<Buffer>(Buffer{std::move(buf), this, std::move(event)});
+                std::unique_ptr<Buffer>(new Buffer{std::move(buf), this, std::move(event)}
+                );
             break;
         }
     default:
@@ -111,13 +112,13 @@ std::unique_ptr<Buffer> BufferResource::allocate(
 }
 
 std::unique_ptr<Buffer> BufferResource::move(std::unique_ptr<std::vector<uint8_t>> data) {
-    return std::make_unique<Buffer>(Buffer{std::move(data), this, nullptr});
+    return std::unique_ptr<Buffer>(new Buffer{std::move(data), this, nullptr});
 }
 
 std::unique_ptr<Buffer> BufferResource::move(
     std::unique_ptr<rmm::device_buffer> data, std::shared_ptr<Event> event
 ) {
-    return std::make_unique<Buffer>(Buffer{std::move(data), this, event});
+    return std::unique_ptr<Buffer>(new Buffer{std::move(data), this, event});
 }
 
 std::unique_ptr<Buffer> BufferResource::move(

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -1074,7 +1074,6 @@ std::shared_ptr<::ucxx::Endpoint> UCXX::get_endpoint(Rank rank) {
 std::unique_ptr<Communicator::Future> UCXX::send(
     std::unique_ptr<std::vector<uint8_t>> msg, Rank rank, Tag tag, BufferResource* br
 ) {
-    RAPIDSMPF_CUDA_TRY(cudaDeviceSynchronize());
     auto req = get_endpoint(rank)->tagSend(
         msg->data(),
         msg->size(),
@@ -1086,7 +1085,6 @@ std::unique_ptr<Communicator::Future> UCXX::send(
 std::unique_ptr<Communicator::Future> UCXX::send(
     std::unique_ptr<Buffer> msg, Rank rank, Tag tag
 ) {
-    RAPIDSMPF_CUDA_TRY(cudaDeviceSynchronize());
     auto req = get_endpoint(rank)->tagSend(
         msg->data(), msg->size, tag_with_rank(shared_resources_->rank(), tag)
     );
@@ -1148,9 +1146,6 @@ std::vector<std::size_t> UCXX::test_some(
             completed.push_back(i);
         }
     }
-    if (completed.size() > 0) {
-        RAPIDSMPF_CUDA_TRY(cudaDeviceSynchronize());
-    }
     return completed;
 }
 
@@ -1166,9 +1161,6 @@ std::vector<std::size_t> UCXX::test_some(
         if (ucxx_future->req_->isCompleted()) {
             completed.push_back(key);
         }
-    }
-    if (completed.size() > 0) {
-        RAPIDSMPF_CUDA_TRY(cudaDeviceSynchronize());
     }
     return completed;
 }

--- a/cpp/src/cuda_event.cpp
+++ b/cpp/src/cuda_event.cpp
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <atomic>
+
+#include <cuda_runtime_api.h>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <rapidsmpf/cuda_event.hpp>
+
+namespace rapidsmpf {
+
+Event::Event() {
+    RAPIDSMPF_CUDA_TRY(cudaEventCreateWithFlags(&event_, cudaEventDisableTiming));
+}
+
+Event::~Event() {
+    cudaEventDestroy(event_);
+}
+
+void Event::record(rmm::cuda_stream_view stream) const {
+    if (!query()) {
+        RAPIDSMPF_CUDA_TRY(cudaEventRecord(event_, stream.value()));
+    }
+}
+
+cudaEvent_t Event::value() const noexcept {
+    return event_;
+}
+
+[[nodiscard]] bool Event::query() const {
+    if (!done_.load(std::memory_order_relaxed)) {
+        auto result = cudaEventQuery(event_);
+        if (result == cudaSuccess) {
+            done_.store(true, std::memory_order_relaxed);
+            return true;
+        } else if (result != cudaErrorNotReady) {
+            RAPIDSMPF_CUDA_TRY(result);
+        }
+    }
+    return done_.load(std::memory_order_relaxed);
+}
+}  // namespace rapidsmpf

--- a/cpp/src/shuffler/postbox.cpp
+++ b/cpp/src/shuffler/postbox.cpp
@@ -52,6 +52,37 @@ std::vector<Chunk> PostBox<KeyType>::extract_all() {
 }
 
 template <typename KeyType>
+std::vector<Chunk> PostBox<KeyType>::extract_all_ready() {
+    std::lock_guard const lock(mutex_);
+    std::vector<Chunk> ret;
+    // Iterate through the outer map
+    auto pid_it = pigeonhole_.begin();
+    while (pid_it != pigeonhole_.end()) {
+        // Iterate through the inner map
+        auto& chunks = pid_it->second;
+        auto chunk_it = chunks.begin();
+        while (chunk_it != chunks.end()) {
+            if (!chunk_it->second.gpu_data || chunk_it->second.gpu_data->is_ready()) {
+                ret.push_back(std::move(chunk_it->second));
+                chunk_it = chunks.erase(chunk_it);
+            } else {
+                ++chunk_it;
+            }
+        }
+
+        // Remove the pid entry if its chunks map is empty
+        if (chunks.empty()) {
+            pid_it = pigeonhole_.erase(pid_it);
+        } else {
+            ++pid_it;
+        }
+    }
+    pigeonhole_.clear();
+
+    return ret;
+}
+
+template <typename KeyType>
 bool PostBox<KeyType>::empty() const {
     return pigeonhole_.empty();
 }

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -176,7 +176,7 @@ class Shuffler::Progress {
 
         // Check for new chunks in the inbox and send off their metadata.
         auto const t0_send_metadata = Clock::now();
-        for (auto&& chunk : shuffler_.outgoing_chunks_.extract_all()) {
+        for (auto&& chunk : shuffler_.outgoing_chunks_.extract_all_ready()) {
             auto dst = shuffler_.partition_owner(shuffler_.comm_, chunk.pid);
             log.trace("send metadata to ", dst, ": ", chunk);
             RAPIDSMPF_EXPECTS(


### PR DESCRIPTION
Rather than using device synchronisation, use events to track work on streams for buffers and only hand over the buffer data pointer to the comms library when the event is ready.