### PR TITLE
ProgressThread: add sleep argument

### DIFF
--- a/cpp/include/rapidsmpf/progress_thread.hpp
+++ b/cpp/include/rapidsmpf/progress_thread.hpp
@@ -132,10 +132,15 @@ class ProgressThread {
      *
      * @param logger The logger instance to use.
      * @param statistics The statistics instance to use (disabled by default).
+     * @param sleep The duration to sleep between each progress loop iteration.
+     * If 0, the thread yields execution instead of sleeping. Anecdotally, a 1 us
+     * sleep time (the default) is sufficient to avoid starvation and get smooth
+     * progress.
      */
     ProgressThread(
         Communicator::Logger& logger,
-        std::shared_ptr<Statistics> statistics = std::make_shared<Statistics>(false)
+        std::shared_ptr<Statistics> statistics = std::make_shared<Statistics>(false),
+        Duration sleep = std::chrono::microseconds{1}
     );
 
     ~ProgressThread();

--- a/cpp/src/progress_thread.cpp
+++ b/cpp/src/progress_thread.cpp
@@ -37,17 +37,20 @@ void ProgressThread::FunctionState::operator()() {
 }
 
 ProgressThread::ProgressThread(
-    Communicator::Logger& logger, std::shared_ptr<Statistics> statistics
+    Communicator::Logger& logger, std::shared_ptr<Statistics> statistics, Duration sleep
 )
-    : thread_([this]() {
-          if (!is_thread_initialized_) {
-              // This thread needs to have a cuda context associated with it.
-              // For now, do so by calling cudaFree to initialise the driver.
-              RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
-              is_thread_initialized_ = true;
-          }
-          return event_loop();
-      }),
+    : thread_(
+        [this]() {
+            if (!is_thread_initialized_) {
+                // This thread needs to have a cuda context associated with it.
+                // For now, do so by calling cudaFree to initialise the driver.
+                RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
+                is_thread_initialized_ = true;
+            }
+            return event_loop();
+        },
+        sleep
+    ),
       logger_(logger),
       statistics_(std::move(statistics)) {
     RAPIDSMPF_EXPECTS(statistics_ != nullptr, "the statistics pointer cannot be NULL");


### PR DESCRIPTION
While working on setups with may shuffle instances I noticed that `ProgressThread::add_function()` can block for a long time when we have many (>30) shuffler instances.

Instead of introducing advance starvation avoidance in `ProgressThread`, I think a 1us sleep suffice. Let's also wait with the Python API.