### PR TITLE
WIP: switch from 'run_script' to 'script' in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   conda-python-build:
@@ -43,6 +44,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   upload-conda:
@@ -66,5 +68,5 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       date: ${{ inputs.date }}
       node_type: "cpu8"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,6 +33,7 @@ jobs:
     with:
       build_type: pull-request
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
+      script: ci/build_cpp.sh
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit
@@ -41,6 +42,7 @@ jobs:
       build_type: pull-request
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      script: ci/test_cpp.sh
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
@@ -48,6 +50,7 @@ jobs:
     with:
       build_type: pull-request
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
+      script: ci/build_python.sh
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
@@ -57,6 +60,7 @@ jobs:
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       run_codecov: false
+      script: ci/test_python.sh
   docs-build:
     needs: conda-python-build
     secrets: inherit
@@ -66,4 +70,4 @@ jobs:
       node_type: "cpu8"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
@@ -34,6 +35,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_python.sh
       sha: ${{ inputs.sha }}
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

## Notes for Reviewers

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
