### PR TITLE
Ensure we drop the gil when calling C++ dtors

### DIFF
--- a/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyx
@@ -54,3 +54,7 @@ cdef class PackedData:
     def __init__(self):
         """Initialize an empty PackedData instance."""
         pass
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()

--- a/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyx
@@ -57,4 +57,4 @@ cdef class PackedData:
 
     def __dealloc__(self):
         with nogil:
-            self._handle.reset()
+            self.c_obj.reset()

--- a/python/rapidsmpf/rapidsmpf/buffer/resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/buffer/resource.pyx
@@ -182,3 +182,7 @@ cdef class LimitAvailableMemory:
         with nogil:
             ret = deref(self._handle)()
         return ret
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()

--- a/python/rapidsmpf/rapidsmpf/buffer/rmm_fallback_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/buffer/rmm_fallback_resource.pyx
@@ -39,6 +39,10 @@ cdef class RmmFallbackResource(UpstreamResourceAdaptor):
             )
         )
 
+    def __dealloc__(self):
+        with nogil:
+            self.c_obj.reset()
+
     def __init__(
         self,
         DeviceMemoryResource upstream_mr,

--- a/python/rapidsmpf/rapidsmpf/communicator/communicator.pyx
+++ b/python/rapidsmpf/rapidsmpf/communicator/communicator.pyx
@@ -45,10 +45,6 @@ cdef class Logger:
     def __init__(self):
         raise TypeError("Please get a `Logger` from a communicater instance")
 
-    def __dealloc__(self):
-        with nogil:
-            self._comm = None
-
     @property
     def verbosity_level(self):
         """
@@ -149,8 +145,8 @@ cdef class Communicator:
         self._logger._comm = self
 
     def __dealloc__(self):
+        self._logger = None
         with nogil:
-            self._logger = None
             self._handle.reset()
 
     @property

--- a/python/rapidsmpf/rapidsmpf/communicator/communicator.pyx
+++ b/python/rapidsmpf/rapidsmpf/communicator/communicator.pyx
@@ -45,6 +45,10 @@ cdef class Logger:
     def __init__(self):
         raise TypeError("Please get a `Logger` from a communicater instance")
 
+    def __dealloc__(self):
+        with nogil:
+            self._comm = None
+
     @property
     def verbosity_level(self):
         """
@@ -141,7 +145,13 @@ cdef class Communicator:
 
     def __cinit__(self):
         self._logger = Logger.__new__(Logger)
+        # TODO: Don't have a refcycle here.
         self._logger._comm = self
+
+    def __dealloc__(self):
+        with nogil:
+            self._logger = None
+            self._handle.reset()
 
     @property
     def rank(self):

--- a/python/rapidsmpf/rapidsmpf/config.pyx
+++ b/python/rapidsmpf/rapidsmpf/config.pyx
@@ -77,6 +77,10 @@ cdef class Options:
         with nogil:
             self._handle = cpp_Options(move(opts))
 
+    def __dealloc__(self):
+        with nogil:
+            self._handle = None
+
     def get_or_assign(self, str key, parser_type, default_value):
         """
         Get the value of the given key, or assign and return a default value.

--- a/python/rapidsmpf/rapidsmpf/config.pyx
+++ b/python/rapidsmpf/rapidsmpf/config.pyx
@@ -79,7 +79,7 @@ cdef class Options:
 
     def __dealloc__(self):
         with nogil:
-            self._handle = None
+            self._handle = cpp_Options()
 
     def get_or_assign(self, str key, parser_type, default_value):
         """

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -357,7 +357,9 @@ def _extract_partition(
     finally:
         if shuffler.finished():
             ctx = get_worker_context()
-            del ctx.shufflers[shuffle_id]
+            with ctx.lock:
+                if shuffle_id in ctx.shufflers:
+                    del ctx.shufflers[shuffle_id]
 
 
 def rapidsmpf_shuffle_graph(

--- a/python/rapidsmpf/rapidsmpf/progress_thread.pyx
+++ b/python/rapidsmpf/rapidsmpf/progress_thread.pyx
@@ -44,3 +44,8 @@ cdef class ProgressThread:
                 deref(comm._handle).logger(),
                 statistics._handle,
             )
+
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()

--- a/python/rapidsmpf/rapidsmpf/progress_thread.pyx
+++ b/python/rapidsmpf/rapidsmpf/progress_thread.pyx
@@ -45,7 +45,6 @@ cdef class ProgressThread:
                 statistics._handle,
             )
 
-
     def __dealloc__(self):
         with nogil:
             self._handle.reset()

--- a/python/rapidsmpf/rapidsmpf/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pyx
@@ -295,6 +295,10 @@ cdef class Shuffler:
                 statistics._handle,
             )
 
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()
+
     def shutdown(self):
         """
         Shutdown the shuffle, blocking until all inflight communication is completed.

--- a/python/rapidsmpf/rapidsmpf/statistics.pyx
+++ b/python/rapidsmpf/rapidsmpf/statistics.pyx
@@ -38,6 +38,10 @@ cdef class Statistics:
         with nogil:
             self._handle = make_shared[cpp_Statistics](enable)
 
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()
+
     @property
     def enabled(self):
         """


### PR DESCRIPTION
Followup to #208, we need to do this everywhere.