### PR TITLE
enable Branch Checker

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -2,7 +2,7 @@
 # - https://github.com/rapidsai/ops-bot
 
 auto_merger: true
-branch_checker: false
+branch_checker: true
 label_checker: true
 release_drafter: false
 recently_updated: false


### PR DESCRIPTION
Now that this project is following RAPIDS calendar versioning and branching, it should enable the `Branch Checker` check. This does that.

I think this will unblock CI on PRs targeting `branch-25.08`: https://github.com/rapidsai/rapidsmpf/pull/308#issuecomment-2916471765