### PR TITLE
Simplified progress thread impl

### DIFF
--- a/cpp/include/rapidsmpf/progress_thread2.hpp
+++ b/cpp/include/rapidsmpf/progress_thread2.hpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <rapidsmpf/communicator/communicator.hpp>
+#include <rapidsmpf/statistics.hpp>
+
+namespace rapidsmpf {
+
+class ProgressThread2 {
+  public:
+    /// @brief The state of a task
+    enum class ProgressState {
+        InProgress,
+        Done
+    };
+
+    /// @brief The type of a task
+    using Function = std::function<ProgressState()>;
+
+    /// @brief The type of a task ID
+    using FunctionID = uint64_t;
+
+    /// @brief Constructor
+    /// @param logger The logger to use
+    /// @param statistics The statistics to use
+    ProgressThread2(
+        Communicator::Logger& logger,
+        std::shared_ptr<Statistics> statistics = std::make_shared<Statistics>(false)
+    );
+    ~ProgressThread2();
+
+    // Delete copy and move operations to make the class non-copyable and non-movable
+    ProgressThread2(const ProgressThread2&) = delete;
+    ProgressThread2& operator=(const ProgressThread2&) = delete;
+    ProgressThread2(ProgressThread2&&) = delete;
+    ProgressThread2& operator=(ProgressThread2&&) = delete;
+
+    /// @brief Start the background thread that executes tasks
+    void start();
+
+    /// @brief Stop the background thread and wait for it to finish
+    void stop();
+
+    /// @brief Add a new task to the queue
+    /// @param task The task to add
+    /// @return A unique ID that can be used to wait for the task
+    FunctionID add_function(Function task);
+
+    /// @brief Remove a task by its ID
+    /// @param id The ID of the task to remove
+    /// @note This function returns immediately, the task will be removed by the worker
+    /// thread.
+    void remove_function(FunctionID id);
+
+    /// @brief Wait for a task to complete
+    /// @param id The ID of the task to wait for
+    /// @note This method will block until the task is completed and removed by the
+    /// background thread If the task is not found, returns immediately
+    void wait_for_function(FunctionID id);
+
+    /// @brief Remove all tasks immediately
+    /// This will not wait for tasks to complete
+    void clear_functions();
+
+  private:
+    /// @brief The information about a task
+    struct FunctionInfo {
+        FunctionID id;  ///< The ID of the task
+        Function task;  ///< The task to execute
+        ProgressState state;  ///< The state of the task
+
+        FunctionInfo(FunctionID id, Function task, ProgressState state)
+            : id(id), task(std::move(task)), state(state) {}
+    };
+
+    /// @brief The main loop of the background thread
+    void run();
+
+    std::unordered_map<FunctionID, FunctionInfo> tasks_;  ///< Main task list
+    std::vector<FunctionInfo> staged_tasks_;  ///< Staging area for new tasks
+    std::vector<FunctionID>
+        staged_removals_;  ///< Staging area for task IDs to be removed
+    std::unordered_set<FunctionID> completed_tasks_;  ///< Set of completed tasks (done/ removed)
+    std::mutex mutex_;
+    std::condition_variable cv_;  ///< For waiting on new tasks
+    std::condition_variable task_done_cv_;  ///< For waiting on task completion
+    std::atomic<bool> running_;
+    std::atomic<FunctionID> next_task_id_;
+    std::thread worker_thread_;
+    Communicator::Logger& logger_;
+    std::shared_ptr<Statistics> statistics_;
+};
+
+}  // namespace rapidsmpf

--- a/cpp/src/progress_thread2.cpp
+++ b/cpp/src/progress_thread2.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rapidsmpf/progress_thread2.hpp>
+
+namespace rapidsmpf {
+
+ProgressThread2::ProgressThread2(
+    Communicator::Logger& logger, std::shared_ptr<Statistics> statistics
+)
+    : running_(false),
+      next_task_id_(0),
+      logger_(logger),
+      statistics_(std::move(statistics)) {
+    start();
+}
+
+ProgressThread2::~ProgressThread2() {
+    stop();
+}
+
+void ProgressThread2::start() {
+    if (running_)
+        return;
+
+    running_ = true;
+    worker_thread_ = std::thread(&ProgressThread2::run, this);
+}
+
+void ProgressThread2::stop() {
+    if (!running_) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        running_ = false;
+    }
+    cv_.notify_one();  // Wake up the worker thread to check if it should stop
+
+    if (worker_thread_.joinable()) {
+        worker_thread_.join();
+    }
+}
+
+ProgressThread2::FunctionID ProgressThread2::add_function(Function task) {
+    FunctionID id;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        id = next_task_id_++;
+        staged_tasks_.emplace_back(id, std::move(task), ProgressState::InProgress);
+    }
+    cv_.notify_one();
+    return id;
+}
+
+void ProgressThread2::remove_function(FunctionID id) {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        staged_removals_.emplace_back(id);
+    }
+    cv_.notify_one();
+}
+
+void ProgressThread2::wait_for_function(FunctionID id) {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    // Wait until task is done or removed
+    task_done_cv_.wait(lock, [this, id]() {
+        return completed_tasks_.find(id) != completed_tasks_.end();
+    });
+
+    completed_tasks_.erase(id);
+}
+
+void ProgressThread2::clear_functions() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    tasks_.clear();
+    staged_tasks_.clear();
+    staged_removals_.clear();
+    completed_tasks_.clear();
+}
+
+void ProgressThread2::run() {
+    while (true) {
+        auto const t0_event_loop = Clock::now();
+        // Merge staged tasks with main task list and handle removals
+        {
+            // lock the mutex to do the housekeeping work
+            std::unique_lock lock(mutex_);
+            // Wait until we should stop, or there are tasks to execute, or there are
+            // staged changes to process
+            cv_.wait(lock, [this] {
+                return !running_ || !tasks_.empty() || !staged_tasks_.empty()
+                       || !staged_removals_.empty();
+            });
+
+            if (!running_)
+                break;
+
+            // Handle staged removals
+            for (FunctionID id : staged_removals_) {
+                tasks_.erase(id);
+                completed_tasks_.insert(id);
+            }
+            staged_removals_.clear();
+
+            // Move staged tasks to main task list
+            for (auto& task_info : staged_tasks_) {
+                tasks_.emplace(task_info.id, std::move(task_info));
+            }
+            staged_tasks_.clear();
+        }
+        task_done_cv_.notify_all();  // wake up any waiting threads
+
+        // Execute tasks and update their states
+        for (auto it = tasks_.begin(); it != tasks_.end();) {
+            ProgressState new_state = it->second.task();
+            if (new_state == ProgressState::Done) {
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    completed_tasks_.insert(it->first);
+                    it = tasks_.erase(it);
+                }
+                task_done_cv_.notify_all();  // wake up any waiting threads for completion
+            } else {
+                ++it;
+            }
+        }
+
+        statistics_->add_duration_stat("event-loop-total", Clock::now() - t0_event_loop);
+    }
+}
+
+}  // namespace rapidsmpf

--- a/cpp/tests/test_progress_thread.cpp
+++ b/cpp/tests/test_progress_thread.cpp
@@ -20,6 +20,7 @@
 #include <cudf_test/base_fixture.hpp>
 
 #include <rapidsmpf/progress_thread.hpp>
+#include <rapidsmpf/progress_thread2.hpp>
 
 #include "environment.hpp"
 #include "rapidsmpf/statistics.hpp"
@@ -37,7 +38,12 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(1, 2, 4, 8),  // num_threads
         testing::Values(0, 1, 2, 4, 8),  // num_functions
         testing::Values(false, true)  // enable_statistics
-    )
+    ),
+    [](const testing::TestParamInfo<std::tuple<int, int, bool>>& info) {
+        return "nt_" + std::to_string(std::get<0>(info.param))
+               + "_nf_" + std::to_string(std::get<1>(info.param))
+               + "_stats_" + std::to_string(std::get<2>(info.param));
+    }
 );
 
 struct TestFunction {
@@ -84,6 +90,63 @@ TEST_P(ProgressThreadEvents, events) {
     for (size_t thread = 0; thread < num_threads; ++thread) {
         for (size_t function = 0; function < num_functions; ++function) {
             auto test_function = test_functions[thread][function];
+            progress_threads[thread]->remove_function(test_function->id);
+            EXPECT_EQ(test_function->counter, expected_count(thread, function));
+        }
+
+        progress_threads[thread]->stop();
+    }
+
+    if (statistics->enabled() && num_functions > 0) {
+        EXPECT_THAT(statistics->report(), ::testing::HasSubstr("event-loop-total"));
+    }
+}
+
+struct TestFunction2 {
+    size_t counter{0};
+    rapidsmpf::ProgressThread2::FunctionID id;
+};
+
+TEST_P(ProgressThreadEvents, events2) {
+    size_t const num_threads = std::get<0>(GetParam());
+    size_t const num_functions = std::get<1>(GetParam());
+    bool const enable_statistics = std::get<2>(GetParam());
+
+    auto& logger = GlobalEnvironment->comm_->logger();
+    auto statistics = std::make_shared<rapidsmpf::Statistics>(enable_statistics);
+    std::vector<std::unique_ptr<rapidsmpf::ProgressThread2>> progress_threads;
+    std::vector<std::vector<std::shared_ptr<TestFunction2>>> test_functions(num_threads);
+
+    // The number of times a particular function is expected to be called
+    auto expected_count = [num_functions](size_t thread, size_t function) {
+        return thread * num_functions + function + 1;
+    };
+
+    for (size_t thread = 0; thread < num_threads; ++thread) {
+        auto& pt = progress_threads.emplace_back(
+            std::make_unique<rapidsmpf::ProgressThread2>(logger, statistics)
+        );
+
+        for (size_t function = 0; function < num_functions; ++function) {
+            auto test_function = std::make_shared<TestFunction2>();
+            auto expected = expected_count(thread, function);
+
+            test_function->id = pt->add_function([test_function, expected]() {
+                if (++test_function->counter == expected) {
+                    return rapidsmpf::ProgressThread2::ProgressState::Done;
+                } else {
+                    return rapidsmpf::ProgressThread2::ProgressState::InProgress;
+                }
+            });
+
+            test_functions[thread].push_back(std::move(test_function));
+        }
+    }
+
+    for (size_t thread = 0; thread < num_threads; ++thread) {
+        for (size_t function = 0; function < num_functions; ++function) {
+            auto test_function = test_functions[thread][function];
+            progress_threads[thread]->wait_for_function(test_function->id);
             progress_threads[thread]->remove_function(test_function->id);
             EXPECT_EQ(test_function->counter, expected_count(thread, function));
         }


### PR DESCRIPTION
This is a simplified Progress thread impl. The motivation was to reduce the locking and avoid sleeping background thread. 
Tries to achieve this by assigning staging space when adding and removing functions. Background thread will only lock the mutex to query these staging containers. Else, it will continue to progress the tasks lock-free. 