### PR TITLE
Support GCC version 11

### DIFF
--- a/cpp/include/rapidsmpf/config.hpp
+++ b/cpp/include/rapidsmpf/config.hpp
@@ -35,7 +35,7 @@ using OptionFactory = std::function<T(std::string const&)>;
  * @brief Configuration option value.
  *
  * The OptionValue class encapsulates a value (of any type using std::any)
- * and an optional string representation of the value.
+ * and a string representation of the value.
  */
 class OptionValue {
   public:
@@ -47,30 +47,12 @@ class OptionValue {
     OptionValue() = default;
 
     /**
-     * @brief Constructs OptionValue from a std::any value.
-     *
-     * @param value The value to store, wrapped in std::any.
-     */
-    OptionValue(std::any value) : value_{std::move(value)} {}
-
-    /**
      * @brief Constructs OptionValue from a string representation.
      *
      * @param value_as_string A string representation of the value.
      */
     OptionValue(std::string value_as_string)
         : value_as_string_{std::move(value_as_string)} {}
-
-    /**
-     * @brief Convenience constructor to store any type.
-     *
-     * Wraps the given value in std::any and stores it.
-     *
-     * @tparam T The type of the value.
-     * @param value The value to store.
-     */
-    template <typename T>
-    OptionValue(T value) : OptionValue(std::make_any<T>(value)) {}
 
     /**
      * @brief Retrieves the stored value.

--- a/cpp/src/config.cpp
+++ b/cpp/src/config.cpp
@@ -41,7 +41,7 @@ std::unordered_map<std::string, OptionValue> from_options_as_strings(
 ) {
     std::unordered_map<std::string, OptionValue> ret;
     for (auto&& [key, val] : transform_keys_trim_lower(std::move(options_as_strings))) {
-        ret.insert({std::move(key), OptionValue(std::move(val))});
+        ret.emplace(std::move(key), OptionValue(std::move(val)));
     }
     return ret;
 }

--- a/cpp/tests/test_config.cpp
+++ b/cpp/tests/test_config.cpp
@@ -72,21 +72,9 @@ OptionFactory<T> make_factory(T default_value, std::function<T(std::string)> par
     };
 }
 
-TEST(OptionsTest, GetOptionCorrectTypeSetExplicitly) {
-    std::unordered_map<std::string, OptionValue> options = {{"myoption", OptionValue(42)}
-    };
-    Options opts(options);
-    auto value = opts.get<int>("myoption", make_factory<int>(0, [](auto s) {
-                                   return std::stoi(s);
-                               }));
-    EXPECT_EQ(value, 42);
-}
-
 TEST(OptionsTest, GetOptionWrongTypeThrows) {
-    std::unordered_map<std::string, OptionValue> options = {
-        {"myoption", OptionValue("not an int")}
-    };
-    Options opts(options);
+    std::unordered_map<std::string, std::string> strings = {{"myoption", "not an int"}};
+    Options opts(strings);
     EXPECT_THROW(
         {
             opts.get<int>("myoption", make_factory<int>(0, [](auto s) {


### PR DESCRIPTION
Removing `OptionValue`'s ctor that takes `std::any`.

Initially, I used SFINAE to fix GCC version 11's ctor confusion but I think it is better to always require a string representation.