### PR TITLE
Deadlock detection

### DIFF
--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -381,7 +381,7 @@ class BufferResource {
     std::shared_ptr<Statistics> statistics();
 
   private:
-    std::mutex mutex_;
+    rapidsmpf_mutex_t mutex_;
     rmm::device_async_resource_ref device_mr_;
     std::unordered_map<MemoryType, MemoryAvailable> memory_available_;
     // Zero initialized reserved counters.

--- a/cpp/include/rapidsmpf/buffer/spill_manager.hpp
+++ b/cpp/include/rapidsmpf/buffer/spill_manager.hpp
@@ -113,7 +113,7 @@ class SpillManager {
     std::size_t spill_to_make_headroom(std::int64_t headroom = 0);
 
   private:
-    mutable std::mutex mutex_;
+    mutable rapidsmpf_mutex_t mutex_;
     BufferResource* br_;
     std::size_t spill_function_id_counter_{0};
     std::map<SpillFunctionID, SpillFunction> spill_functions_;

--- a/cpp/include/rapidsmpf/communicator/communicator.hpp
+++ b/cpp/include/rapidsmpf/communicator/communicator.hpp
@@ -331,7 +331,7 @@ class Communicator {
             std::ostringstream full_log_msg;
             full_log_msg << "[" << level_name(level) << ":" << comm_->rank() << ":"
                          << get_thread_id() << "] " << ss.str();
-            std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+            RAPIDSMPF_LOCK_GUARD(mutex_);
             std::cout << full_log_msg.str() << std::endl;
         }
 

--- a/cpp/include/rapidsmpf/communicator/communicator.hpp
+++ b/cpp/include/rapidsmpf/communicator/communicator.hpp
@@ -331,7 +331,7 @@ class Communicator {
             std::ostringstream full_log_msg;
             full_log_msg << "[" << level_name(level) << ":" << comm_->rank() << ":"
                          << get_thread_id() << "] " << ss.str();
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
             std::cout << full_log_msg.str() << std::endl;
         }
 
@@ -345,7 +345,7 @@ class Communicator {
         }
 
       private:
-        std::mutex mutex_;
+        rapidsmpf_mutex_t mutex_;
         Communicator* comm_;
         LOG_LEVEL const level_;
 

--- a/cpp/include/rapidsmpf/config.hpp
+++ b/cpp/include/rapidsmpf/config.hpp
@@ -194,7 +194,7 @@ class Options {
     template <typename T>
     T const& get(const std::string& key, OptionFactory<T> factory) {
         auto& shared = *shared_;
-        std::lock_guard<rapidsmpf_mutex_t> lock(shared.mutex);
+        RAPIDSMPF_LOCK_GUARD(shared.mutex);
         auto& option = shared.options[key];
         if (!option.get_value().has_value()) {
             option.set_value(std::make_any<T>(factory(option.get_value_as_string())));

--- a/cpp/include/rapidsmpf/locking.hpp
+++ b/cpp/include/rapidsmpf/locking.hpp
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+
+#include <condition_variable>  // NOLINT(unused-includes)
+#include <mutex>  // NOLINT(unused-includes)
+
+namespace rapidsmpf {
+
+
+#define rapidsmpf_mutex_t std::mutex
+#define rapidsmpf_condition_variable_t std::condition_variable
+
+
+}  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/locking.hpp
+++ b/cpp/include/rapidsmpf/locking.hpp
@@ -16,4 +16,9 @@ namespace rapidsmpf {
 #define rapidsmpf_condition_variable_t std::condition_variable
 
 
+#define RAPIDSMPF_LOCK_GUARD(mutex)          \
+    std::lock_guard<rapidsmpf_mutex_t> const \
+        RAPIDSMPF_CONCAT(_rapidsmpf_lock_guard_, __LINE__)(mutex);
+
+
 }  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/locking.hpp
+++ b/cpp/include/rapidsmpf/locking.hpp
@@ -5,20 +5,111 @@
 
 #pragma once
 
-
+#include <chrono>
 #include <condition_variable>  // NOLINT(unused-includes)
 #include <mutex>  // NOLINT(unused-includes)
+#include <stdexcept>
+
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/utils.hpp>
 
 namespace rapidsmpf {
 
-
+/**
+ * @def rapidsmpf_mutex_t
+ * @brief Type alias for mutex used throughout RAPIDSMPF.
+ *
+ * Resolves to `std::timed_mutex` in debug builds (for timeout-based deadlock detection),
+ * and `std::mutex` in release builds (for performance).
+ */
+#ifdef RAPIDSMPF_DEBUG
+#define rapidsmpf_mutex_t std::timed_mutex
+#else
 #define rapidsmpf_mutex_t std::mutex
+#endif
+
+/**
+ * @def rapidsmpf_condition_variable_t
+ * @brief Type alias for condition variable used throughout RAPIDSMPF.
+ *
+ * Resolves to `std::condition_variable_any` in debug builds to support
+ * `std::timed_mutex`, and to `std::condition_variable` in release builds.
+ */
+#ifdef RAPIDSMPF_DEBUG
+#define rapidsmpf_condition_variable_t std::condition_variable_any
+#else
 #define rapidsmpf_condition_variable_t std::condition_variable
+#endif
 
-
+/**
+ * @def RAPIDSMPF_LOCK_GUARD
+ * @brief Lock guard macro that optionally enforces a timeout in debug builds.
+ *
+ * In debug mode, this uses a `timeout_lock_guard` to detect deadlocks.
+ * In release mode, it uses a standard `std::lock_guard` for performance.
+ *
+ * @param mutex A reference to a `rapidsmpf_mutex_t` instance.
+ */
+#ifdef RAPIDSMPF_DEBUG
+#define RAPIDSMPF_LOCK_GUARD(mutex)             \
+    rapidsmpf::detail::timeout_lock_guard const \
+        RAPIDSMPF_CONCAT(_rapidsmpf_lock_guard_, __LINE__)(mutex, __FILE__, __LINE__);
+#else
 #define RAPIDSMPF_LOCK_GUARD(mutex)          \
     std::lock_guard<rapidsmpf_mutex_t> const \
         RAPIDSMPF_CONCAT(_rapidsmpf_lock_guard_, __LINE__)(mutex);
+#endif
 
+
+namespace detail {
+
+/**
+ * @brief A lock guard that enforces a timeout when acquiring a lock.
+ *
+ * Used in debug builds to help detect potential deadlocks by failing fast
+ * when a lock cannot be acquired within a fixed duration.
+ *
+ * @note Automatically unlocks the mutex when destroyed.
+ */
+class timeout_lock_guard {
+  public:
+    /**
+     * @brief Constructs and attempts to acquire a lock with a timeout.
+     *
+     * If the lock cannot be acquired within the specified timeout, a
+     * `std::runtime_error` is thrown with filename and line number for debugging.
+     *
+     * @param mutex The `std::timed_mutex` to lock.
+     * @param filename Source file name (used in error message).
+     * @param line_number Line number (used in error message).
+     * @param timeout Maximum duration to wait before timing out.
+     *
+     * @throws std::runtime_error If the lock could not be acquired in time.
+     */
+    timeout_lock_guard(
+        std::timed_mutex& mutex,
+        char const* filename,
+        int line_number,
+        Duration const& timeout = std::chrono::seconds{60}
+    )
+        : lock_(mutex, std::defer_lock) {
+        if (!lock_.try_lock_for(timeout)) {
+            throw std::runtime_error(
+                "[DEADLOCK] timeout: " + std::string(filename) + ":"
+                + std::to_string(line_number)
+            );
+        }
+    }
+
+    // No move or copy.
+    timeout_lock_guard(const timeout_lock_guard&) = delete;
+    timeout_lock_guard& operator=(const timeout_lock_guard&) = delete;
+    timeout_lock_guard(timeout_lock_guard&&) = delete;
+    timeout_lock_guard& operator=(timeout_lock_guard&&) = delete;
+
+  private:
+    std::unique_lock<std::timed_mutex> lock_;
+};
+}  // namespace detail
 
 }  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/locking.hpp
+++ b/cpp/include/rapidsmpf/locking.hpp
@@ -15,6 +15,8 @@
 
 namespace rapidsmpf {
 
+#define RAPIDSMPF_DEBUG
+
 /**
  * @def rapidsmpf_mutex_t
  * @brief Type alias for mutex used throughout RAPIDSMPF.

--- a/cpp/include/rapidsmpf/pausable_thread_loop.hpp
+++ b/cpp/include/rapidsmpf/pausable_thread_loop.hpp
@@ -7,9 +7,9 @@
 
 #include <condition_variable>
 #include <functional>
-#include <mutex>
 #include <thread>
 
+#include <rapidsmpf/locking.hpp>
 #include <rapidsmpf/utils.hpp>
 
 namespace rapidsmpf::detail {
@@ -81,8 +81,8 @@ class PausableThreadLoop {
 
   private:
     std::thread thread_;
-    mutable std::mutex mutex_;
-    std::condition_variable cv_;
+    mutable rapidsmpf_mutex_t mutex_;
+    rapidsmpf_condition_variable_t cv_;
     bool active_{true};
     bool paused_{true};
 };

--- a/cpp/include/rapidsmpf/progress_thread.hpp
+++ b/cpp/include/rapidsmpf/progress_thread.hpp
@@ -204,8 +204,8 @@ class ProgressThread {
     Communicator::Logger& logger_;
     std::shared_ptr<Statistics> statistics_;
     bool is_thread_initialized_{false};
-    std::mutex mutex_;
-    std::condition_variable cv_;
+    rapidsmpf_mutex_t mutex_;
+    rapidsmpf_condition_variable_t cv_;
     FunctionIndex next_function_id_{0};
     std::unordered_map<FunctionIndex, FunctionState> functions_;
 };

--- a/cpp/include/rapidsmpf/rmm_resource_adaptor.hpp
+++ b/cpp/include/rapidsmpf/rmm_resource_adaptor.hpp
@@ -7,7 +7,6 @@
 
 #include <array>
 #include <cstddef>
-#include <mutex>
 #include <optional>
 #include <stack>
 #include <thread>
@@ -18,6 +17,8 @@
 #include <rmm/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <rapidsmpf/locking.hpp>
 
 namespace rapidsmpf {
 
@@ -314,7 +315,7 @@ class RmmResourceAdaptor final : public rmm::mr::device_memory_resource {
     [[nodiscard]] bool do_is_equal(rmm::mr::device_memory_resource const& other
     ) const noexcept override;
 
-    mutable std::mutex mutex_;
+    mutable rapidsmpf_mutex_t mutex_;
     rmm::device_async_resource_ref primary_mr_;
     std::optional<rmm::device_async_resource_ref> fallback_mr_;
     std::unordered_set<void*> fallback_allocations_;

--- a/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
+++ b/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
@@ -83,7 +83,7 @@ class FinishCounter {
      * @return True if all partitions are finished, otherwise false.
      */
     [[nodiscard]] bool all_finished() const {
-        std::unique_lock<std::mutex> lock(mutex_);
+        std::unique_lock<rapidsmpf_mutex_t> lock(mutex_);
         return partitions_ready_to_wait_on_.empty();
     }
 
@@ -163,8 +163,8 @@ class FinishCounter {
     //   - If it is true, the partition is finished and can be waited on.
     //   - If it is absent, the partition is finished and has already been waited on.
     std::unordered_map<PartID, bool> partitions_ready_to_wait_on_;
-    mutable std::mutex mutex_;  // TODO: use a shared_mutex lock?
-    mutable std::condition_variable cv_;
+    mutable rapidsmpf_mutex_t mutex_;  // TODO: use a shared_mutex lock?
+    mutable rapidsmpf_condition_variable_t cv_;
 };
 }  // namespace detail
 

--- a/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
+++ b/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
@@ -83,7 +83,7 @@ class FinishCounter {
      * @return True if all partitions are finished, otherwise false.
      */
     [[nodiscard]] bool all_finished() const {
-        std::unique_lock<rapidsmpf_mutex_t> lock(mutex_);
+        RAPIDSMPF_LOCK_GUARD(mutex_);
         return partitions_ready_to_wait_on_.empty();
     }
 

--- a/cpp/include/rapidsmpf/shuffler/postbox.hpp
+++ b/cpp/include/rapidsmpf/shuffler/postbox.hpp
@@ -115,7 +115,7 @@ class PostBox {
 
   private:
     // TODO: more fine-grained locking e.g. by locking each partition individually.
-    mutable std::mutex mutex_;
+    mutable rapidsmpf_mutex_t mutex_;
     std::function<key_type(PartID)>
         key_map_fn_;  ///< Function to map partition IDs to keys.
     std::unordered_map<key_type, std::unordered_map<ChunkID, Chunk>>

--- a/cpp/include/rapidsmpf/shuffler/shuffler.hpp
+++ b/cpp/include/rapidsmpf/shuffler/shuffler.hpp
@@ -252,11 +252,11 @@ class Shuffler {
 
     detail::FinishCounter finish_counter_;
     std::unordered_map<PartID, detail::ChunkID> outbound_chunk_counter_;
-    mutable std::mutex outbound_chunk_counter_mutex_;
+    mutable rapidsmpf_mutex_t outbound_chunk_counter_mutex_;
 
     // We protect outbox extraction to avoid returning a chunk that is in the process
     // of being spilled by `Shuffler::spill`.
-    mutable std::mutex outbox_spilling_mutex_;
+    mutable rapidsmpf_mutex_t outbox_spilling_mutex_;
 
     std::atomic<detail::ChunkID> chunk_id_counter_{0};
 

--- a/cpp/include/rapidsmpf/statistics.hpp
+++ b/cpp/include/rapidsmpf/statistics.hpp
@@ -200,7 +200,7 @@ class Statistics {
     Duration add_duration_stat(std::string const& name, Duration seconds);
 
   private:
-    mutable std::mutex mutex_;
+    mutable rapidsmpf_mutex_t mutex_;
     bool enabled_;
     std::map<std::string, Stat> stats_;
 };

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -37,7 +37,7 @@ std::pair<MemoryReservation, std::size_t> BufferResource::reserve(
     MemoryType mem_type, std::size_t size, bool allow_overbooking
 ) {
     auto const& available = memory_available(mem_type);
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     std::size_t& reserved = memory_reserved(mem_type);
 
     // Calculate the available memory _after_ the memory has been reserved.
@@ -64,7 +64,7 @@ std::size_t BufferResource::release(
         "the memory type of MemoryReservation doesn't match",
         std::invalid_argument
     );
-    std::lock_guard const lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     RAPIDSMPF_EXPECTS(
         size <= reservation.size_,
         "MemoryReservation(" + format_nbytes(reservation.size_) + ") isn't big enough ("

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -37,7 +37,7 @@ std::pair<MemoryReservation, std::size_t> BufferResource::reserve(
     MemoryType mem_type, std::size_t size, bool allow_overbooking
 ) {
     auto const& available = memory_available(mem_type);
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     std::size_t& reserved = memory_reserved(mem_type);
 
     // Calculate the available memory _after_ the memory has been reserved.

--- a/cpp/src/buffer/spill_manager.cpp
+++ b/cpp/src/buffer/spill_manager.cpp
@@ -32,7 +32,7 @@ SpillManager::~SpillManager() {
 SpillManager::SpillFunctionID SpillManager::add_spill_function(
     SpillFunction spill_function, int priority
 ) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     auto const id = spill_function_id_counter_++;
     RAPIDSMPF_EXPECTS(
         spill_functions_.insert({id, std::move(spill_function)}).second,
@@ -48,7 +48,7 @@ SpillManager::SpillFunctionID SpillManager::add_spill_function(
 }
 
 void SpillManager::remove_spill_function(SpillFunctionID fid) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     auto& prio = spill_function_priorities_;
     for (auto it = prio.begin(); it != prio.end(); ++it) {
         if (it->second == fid) {
@@ -67,7 +67,7 @@ void SpillManager::remove_spill_function(SpillFunctionID fid) {
 std::size_t SpillManager::spill(std::size_t amount) {
     RAPIDSMPF_NVTX_FUNC_RANGE();
     std::size_t spilled{0};
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::unique_lock<rapidsmpf_mutex_t> lock(mutex_);
     auto const t0_elapsed = Clock::now();
     for (auto const [_, fid] : spill_function_priorities_) {
         if (spilled >= amount) {

--- a/cpp/src/buffer/spill_manager.cpp
+++ b/cpp/src/buffer/spill_manager.cpp
@@ -32,7 +32,7 @@ SpillManager::~SpillManager() {
 SpillManager::SpillFunctionID SpillManager::add_spill_function(
     SpillFunction spill_function, int priority
 ) {
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     auto const id = spill_function_id_counter_++;
     RAPIDSMPF_EXPECTS(
         spill_functions_.insert({id, std::move(spill_function)}).second,
@@ -48,7 +48,7 @@ SpillManager::SpillFunctionID SpillManager::add_spill_function(
 }
 
 void SpillManager::remove_spill_function(SpillFunctionID fid) {
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     auto& prio = spill_function_priorities_;
     for (auto it = prio.begin(); it != prio.end(); ++it) {
         if (it->second == fid) {

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -215,7 +215,7 @@ class SharedResources {
      * @param listener The listener to register.
      */
     void register_listener(std::shared_ptr<::ucxx::Listener> listener) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(listener_mutex_);
+        RAPIDSMPF_LOCK_GUARD(listener_mutex_);
         auto worker = std::dynamic_pointer_cast<::ucxx::Worker>(listener->getParent());
         rank_to_listener_address_[rank_] =
             ListenerAddress{.address = worker->getAddress(), .rank = rank_};
@@ -231,7 +231,7 @@ class SharedResources {
      * @param endpoint The endpoint to register.
      */
     void register_endpoint(Rank const rank, std::shared_ptr<::ucxx::Endpoint> endpoint) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(endpoints_mutex_);
+        RAPIDSMPF_LOCK_GUARD(endpoints_mutex_);
         rank_to_endpoint_[rank] = endpoint;
         endpoints_[endpoint->getHandle()] = std::move(endpoint);
     }
@@ -245,7 +245,7 @@ class SharedResources {
      * @param endpoint The endpoint to register.
      */
     void register_endpoint(std::shared_ptr<::ucxx::Endpoint> endpoint) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(endpoints_mutex_);
+        RAPIDSMPF_LOCK_GUARD(endpoints_mutex_);
         endpoints_[endpoint->getHandle()] = std::move(endpoint);
     }
 
@@ -258,7 +258,7 @@ class SharedResources {
      * @param endpoint_handle The handle of the endpoint to register.
      */
     void associate_endpoint_rank(Rank const rank, ucp_ep_h const endpoint_handle) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(endpoints_mutex_);
+        RAPIDSMPF_LOCK_GUARD(endpoints_mutex_);
         rank_to_endpoint_[rank] = endpoints_[endpoint_handle];
     }
 
@@ -270,7 +270,7 @@ class SharedResources {
      * @return The registered listener.
      */
     [[nodiscard]] std::shared_ptr<::ucxx::Listener> get_listener() {
-        std::lock_guard<rapidsmpf_mutex_t> lock(listener_mutex_);
+        RAPIDSMPF_LOCK_GUARD(listener_mutex_);
         return listener_;
     }
 
@@ -284,7 +284,7 @@ class SharedResources {
      */
     [[nodiscard]] std::shared_ptr<::ucxx::Endpoint> get_endpoint(ucp_ep_h const ep_handle
     ) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(endpoints_mutex_);
+        RAPIDSMPF_LOCK_GUARD(endpoints_mutex_);
         return endpoints_.at(ep_handle);
     }
 
@@ -297,7 +297,7 @@ class SharedResources {
      * @return The endpoint associated with the specified rank.
      */
     [[nodiscard]] std::shared_ptr<::ucxx::Endpoint> get_endpoint(Rank const rank) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(endpoints_mutex_);
+        RAPIDSMPF_LOCK_GUARD(endpoints_mutex_);
         return rank_to_endpoint_.at(rank);
     }
 
@@ -310,7 +310,7 @@ class SharedResources {
      * @return The listener address associated with the specified rank.
      */
     [[nodiscard]] ListenerAddress get_listener_address(Rank const rank) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(listener_mutex_);
+        RAPIDSMPF_LOCK_GUARD(listener_mutex_);
         return rank_to_listener_address_.at(rank);
     }
 
@@ -323,7 +323,7 @@ class SharedResources {
      * @param listener_address The listener address to register.
      */
     void register_listener_address(Rank const rank, ListenerAddress listener_address) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(listener_mutex_);
+        RAPIDSMPF_LOCK_GUARD(listener_mutex_);
         rank_to_listener_address_[rank] = std::move(listener_address);
     }
 
@@ -335,7 +335,7 @@ class SharedResources {
      * @param future The future to add.
      */
     void add_future(std::unique_ptr<HostFuture> future) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(futures_mutex_);
+        RAPIDSMPF_LOCK_GUARD(futures_mutex_);
         futures_.push_back(std::move(future));
     }
 
@@ -382,7 +382,7 @@ class SharedResources {
     }
 
     void clear_completed_futures() {
-        std::lock_guard<rapidsmpf_mutex_t> lock(futures_mutex_);
+        RAPIDSMPF_LOCK_GUARD(futures_mutex_);
         futures_.erase(
             std::remove_if(
                 futures_.begin(),
@@ -398,7 +398,7 @@ class SharedResources {
     void progress_worker() {
         decltype(delayed_progress_callbacks_) delayed_progress_callbacks{};
         {
-            std::lock_guard<rapidsmpf_mutex_t> lock(delayed_progress_callbacks_mutex_);
+            RAPIDSMPF_LOCK_GUARD(delayed_progress_callbacks_mutex_);
             std::swap(delayed_progress_callbacks, delayed_progress_callbacks_);
         }
         for (auto& callback : delayed_progress_callbacks)
@@ -419,7 +419,7 @@ class SharedResources {
      * @param future The future to add.
      */
     void add_delayed_progress_callback(std::function<void()> callback) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(delayed_progress_callbacks_mutex_);
+        RAPIDSMPF_LOCK_GUARD(delayed_progress_callbacks_mutex_);
         delayed_progress_callbacks_.emplace_back(std::move(callback));
     }
 

--- a/cpp/src/config.cpp
+++ b/cpp/src/config.cpp
@@ -61,7 +61,7 @@ std::size_t Options::insert_if_absent(
     std::unordered_map<std::string, std::string> options_as_strings
 ) {
     auto& shared = *shared_;
-    std::lock_guard<rapidsmpf_mutex_t> lock(shared.mutex);
+    RAPIDSMPF_LOCK_GUARD(shared.mutex);
     std::size_t ret = 0;
     for (auto&& [key, val] : options_as_strings) {
         auto new_key = rapidsmpf::to_lower(rapidsmpf::trim(key));
@@ -77,7 +77,7 @@ std::size_t Options::insert_if_absent(
 std::unordered_map<std::string, std::string> Options::get_strings() const {
     auto const& shared = *shared_;
     std::unordered_map<std::string, std::string> ret;
-    std::lock_guard<rapidsmpf_mutex_t> lock(shared.mutex);
+    RAPIDSMPF_LOCK_GUARD(shared.mutex);
     for (const auto& [key, option] : shared.options) {
         ret[key] = option.get_value_as_string();
     }
@@ -86,7 +86,7 @@ std::unordered_map<std::string, std::string> Options::get_strings() const {
 
 std::vector<std::uint8_t> Options::serialize() const {
     auto const& shared = *shared_;
-    std::lock_guard<rapidsmpf_mutex_t> lock(shared.mutex);
+    RAPIDSMPF_LOCK_GUARD(shared.mutex);
 
     std::size_t const count = shared.options.size();
     std::size_t const header_size = (1 + 2 * count) * sizeof(uint64_t);

--- a/cpp/src/config.cpp
+++ b/cpp/src/config.cpp
@@ -61,7 +61,7 @@ std::size_t Options::insert_if_absent(
     std::unordered_map<std::string, std::string> options_as_strings
 ) {
     auto& shared = *shared_;
-    std::lock_guard<std::mutex> lock(shared.mutex);
+    std::lock_guard<rapidsmpf_mutex_t> lock(shared.mutex);
     std::size_t ret = 0;
     for (auto&& [key, val] : options_as_strings) {
         auto new_key = rapidsmpf::to_lower(rapidsmpf::trim(key));
@@ -77,7 +77,7 @@ std::size_t Options::insert_if_absent(
 std::unordered_map<std::string, std::string> Options::get_strings() const {
     auto const& shared = *shared_;
     std::unordered_map<std::string, std::string> ret;
-    std::lock_guard<std::mutex> lock(shared.mutex);
+    std::lock_guard<rapidsmpf_mutex_t> lock(shared.mutex);
     for (const auto& [key, option] : shared.options) {
         ret[key] = option.get_value_as_string();
     }
@@ -86,7 +86,7 @@ std::unordered_map<std::string, std::string> Options::get_strings() const {
 
 std::vector<std::uint8_t> Options::serialize() const {
     auto const& shared = *shared_;
-    std::lock_guard<std::mutex> lock(shared.mutex);
+    std::lock_guard<rapidsmpf_mutex_t> lock(shared.mutex);
 
     std::size_t const count = shared.options.size();
     std::size_t const header_size = (1 + 2 * count) * sizeof(uint64_t);

--- a/cpp/src/pausable_thread_loop.cpp
+++ b/cpp/src/pausable_thread_loop.cpp
@@ -36,18 +36,18 @@ PausableThreadLoop::~PausableThreadLoop() {
 }
 
 bool PausableThreadLoop::is_running() const noexcept {
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     return !paused_;
 }
 
 void PausableThreadLoop::pause() {
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     paused_ = true;
 }
 
 void PausableThreadLoop::resume() {
     {
-        std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+        RAPIDSMPF_LOCK_GUARD(mutex_);
         paused_ = false;
     }
     cv_.notify_one();
@@ -55,7 +55,7 @@ void PausableThreadLoop::resume() {
 
 void PausableThreadLoop::stop() {
     {
-        std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+        RAPIDSMPF_LOCK_GUARD(mutex_);
         active_ = false;
         paused_ = false;  // Ensure it's not stuck in pause
     }

--- a/cpp/src/progress_thread.cpp
+++ b/cpp/src/progress_thread.cpp
@@ -67,7 +67,7 @@ void ProgressThread::stop() {
 }
 
 ProgressThread::FunctionID ProgressThread::add_function(Function&& function) {
-    std::lock_guard lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     // We can use `this` as the thread address only because `ProgressThread` isn't
     // moveable or copyable.
     auto id =
@@ -122,7 +122,7 @@ bool ProgressThread::is_running() const {
 void ProgressThread::event_loop() {
     auto const t0_event_loop = Clock::now();
     {
-        std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+        RAPIDSMPF_LOCK_GUARD(mutex_);
         for (auto& [id, function] : functions_) {
             function();
         }

--- a/cpp/src/progress_thread.cpp
+++ b/cpp/src/progress_thread.cpp
@@ -84,7 +84,7 @@ void ProgressThread::remove_function(FunctionID function_id) {
         "Function was not registered with this ProgressThread"
     );
 
-    std::unique_lock lock(mutex_);
+    std::unique_lock<rapidsmpf_mutex_t> lock(mutex_);
     auto it = functions_.find(function_id.function_index);
     RAPIDSMPF_EXPECTS(
         it != functions_.end(), "Function not registered or already removed"

--- a/cpp/src/progress_thread.cpp
+++ b/cpp/src/progress_thread.cpp
@@ -122,7 +122,7 @@ bool ProgressThread::is_running() const {
 void ProgressThread::event_loop() {
     auto const t0_event_loop = Clock::now();
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
         for (auto& [id, function] : functions_) {
             function();
         }

--- a/cpp/src/rmm_resource_adaptor.cpp
+++ b/cpp/src/rmm_resource_adaptor.cpp
@@ -104,17 +104,17 @@ ScopedMemoryRecord& ScopedMemoryRecord::add_scope(ScopedMemoryRecord const& scop
 }
 
 ScopedMemoryRecord RmmResourceAdaptor::get_main_record() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     return main_record_;
 }
 
 std::int64_t RmmResourceAdaptor::current_allocated() const noexcept {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     return main_record_.current();
 }
 
 void RmmResourceAdaptor::begin_scoped_memory_record() {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     // Push an empty scope on the stack.
     record_stacks_[std::this_thread::get_id()].emplace();
 }
@@ -143,13 +143,13 @@ void* RmmResourceAdaptor::do_allocate(std::size_t nbytes, rmm::cuda_stream_view 
         if (fallback_mr_.has_value()) {
             alloc_type = FALLBACK;
             ret = fallback_mr_->allocate_async(nbytes, stream);
-            std::lock_guard<std::mutex> lock(mutex_);
+            std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
             fallback_allocations_.insert(ret);
         } else {
             throw;
         }
     }
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
 
     // Always record the allocation on the main record.
     main_record_.record_allocation(alloc_type, static_cast<std::int64_t>(nbytes));
@@ -175,7 +175,7 @@ void RmmResourceAdaptor::do_deallocate(
 
     ScopedMemoryRecord::AllocType alloc_type;
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
         alloc_type = (fallback_allocations_.erase(ptr) == 0) ? PRIMARY : FALLBACK;
     }
 
@@ -185,7 +185,7 @@ void RmmResourceAdaptor::do_deallocate(
         fallback_mr_->deallocate_async(ptr, nbytes, stream);
     }
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     // Always record the deallocation on the main record.
     main_record_.record_deallocation(alloc_type, static_cast<std::int64_t>(nbytes));
     // But only record it on the thread stack if it exist.

--- a/cpp/src/shuffler/finish_counter.cpp
+++ b/cpp/src/shuffler/finish_counter.cpp
@@ -17,7 +17,7 @@ FinishCounter::FinishCounter(Rank nranks, std::vector<PartID> const& local_parti
 }
 
 void FinishCounter::move_goalpost(PartID pid, ChunkID nchunks) {
-    std::unique_lock<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     auto& [rank_counter, chunk_goal] = goalposts_[pid];
     RAPIDSMPF_EXPECTS(
         rank_counter++ < nranks_, "the goalpost was moved more than one per rank"
@@ -26,7 +26,7 @@ void FinishCounter::move_goalpost(PartID pid, ChunkID nchunks) {
 }
 
 void FinishCounter::add_finished_chunk(PartID pid) {
-    std::unique_lock<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     auto& finished_chunk = ++finished_chunk_counters_[pid];
     auto& [rank_counter, chunk_goal] = goalposts_[pid];
 

--- a/cpp/src/shuffler/postbox.cpp
+++ b/cpp/src/shuffler/postbox.cpp
@@ -22,32 +22,32 @@ void PostBox<KeyType>::insert(Chunk&& chunk) {
             "PostBox.insert(): all messages in the chunk must map to the same key"
         );
     }
-    std::lock_guard const lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     auto [_, inserted] = pigeonhole_[key].insert({chunk.chunk_id(), std::move(chunk)});
     RAPIDSMPF_EXPECTS(inserted, "PostBox.insert(): chunk already exist");
 }
 
 template <typename KeyType>
 Chunk PostBox<KeyType>::extract(PartID pid, ChunkID cid) {
-    std::lock_guard const lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     return extract_item(pigeonhole_[key_map_fn_(pid)], cid).second;
 }
 
 template <typename KeyType>
 std::unordered_map<ChunkID, Chunk> PostBox<KeyType>::extract(PartID pid) {
-    std::lock_guard const lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     return extract_value(pigeonhole_, key_map_fn_(pid));
 }
 
 template <typename KeyType>
 std::unordered_map<ChunkID, Chunk> PostBox<KeyType>::extract_by_key(KeyType key) {
-    std::lock_guard const lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     return extract_value(pigeonhole_, key);
 }
 
 template <typename KeyType>
 std::vector<Chunk> PostBox<KeyType>::extract_all_ready() {
-    std::lock_guard const lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     std::vector<Chunk> ret;
 
     // Iterate through the outer map
@@ -85,7 +85,7 @@ template <typename KeyType>
 std::vector<std::tuple<KeyType, ChunkID, std::size_t>> PostBox<KeyType>::search(
     MemoryType mem_type
 ) const {
-    std::lock_guard const lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     std::vector<std::tuple<KeyType, ChunkID, std::size_t>> ret;
     for (auto& [key, chunks] : pigeonhole_) {
         for (auto& [cid, chunk] : chunks) {

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -495,7 +495,7 @@ void Shuffler::insert_into_ready_postbox(detail::Chunk&& chunk) {
 
 void Shuffler::insert(detail::Chunk&& chunk) {
     {
-        std::lock_guard const lock(outbound_chunk_counter_mutex_);
+        RAPIDSMPF_LOCK_GUARD(outbound_chunk_counter_mutex_);
         // TODO: There are multiple partitions in the chunk. So, do this for each
         // partition.
         ++outbound_chunk_counter_[chunk.part_id(0)];
@@ -557,7 +557,7 @@ void Shuffler::insert(std::unordered_map<PartID, PackedData>&& chunks) {
 void Shuffler::insert_finished(PartID pid) {
     detail::ChunkID expected_num_chunks;
     {
-        std::lock_guard const lock(outbound_chunk_counter_mutex_);
+        RAPIDSMPF_LOCK_GUARD(outbound_chunk_counter_mutex_);
         expected_num_chunks = outbound_chunk_counter_[pid];
     }
     insert(detail::Chunk::from_finished_partition(
@@ -623,7 +623,7 @@ std::size_t Shuffler::spill(std::optional<std::size_t> amount) {
     }
     std::size_t spilled{0};
     if (spill_need > 0) {
-        std::lock_guard<rapidsmpf_mutex_t> lock(outbox_spilling_mutex_);
+        RAPIDSMPF_LOCK_GUARD(outbox_spilling_mutex_);
         spilled =
             postbox_spilling(br_, comm_->logger(), stream_, ready_postbox_, spill_need);
     }

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -569,7 +569,7 @@ std::vector<PackedData> Shuffler::extract(PartID pid) {
     RAPIDSMPF_NVTX_FUNC_RANGE();
     // Protect the chunk extraction to make sure we don't get a chunk
     // `Shuffler::spill` is in the process of spilling.
-    std::unique_lock<std::mutex> lock(outbox_spilling_mutex_);
+    std::unique_lock<rapidsmpf_mutex_t> lock(outbox_spilling_mutex_);
     auto chunks = ready_postbox_.extract(pid);
     lock.unlock();
     std::vector<PackedData> ret;
@@ -623,7 +623,7 @@ std::size_t Shuffler::spill(std::optional<std::size_t> amount) {
     }
     std::size_t spilled{0};
     if (spill_need > 0) {
-        std::lock_guard<std::mutex> lock(outbox_spilling_mutex_);
+        std::lock_guard<rapidsmpf_mutex_t> lock(outbox_spilling_mutex_);
         spilled =
             postbox_spilling(br_, comm_->logger(), stream_, ready_postbox_, spill_need);
     }
@@ -646,7 +646,7 @@ std::string Shuffler::str() const {
 }
 
 std::string detail::FinishCounter::str() const {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::unique_lock<rapidsmpf_mutex_t> lock(mutex_);
     std::stringstream ss;
     ss << "FinishCounter(goalposts={";
     for (auto const& [pid, goal] : goalposts_) {

--- a/cpp/src/statistics.cpp
+++ b/cpp/src/statistics.cpp
@@ -18,7 +18,7 @@ void Statistics::FormatterDefault(std::ostream& os, std::size_t count, double va
 };
 
 Statistics::Stat Statistics::get_stat(std::string const& name) const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     return stats_.at(name);
 }
 
@@ -28,7 +28,7 @@ double Statistics::add_stat(
     if (!enabled()) {
         return 0;
     }
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
     auto it = stats_.find(name);
     if (it == stats_.end()) {
         it = stats_.insert({name, Stat(formatter)}).first;
@@ -65,7 +65,7 @@ std::string Statistics::report(std::string const& header) const {
         ss << " disabled.";
         return ss.str();
     }
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
 
     std::size_t max_length{0};
     for (auto const& [name, _] : stats_) {

--- a/cpp/src/statistics.cpp
+++ b/cpp/src/statistics.cpp
@@ -18,7 +18,7 @@ void Statistics::FormatterDefault(std::ostream& os, std::size_t count, double va
 };
 
 Statistics::Stat Statistics::get_stat(std::string const& name) const {
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     return stats_.at(name);
 }
 
@@ -28,7 +28,7 @@ double Statistics::add_stat(
     if (!enabled()) {
         return 0;
     }
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
     auto it = stats_.find(name);
     if (it == stats_.end()) {
         it = stats_.insert({name, Stat(formatter)}).first;
@@ -65,7 +65,7 @@ std::string Statistics::report(std::string const& header) const {
         ss << " disabled.";
         return ss.str();
     }
-    std::lock_guard<rapidsmpf_mutex_t> lock(mutex_);
+    RAPIDSMPF_LOCK_GUARD(mutex_);
 
     std::size_t max_length{0};
     for (auto const& [name, _] : stats_) {

--- a/cpp/tests/test_pausable_thread_loop.cpp
+++ b/cpp/tests/test_pausable_thread_loop.cpp
@@ -16,13 +16,13 @@ using rapidsmpf::detail::PausableThreadLoop;
 
 TEST(PausableThreadLoop, ResumeAndPause) {
     int counter{0};
-    std::mutex mutex;
-    std::condition_variable cv;
+    rapidsmpf_mutex_t mutex;
+    rapidsmpf_condition_variable_t cv;
     bool updated = false;
 
     PausableThreadLoop loop([&]() {
         {
-            std::lock_guard<std::mutex> lock(mutex);
+            std::lock_guard<rapidsmpf_mutex_t> lock(mutex);
             ++counter;
             updated = true;
         }
@@ -36,7 +36,7 @@ TEST(PausableThreadLoop, ResumeAndPause) {
 
     // Wait for the counter to be increased.
     {
-        std::unique_lock<std::mutex> lock(mutex);
+        std::unique_lock<rapidsmpf_mutex_t> lock(mutex);
         cv.wait(lock, [&]() { return updated; });
     }
     EXPECT_GT(counter, 0);

--- a/cpp/tests/test_pausable_thread_loop.cpp
+++ b/cpp/tests/test_pausable_thread_loop.cpp
@@ -22,7 +22,7 @@ TEST(PausableThreadLoop, ResumeAndPause) {
 
     PausableThreadLoop loop([&]() {
         {
-            std::lock_guard<rapidsmpf_mutex_t> lock(mutex);
+            RAPIDSMPF_LOCK_GUARD(mutex);
             ++counter;
             updated = true;
         }


### PR DESCRIPTION
When `RAPIDSMPF_DEBUG` is defined, all lock guards have a timeout of 60 seconds. 