### PR TITLE
Remove ucxx Python CMake workarounds

### DIFF
--- a/python/rapidsmpf/CMakeLists.txt
+++ b/python/rapidsmpf/CMakeLists.txt
@@ -19,9 +19,6 @@ project(
   LANGUAGES CXX CUDA
 )
 
-set(ucxx-python_DIR $ENV{SITE_PACKAGES}/ucxx/lib64/cmake/ucxx-python/)
-include_directories($ENV{SITE_PACKAGES}/ucxx/include)
-
 find_package(rapidsmpf REQUIRED "${RAPIDS_VERSION}")
 
 rapids_find_package(ucxx-python REQUIRED "${UCXX_VERSION}")


### PR DESCRIPTION
We previously had to manually set `ucxx_DIR` and the include directories due to issues with the ucxx build. Those issues have been resolved as of https://github.com/rapidsai/ucxx/pull/429, so remove these workarounds.

Follow-up to https://github.com/rapidsai/rapidsmpf/pull/269.