### PR TITLE
Install Ray from PyPI to build docs on Python 3.13

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -229,6 +229,10 @@ dependencies:
         matrices:
           - matrix:
               arch: x86_64
+              py: "3.13"
+            packages:
+          - matrix:
+              arch: x86_64
             packages:
               - ray-default==2.42.*,>=0.0.0a0
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -231,6 +231,10 @@ dependencies:
               arch: x86_64
               py: "3.13"
             packages:
+              - pip:
+                # Ray for Python 3.13 not available from conda-forge, for
+                # now install it from PyPI just to build docs
+                - ray==2.45.*,>=0.0.0a0
           - matrix:
               arch: x86_64
             packages:


### PR DESCRIPTION
RAPIDS' build-docs default has switched to a Python 3.13 environment. However, Ray for Python 3.13 is not available in conda-forge yet, thus we allow installing from PyPI for the time being just to ensure docs can build successfully, even though it may not be usable if installed on from PyPI on a conda environment. See also #272.