### PR TITLE
add wheel publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,17 @@ jobs:
       package-type: cpp
       # build for every combination of arch on CUDA 12 and latest Python
       matrix_filter: group_by([.ARCH]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
+  wheel-publish-librapidsmpf:
+    needs: wheel-build-librapidsmpf
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: librapidsmpf
+      package-type: cpp
   wheel-build-rapidsmpf:
     needs: wheel-build-librapidsmpf
     secrets: inherit
@@ -96,3 +107,14 @@ jobs:
       package-name: rapidsmpf
       package-type: python
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
+  wheel-publish-rapidsmpf:
+    needs: wheel-build-rapidsmpf
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: rapidsmpf
+      package-type: python

--- a/ci/build_wheel_librapidsmpf.sh
+++ b/ci/build_wheel_librapidsmpf.sh
@@ -40,3 +40,6 @@ python -m auditwheel repair \
     ${package_dir}/dist/*
 
 ./ci/validate_wheel.sh "${package_dir}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
+RAPIDS_PY_WHEEL_NAME="librapidsmpf_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 cpp "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_rapidsmpf.sh
+++ b/ci/build_wheel_rapidsmpf.sh
@@ -51,3 +51,5 @@ python -m auditwheel repair \
     ${package_dir}/dist/*
 
 ./ci/validate_wheel.sh "${package_dir}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PY_WHEEL_NAME="rapidsmpf_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"


### PR DESCRIPTION
Followup to #269

Adds wheel publishing to https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ on merges to `branch-25.06` + nightly runs.