### PR TITLE
Remove spdlog dep

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -40,7 +40,6 @@ dependencies:
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - rmm==25.6.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
-- spdlog
 - sphinx
 - sphinx-autobuild
 - sphinx-copybutton

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -41,7 +41,6 @@ dependencies:
 - ray-default==2.42.*,>=0.0.0a0
 - rmm==25.6.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
-- spdlog
 - sphinx
 - sphinx-autobuild
 - sphinx-copybutton

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -63,7 +63,6 @@ dependencies:
           - libcudf==25.6.*,>=0.0.0a0
           - libucxx==0.44.*,>=0.0.0a0
           - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
-          - spdlog
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
AFAICT spdlog is entirely unused. Best to remove it before it accidentally gets used and causes us the same old headaches.