### PR TITLE
Add <cstring> header for std::memcpy

### DIFF
--- a/cpp/src/shuffler/chunk.cpp
+++ b/cpp/src/shuffler/chunk.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cstring>
+
 #include <rapidsmpf/buffer/buffer.hpp>
 #include <rapidsmpf/buffer/packed_data.hpp>
 #include <rapidsmpf/buffer/resource.hpp>


### PR DESCRIPTION
Devcontainer builds are failing: https://github.com/rapidsai/devcontainers/actions/runs/15420568024/job/43475266470?pr=522#step:9:9487

```
/home/coder/rapidsmpf/cpp/src/shuffler/chunk.cpp:113:10: error: 'memcpy' is not a member of 'std'; did you mean 'wmemcpy'?
113 |     std::memcpy(&chunk_id, msg.data() + offset, sizeof(ChunkID));
    |          ^~~~~~
    |          wmemcpy
```

The header `<cstring>` that defines `std::memcpy` needs to be included in this file.
