### PR TITLE
use GitHub Actions artifact store for package downloads

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -14,8 +14,8 @@ rapids-logger "Create test conda environment"
 ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,7 +16,7 @@ rapids-print-env
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 sccache --zero-stats
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-infra/issues/237

Switches package downloads in CI away from `downloads.rapids.ai`, to GitHub Actions artifact store. This is part of an ongoing migration across RAPIDS to use the GitHub Actions artifact store.

## Notes for Reviewers

I found these like this:

```shell
git grep -E '\-s3'
git grep -i downloads
```