### PR TITLE
Dask shuffler cleanup

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -68,10 +68,10 @@ def _get_new_shuffle_id(client: Client) -> int:
             _shuffle_id_vacancy.update(range(256))
             _shuffle_id_vacancy.difference_update(*client.run(get_vacancy_ids).values())
 
-        if not _shuffle_id_vacancy:
-            raise ValueError(
-                "Cannot shuffle more than 256 times in a single Dask compute."
-            )
+            if not _shuffle_id_vacancy:
+                raise ValueError(
+                    "Cannot shuffle more than 256 times in a single Dask compute."
+                )
 
         return _shuffle_id_vacancy.pop()
 

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -314,18 +314,17 @@ def _extract_partition(
     -------
     Extracted DataFrame partition.
     """
-    if callback is None:
-        raise ValueError("Missing callback in _extract_partition.")
     shuffler = get_shuffler(shuffle_id)
-    ret = callback(
-        partition_id,
-        column_names,
-        shuffler,
-    )
-    if shuffler.finished():
-        ctx = get_worker_context()
-        del ctx.shufflers[shuffle_id]
-    return ret
+    try:
+        return callback(
+            partition_id,
+            column_names,
+            shuffler,
+        )
+    finally:
+        if shuffler.finished():
+            ctx = get_worker_context()
+            del ctx.shufflers[shuffle_id]
 
 
 def rapidsmpf_shuffle_graph(

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -282,11 +282,16 @@ def _extract_partition(
     """
     if callback is None:
         raise ValueError("Missing callback in _extract_partition.")
-    return callback(
+    shuffler = get_shuffler(shuffle_id)
+    ret = callback(
         partition_id,
         column_names,
-        get_shuffler(shuffle_id),
+        shuffler,
     )
+    if shuffler.finished():
+        ctx = get_worker_context()
+        del ctx.shufflers[shuffle_id]
+    return ret
 
 
 def rapidsmpf_shuffle_graph(

--- a/python/rapidsmpf/rapidsmpf/shuffler.pxd
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pxd
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
-from libc.stdint cimport uint16_t, uint32_t
+from libc.stdint cimport uint8_t, uint32_t
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.string cimport string
@@ -38,7 +38,7 @@ cdef extern from "<rapidsmpf/shuffler/shuffler.hpp>" nogil:
         cpp_Shuffler(
             shared_ptr[cpp_Communicator] comm,
             shared_ptr[cpp_ProgressThread] comm,
-            uint16_t op_id,
+            uint8_t op_id,
             uint32_t total_num_partitions,
             cuda_stream_view stream,
             cpp_BufferResource *br,

--- a/python/rapidsmpf/rapidsmpf/shuffler.pyi
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pyi
@@ -34,6 +34,7 @@ def unpack_and_concat(
 ) -> Table: ...
 
 class Shuffler:
+    max_concurrent_shuffles: int
     def __init__(
         self,
         comm: Communicator,

--- a/python/rapidsmpf/rapidsmpf/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pyx
@@ -242,7 +242,7 @@ cdef class Shuffler:
         The progress thread to use for tracking progress.
     op_id
         The operation ID of the shuffle. Must have a value between 0 and
-        `max_concurrent_shuffles-1`.
+        ``max_concurrent_shuffles-1``.
     total_num_partitions
         Total number of partitions in the shuffle.
     stream

--- a/python/rapidsmpf/rapidsmpf/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pyx
@@ -4,7 +4,7 @@
 
 from cython.operator cimport dereference as deref
 from cython.operator cimport postincrement
-from libc.stdint cimport uint32_t
+from libc.stdint cimport UINT8_MAX, uint32_t
 from libcpp.memory cimport make_unique, unique_ptr
 from libcpp.unordered_map cimport unordered_map
 from libcpp.utility cimport move
@@ -241,7 +241,8 @@ cdef class Shuffler:
     progress_thread
         The progress thread to use for tracking progress.
     op_id
-        The operation ID of the shuffle.
+        The operation ID of the shuffle. Must have a value between 0 and
+        `max_concurrent_shuffles-1`.
     total_num_partitions
         Total number of partitions in the shuffle.
     stream
@@ -251,12 +252,19 @@ cdef class Shuffler:
     statistics
         The statistics instance to use. If None, statistics is disabled.
 
+    Attributes
+    ----------
+    max_concurrent_shuffles
+        Maximum number of concurrent shufflers.
+
     Notes
     -----
     This class is designed to handle distributed operations by partitioning data
     and redistributing it across ranks in a cluster. It is typically used in
     distributed data processing workflows involving cuDF tables.
     """
+    max_concurrent_shuffles = UINT8_MAX + 1  # match the type of the `op_id` argument.
+
     def __init__(
         self,
         Communicator comm,

--- a/python/rapidsmpf/rapidsmpf/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pyx
@@ -273,6 +273,7 @@ cdef class Shuffler:
         self._comm = comm
         self._br = br
         cdef cpp_BufferResource* br_ = br.ptr()
+        cdef cuda_stream_view _stream = self._stream.view()
         if statistics is None:
             statistics = Statistics(enable=False)  # Disables statistics.
         with nogil:
@@ -281,7 +282,7 @@ cdef class Shuffler:
                 progress_thread._handle,
                 op_id,
                 total_num_partitions,
-                self._stream.view(),
+                _stream,
                 br_,
                 statistics._handle,
             )

--- a/python/rapidsmpf/rapidsmpf/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pyx
@@ -261,7 +261,7 @@ cdef class Shuffler:
         self,
         Communicator comm,
         ProgressThread progress_thread,
-        uint16_t op_id,
+        uint8_t op_id,
         uint32_t total_num_partitions,
         stream,
         BufferResource br,

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -170,9 +170,9 @@ def test_many_shuffles(loop: pytest.FixtureDef) -> None:  # noqa: F811
             bootstrap_dask_cluster(client, spill_device=0.1)
             max_num_shuffles = Shuffler.max_concurrent_shuffles
 
-            # We can shuffle `max_num_shuffles` consecutive times.
-            do_shuffle(seed=1, num_shuffles=max_num_shuffles)
-            # And more times after a compute.
+            # We can shuffle `max_num_shuffles` consecutive times but to limit CI
+            # running time, we just do 5+10 shuffles.
+            do_shuffle(seed=1, num_shuffles=5)
             do_shuffle(seed=2, num_shuffles=10)
 
             # Check that all shufflers has been cleaned up.

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import dask
+import dask.dataframe as dd
 import pytest
 
+from rapidsmpf.examples.dask import DaskCudfIntegration
 from rapidsmpf.integrations.dask.core import get_worker_context
+from rapidsmpf.integrations.dask.shuffler import rapidsmpf_shuffle_graph
 
 dask_cuda = pytest.importorskip("dask_cuda")
 
@@ -110,3 +113,61 @@ def test_bootstrap_dask_cluster_idempotent() -> None:
 def test_boostrap_single_node_cluster_no_deadlock() -> None:
     with LocalCUDACluster(n_workers=1) as cluster, Client(cluster) as client:
         bootstrap_dask_cluster(client, spill_device=0.1)
+
+
+def test_many_consecutive_shuffles(loop: pytest.FixtureDef) -> None:  # noqa: F811
+    pytest.importorskip("dask_cudf")
+
+    with LocalCUDACluster(n_workers=1, loop=loop) as cluster:  # noqa: SIM117
+        with Client(cluster) as client:
+            bootstrap_dask_cluster(client, spill_device=0.1)
+
+            df = (
+                dask.datasets.timeseries(
+                    freq="3600s",
+                    partition_freq="2D",
+                )
+                .reset_index(drop=True)
+                .to_backend("cudf")
+            )
+            expect = df.compute().sort_values(["x", "y"])
+            df0 = df.optimize()
+            partition_count_in = df0.npartitions
+            partition_count_out = partition_count_in
+            column_names = list(df0.columns)
+            shuffle_on = ["name", "id"]
+
+            # Create a graph that shuffle `df` many consecutive times.
+            graph = df0.dask.copy()
+            name_in = df0._name
+            for i in range(256):
+                name_out = f"test_many_shuffles-output-{i}"
+                graph.update(
+                    rapidsmpf_shuffle_graph(
+                        input_name=name_in,
+                        output_name=name_out,
+                        column_names=column_names,
+                        shuffle_on=shuffle_on,
+                        partition_count_in=partition_count_in,
+                        partition_count_out=partition_count_out,
+                        integration=DaskCudfIntegration,
+                    )
+                )
+                name_in = name_out
+            shuffled = dd.from_graph(
+                graph,
+                df0._meta,
+                (None,) * (partition_count_out + 1),
+                [(name_out, pid) for pid in range(partition_count_out)],
+                "rapidsmpf",
+            )
+
+            got = shuffled.compute().sort_values(["x", "y"])
+            dd.assert_eq(expect, got, check_index=False)
+
+            # Check that all shufflers has been cleaned up.
+            def check_worker(dask_worker: Worker) -> None:
+                ctx = get_worker_context(dask_worker)
+                assert len(ctx.shufflers) == 0
+
+            client.run(check_worker)

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -170,9 +170,9 @@ def test_many_shuffles(loop: pytest.FixtureDef) -> None:  # noqa: F811
             bootstrap_dask_cluster(client, spill_device=0.1)
             max_num_shuffles = Shuffler.max_concurrent_shuffles
 
-            # We can shuffle `max_num_shuffles` consecutive times but to limit CI
-            # running time, we just do 5+10 shuffles.
-            do_shuffle(seed=1, num_shuffles=5)
+            # We can shuffle `max_num_shuffles` consecutive times.
+            do_shuffle(seed=1, num_shuffles=max_num_shuffles)
+            # And more times after a compute.
             do_shuffle(seed=2, num_shuffles=10)
 
             # Check that all shufflers has been cleaned up.


### PR DESCRIPTION
~Depend on https://github.com/rapidsai/rapidsmpf/pull/253~
Closes https://github.com/rapidsai/rapidsmpf/issues/239

Currently, Dask never cleanup shuffler instances.