### PR TITLE
Fix `dependencies.yaml` pip requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 .mypy_cache
 .hypothesis
 __pycache__
+compile_commands.json

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - libcudf==25.6.*,>=0.0.0a0
 - libucxx==0.44.*,>=0.0.0a0
 - make
-- mpi4py
+- mpi4py>=3,<4
 - myst-parser
 - ninja
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -38,7 +38,6 @@ dependencies:
 - pytest
 - python>=3.10,<3.13
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
-- ray-default==2.42.*,>=0.0.0a0
 - rmm==25.6.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - spdlog

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - libcudf==25.6.*,>=0.0.0a0
 - libucxx==0.44.*,>=0.0.0a0
 - make
-- mpi4py>=3,<4
+- mpi4py
 - myst-parser
 - ninja
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - libcudf==25.6.*,>=0.0.0a0
 - libucxx==0.44.*,>=0.0.0a0
 - make
-- mpi4py
+- mpi4py>=3,<4
 - myst-parser
 - ninja
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - libcudf==25.6.*,>=0.0.0a0
 - libucxx==0.44.*,>=0.0.0a0
 - make
-- mpi4py>=3,<4
+- mpi4py
 - myst-parser
 - ninja
 - numpydoc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
           - *rmm_unsuffixed
           - pylibcudf==25.6.*,>=0.0.0a0
           - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
-          - mpi4py>=3,<4
+          - mpi4py
   checks:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -49,7 +49,7 @@ channels:
 dependencies:
   build-universal:
     common:
-      - output_types: [conda, pyproject]
+      - output_types: [conda, pyproject, requirements]
         packages:
           - &cmake_ver cmake>=3.26.4,!=3.30.0
           - ninja
@@ -87,18 +87,18 @@ dependencies:
               - cuda-nvcc
   rapids_build_skbuild:
     common:
-      - output_types: [conda, pyproject]
+      - output_types: [conda, pyproject, requirements]
         packages:
           - &rapids_build_backend rapids-build-backend>=0.3.0,<0.4.0.dev0
       - output_types: conda
         packages:
           - scikit-build-core>=0.10.0
-      - output_types: [pyproject]
+      - output_types: [pyproject, requirements]
         packages:
           - scikit-build-core[pyproject]>=0.10.0
   build-python:
     common:
-      - output_types: [conda, pyproject]
+      - output_types: [conda, pyproject, requirements]
         packages:
           - cython>=3.0.3
           - *rmm_unsuffixed
@@ -176,12 +176,14 @@ dependencies:
           - rapidsmpf==25.6.*,>=0.0.0a0
   test_python:
     common:
-      - output_types: [conda, pyproject]
+      - output_types: conda
+        packages:
+          - gdb
+      - output_types: [conda, pyproject, requirements]
         packages:
           - cudf==25.6.*,>=0.0.0a0
           - dask-cuda==25.6.*,>=0.0.0a0
           - dask-cudf==25.6.*,>=0.0.0a0
-          - gdb
           - psutil
           - pytest
           - ucxx==0.44.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
           - *rmm_unsuffixed
           - pylibcudf==25.6.*,>=0.0.0a0
           - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
-          - mpi4py
+          - mpi4py>=3,<4
   checks:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -209,8 +209,17 @@ dependencies:
           - myst-parser
           - numpydoc
           - pydata-sphinx-theme
-          - ray-default==2.42.*,>=0.0.0a0
           - sphinx
           - sphinx-autobuild
           - sphinx-copybutton
           - ucxx==0.44.*,>=0.0.0a0
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              arch: x86_64
+            packages:
+              - ray-default==2.42.*,>=0.0.0a0
+          - matrix:
+              arch: aarch64
+            packages:


### PR DESCRIPTION
This should fix the pip devcontainer build errors in https://github.com/rapidsai/devcontainers/pull/497.