### PR TITLE
Buffer copy utils

### DIFF
--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -199,6 +199,20 @@ class Buffer {
      */
     [[nodiscard]] bool is_ready() const;
 
+    /**
+     * @brief Copy data from this buffer to a destination buffer with a given offset.
+     *
+     * @param dest Destination buffer.
+     * @param dest_offset Offset of the destination buffer.
+     * @param stream CUDA stream to use for the copy.
+     * @returns Number of bytes written to the destination buffer.
+     * @throws std::invalid_argument if copy violates the bounds of the destination
+     * buffer.
+     */
+    [[nodiscard]] std::ptrdiff_t copy_to(
+        Buffer& dest, std::ptrdiff_t dest_offset, rmm::cuda_stream_view stream
+    ) const;
+
     /// @brief Delete move and copy constructors and assignment operators.
     Buffer(Buffer&&) = delete;
     Buffer(Buffer const&) = delete;

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -47,8 +47,8 @@ class MemoryReservation {
      */
     MemoryReservation(MemoryReservation&& o)
         : MemoryReservation{
-            o.mem_type_, std::exchange(o.br_, nullptr), std::exchange(o.size_, 0)
-        } {}
+              o.mem_type_, std::exchange(o.br_, nullptr), std::exchange(o.size_, 0)
+          } {}
 
     /**
      * @brief Move assignment operator for MemoryReservation.
@@ -344,6 +344,26 @@ class BufferResource {
     std::unique_ptr<Buffer> copy(
         MemoryType target,
         std::unique_ptr<Buffer> const& buffer,
+        rmm::cuda_stream_view stream,
+        MemoryReservation& reservation
+    );
+
+    /**
+     * @brief Copy a slice of the buffer to a new buffer.
+     *
+     * @param target Memory type of the new buffer.
+     * @param buffer The buffer to copy from.
+     * @param offset Offset in bytes from the start of the buffer.
+     * @param length Length in bytes of the slice.
+     * @param stream CUDA stream to use for the copy.
+     * @param reservation The reservation to use for memory allocations.
+     * @returns A new buffer containing the copied slice.
+     */
+    [[nodiscard]] std::unique_ptr<Buffer> copy_slice(
+        MemoryType target,
+        std::unique_ptr<Buffer> const& buffer,
+        std::ptrdiff_t offset,
+        std::ptrdiff_t length,
         rmm::cuda_stream_view stream,
         MemoryReservation& reservation
     );

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -47,8 +47,8 @@ class MemoryReservation {
      */
     MemoryReservation(MemoryReservation&& o)
         : MemoryReservation{
-              o.mem_type_, std::exchange(o.br_, nullptr), std::exchange(o.size_, 0)
-          } {}
+            o.mem_type_, std::exchange(o.br_, nullptr), std::exchange(o.size_, 0)
+        } {}
 
     /**
      * @brief Move assignment operator for MemoryReservation.

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -161,6 +161,19 @@ std::unique_ptr<Buffer> BufferResource::copy(
     return ret;
 }
 
+std::unique_ptr<Buffer> BufferResource::copy_slice(
+    MemoryType target,
+    std::unique_ptr<Buffer> const& buffer,
+    std::ptrdiff_t offset,
+    std::ptrdiff_t length,
+    rmm::cuda_stream_view stream,
+    MemoryReservation& reservation
+) {
+    auto ret = buffer->copy_slice(target, offset, length, stream);
+    release(reservation, target, ret->size);
+    return ret;
+}
+
 SpillManager& BufferResource::spill_manager() {
     return spill_manager_;
 }


### PR DESCRIPTION
This PR adds the following utils to the `Buffer` class. These will be used in the Chunk in a follow up PR. 

```c++ 
public: 
    /**
     * @brief Copy data from this buffer to a destination buffer with a given offset.
     *
     * @param dest Destination buffer.
     * @param dest_offset Offset of the destination buffer.
     * @param stream CUDA stream to use for the copy.
     * @returns Number of bytes written to the destination buffer.
     * @throws std::invalid_argument if copy violates the bounds of the destination
     * buffer.
     */
    [[nodiscard]] std::ptrdiff_t copy_to(
        Buffer& dest, std::ptrdiff_t dest_offset, rmm::cuda_stream_view stream
    ) const;

private:
    /**
     * @brief Copy a slice of the buffer to a new buffer.
     *
     * @param offset Offset in bytes from the start of the buffer.
     * @param length Length in bytes of the slice.
     * @param stream CUDA stream to use for the copy.
     * @returns A new buffer containing the copied slice.
     */
    [[nodiscard]] std::unique_ptr<Buffer> copy_slice(
        std::ptrdiff_t offset, std::ptrdiff_t length, rmm::cuda_stream_view stream
    ) const;

    /**
     * @brief Copy a slice of the buffer to a new buffer.
     *
     * @param target Memory type of the new buffer.
     * @param offset Offset in bytes from the start of the buffer.
     * @param length Length in bytes of the slice.
     * @param stream CUDA stream to use for the copy.
     * @returns A new buffer containing the copied slice.
     */
    [[nodiscard]] std::unique_ptr<Buffer> copy_slice(
        MemoryType target,
        std::ptrdiff_t offset,
        std::ptrdiff_t length,
        rmm::cuda_stream_view stream
    ) const;
```
