### PR TITLE
add wheel publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,17 @@ jobs:
       package-type: cpp
       # build for every combination of arch on CUDA 12 and latest Python
       matrix_filter: group_by([.ARCH]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
+  wheel-publish-librapidsmpf:
+    needs: wheel-build-librapidsmpf
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: librapidsmpf
+      package-type: cpp
   wheel-build-rapidsmpf:
     needs: wheel-build-librapidsmpf
     secrets: inherit
@@ -96,3 +107,14 @@ jobs:
       package-name: rapidsmpf
       package-type: python
       matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
+  wheel-publish-rapidsmpf:
+    needs: wheel-build-rapidsmpf
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: rapidsmpf
+      package-type: python


### PR DESCRIPTION
Adds wheel publishing.

This was added on `branch-25.06` in #319, but those changes were lost in a forward-merge.

Note that I'm intentionally NOT adding the `rapids-upload-to-s3` changes from that PR... those are no longer necessary in 25.08, for the reasons described in https://github.com/rapidsai/build-planning/issues/181