### PR TITLE
Turn off uploads of nightly conda packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,8 @@ name: build
 
 on:
   push:
-    branches:
-      - "branch-*"
+    # branches:
+    #   - "branch-*"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:
@@ -45,15 +45,15 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
-  upload-conda:
-    needs: [conda-cpp-build, conda-python-build]
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda-12.9.0
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
+  # upload-conda:
+  #   needs: [conda-cpp-build, conda-python-build]
+  #   secrets: inherit
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@cuda-12.9.0
+  #   with:
+  #     build_type: ${{ inputs.build_type || 'branch' }}
+  #     branch: ${{ inputs.branch }}
+  #     date: ${{ inputs.date }}
+  #     sha: ${{ inputs.sha }}
   docs-build:
     if: github.ref_type == 'branch'
     needs: conda-python-build


### PR DESCRIPTION
They rely on ABI stability of pylibcudf's cython bindings, which doesn't exist.