### PR TITLE
Improve the performance of rapidsmpf_shuffle_graph

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -472,6 +472,10 @@ def rapidsmpf_shuffle_graph(
     if not isinstance(integration, DaskIntegration):
         raise TypeError(f"Expected DaskIntegration object, got {integration}.")
 
+    # Note: We've observed high overhead from `Client.run` on some systems with
+    # some networking configurations. Minimize the number of `Client.run` calls
+    # by batching as much work as possible into a single call as possible.
+    # See https://github.com/rapidsai/rapidsmpf/pull/323 for more.
     worker_ranks: dict[int, str] = {
         v: k
         for k, v in client.run(

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -362,6 +362,16 @@ def _extract_partition(
                     del ctx.shufflers[shuffle_id]
 
 
+def _get_worker_ranks_and_stage_shuffler(
+    shuffle_id: int, partition_count: int, dask_worker: Worker | None = None
+) -> int:
+    rank = get_worker_rank(dask_worker)
+
+    _stage_shuffler(shuffle_id, partition_count, dask_worker)
+
+    return rank
+
+
 def rapidsmpf_shuffle_graph(
     input_name: str,
     output_name: str,
@@ -462,10 +472,15 @@ def rapidsmpf_shuffle_graph(
     if not isinstance(integration, DaskIntegration):
         raise TypeError(f"Expected DaskIntegration object, got {integration}.")
 
-    # Extract mapping between ranks and worker addresses
     worker_ranks: dict[int, str] = {
-        v: k for k, v in client.run(get_worker_rank).items()
+        v: k
+        for k, v in client.run(
+            _get_worker_ranks_and_stage_shuffler,
+            shuffle_id,
+            partition_count_out,
+        ).items()
     }
+
     n_workers = len(worker_ranks)
     restricted_keys: MutableMapping[Any, str] = {}
 
@@ -474,13 +489,6 @@ def rapidsmpf_shuffle_graph(
     global_barrier_1_name = f"rmpf-global-barrier-1-{output_name}"
     global_barrier_2_name = f"rmpf-global-barrier-2-{output_name}"
     worker_barrier_name = f"rmpf-worker-barrier-{output_name}"
-
-    # Stage a shuffler on every worker for this shuffle id
-    client.run(
-        _stage_shuffler,
-        shuffle_id=shuffle_id,
-        partition_count=partition_count_out,
-    )
 
     # Add tasks to insert each partition into the shuffler
     graph: dict[Any, Any] = {


### PR DESCRIPTION
We've observed some slowness in
`rapidsmpf.integrations.dask.shuffler.rapidsmpf_shuffle_graph`, where a relatively large amount of time (100s of ms) is spent in `client.run` staging things for the shuffle.

This is especially pronounced when using the ucx and ucxx protocol and as the number of workers increase. With Dask's tcp executor, the time spent in `client.run` is on the order of 1-10 ms. With ucx that goes to 100s of ms.

Long term, we want to address this at the root: our needs are relatively simple here and we should be able to speed this up in dask / ucx-py / ucxx.

Short term, we speed things up by only calling `client.run` once instead of twice by combining the two things (getting worker ranks and staging the shuffler) into the same function.

This was tested with the following script:

<details>

```python
import time

import dask.distributed
from dask_cuda import LocalCUDACluster

from rapidsmpf.examples.dask import DaskCudfIntegration
from rapidsmpf.integrations.dask import bootstrap_dask_cluster, rapidsmpf_shuffle_graph


def main():
    df = dask.datasets.timeseries().reset_index(drop=True).to_backend("cudf")

    # RapidsMPF is compatible with `dask_cuda` workers.
    # Use an rmm pool for optimal performance.
    with LocalCUDACluster(rmm_pool_size=0.8, protocol="ucx") as cluster, cluster.get_client() as client:
        bootstrap_dask_cluster(client, enable_statistics=False)
        t0 = time.time()
        for _ in range(5):
            rapidsmpf_shuffle_graph(
                input_name="timeseries",
                output_name="timeseries-shuffled",
                partition_count_in=df.npartitions,
                partition_count_out=df.npartitions,
                integration=DaskCudfIntegration(),
                options={"on": ["name"], "column_names": list(df.columns)},
            )

        t1 = time.time()
        print(f"rapidsmpf_shuffle_graph: {((t1 - t0)/5):0.4f}")

if __name__ == "__main__":
    main()
```

</details>


on main that took

```
rapidsmpf_shuffle_graph: 0.3974
```

on this branch, that took

```
rapidsmpf_shuffle_graph: 0.2036
```

roughly a 2x speedup.