### PR TITLE
Fix lifetime issues in Cython BufferResource

### DIFF
--- a/python/rapidsmpf/rapidsmpf/buffer/resource.pxd
+++ b/python/rapidsmpf/rapidsmpf/buffer/resource.pxd
@@ -40,6 +40,7 @@ cdef class BufferResource:
     cdef shared_ptr[cpp_BufferResource] _handle
     cdef readonly SpillManager spill_manager
     cdef cpp_BufferResource* ptr(self)
+    cdef DeviceMemoryResource _mr
 
 
 cdef extern from "<rapidsmpf/buffer/resource.hpp>" nogil:

--- a/python/rapidsmpf/rapidsmpf/buffer/resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/buffer/resource.pyx
@@ -69,6 +69,11 @@ cdef class BufferResource:
         if periodic_spill_check is not None:
             period = cpp_Duration(periodic_spill_check)
 
+        # Keep MR alive because the C++ BufferResource stores a raw pointer.
+        # TODO: once RMM is migrating to CCCL (copyable) any_resource,
+        # rather than the any_resource_ref reference type, we don't
+        # need to keep this alive here.
+        self._mr = device_mr
         with nogil:
             self._handle = make_shared[cpp_BufferResource](
                 device_mr.get_mr(),


### PR DESCRIPTION
Since the C++ BufferResource stores a raw pointer to the memory resource, on the Python side we must keep the MR alive ourselves.

- Closes #349