### PR TITLE
Change get_gtest to link statically and remove tests from package

### DIFF
--- a/cmake/thirdparty/get_gtest.cmake
+++ b/cmake/thirdparty/get_gtest.cmake
@@ -8,24 +8,7 @@ function(find_and_configure_gtest)
   include(${rapids-cmake-dir}/cpm/gtest.cmake)
 
   # Find or install GoogleTest
-  rapids_cpm_gtest(
-    BUILD_EXPORT_SET rapidsmpf-testing-exports INSTALL_EXPORT_SET rapidsmpf-testing-exports
-  )
-
-  if(GTest_ADDED)
-    rapids_export(
-      BUILD GTest
-      VERSION ${GTest_VERSION}
-      EXPORT_SET GTestTargets
-      GLOBAL_TARGETS gtest gmock gtest_main gmock_main
-      NAMESPACE GTest::
-    )
-
-    include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(
-      BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET rapidsmpf-testing-exports
-    )
-  endif()
+  rapids_cpm_gtest(BUILD_STATIC)
 
 endfunction()
 

--- a/conda/recipes/librapidsmpf/install_librapidsmpf.sh
+++ b/conda/recipes/librapidsmpf/install_librapidsmpf.sh
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake --install cpp/build
+cmake --install cpp/build --component rapidsmpf

--- a/conda/recipes/librapidsmpf/install_librapidsmpf.sh
+++ b/conda/recipes/librapidsmpf/install_librapidsmpf.sh
@@ -2,4 +2,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake --install cpp/build --component rapidsmpf
+cmake --install cpp/build
+cmake --install cpp/build --component=benchmarking

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(
 )
 install(
   TARGETS bench_shuffle
-  COMPONENT testing
+  COMPONENT benchmarking
   DESTINATION bin/benchmarks/librapidsmpf
   EXCLUDE_FROM_ALL
 )
@@ -51,7 +51,7 @@ target_link_libraries(
 )
 install(
   TARGETS bench_comm
-  COMPONENT testing
+  COMPONENT benchmarking
   DESTINATION bin/benchmarks/librapidsmpf
   EXCLUDE_FROM_ALL
 )

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -138,6 +138,7 @@ install(
   TARGETS ${testing_targets}
   DESTINATION bin/tests/librapidsmpf/gtests
   COMPONENT testing
+  EXCLUDE_FROM_ALL
 )
 
 # Install the CTestTestfile.cmake to bin/tests/librapidsmpf
@@ -145,4 +146,5 @@ install(
   FILES "${RAPIDSMPF_BINARY_DIR}/tests/CTestTestfile.cmake"
   DESTINATION bin/tests/librapidsmpf
   COMPONENT testing
+  EXCLUDE_FROM_ALL
 )


### PR DESCRIPTION
Currently, the `librapidsmpf` packages ship gtest/gmock library and include files, which they shouldn't.
Simplifying this down to the current version also in libcudf should fix that (i.e. by linking statically).

I would just do this to keep similar to stay similar to other rapids libraries, unless this is somehow different?

~(I think there is another small issue with `mpi_tests` and `ucxx_tests` getting shipped in `librapidsmpf` rather than `librapidsmpf-tests`, but I'll have a look at it seperately.)~