### PR TITLE
PostBox with multiple mutexes 

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -111,3 +111,29 @@ install(
   DESTINATION bin/benchmarks/librapidsmpf
   EXCLUDE_FROM_ALL
 )
+
+add_executable(bench_postbox "postbox/bench_postbox.cpp" "postbox/postbox2.hpp" ${UTILS_SOURCES})
+set_target_properties(
+  bench_postbox
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks>"
+             CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED ON
+             # For std:: support of __int128_t. Can be removed once using cuda::std
+             CXX_EXTENSIONS ON
+             CUDA_STANDARD 20
+             CUDA_STANDARD_REQUIRED ON
+)
+target_compile_options(
+  bench_postbox PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
+                        "$<$<COMPILE_LANGUAGE:CUDA>:${RAPIDSMPF_CUDA_FLAGS}>"
+)
+target_link_libraries(
+  bench_postbox PRIVATE rapidsmpf::rapidsmpf benchmark::benchmark benchmark::benchmark_main
+                        $<TARGET_NAME_IF_EXISTS:conda_env>
+)
+install(
+  TARGETS bench_postbox
+  COMPONENT benchmarking
+  DESTINATION bin/benchmarks/librapidsmpf
+  EXCLUDE_FROM_ALL
+)

--- a/cpp/benchmarks/postbox/bench_postbox.cpp
+++ b/cpp/benchmarks/postbox/bench_postbox.cpp
@@ -1,0 +1,224 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <limits>
+#include <thread>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/host/pinned_memory_resource.hpp>
+
+#include <rapidsmpf/buffer/buffer.hpp>
+#include <rapidsmpf/buffer/packed_data.hpp>
+#include <rapidsmpf/buffer/resource.hpp>
+#include <rapidsmpf/shuffler/chunk.hpp>
+#include <rapidsmpf/shuffler/postbox.hpp>
+
+#include "postbox2.hpp"
+
+namespace rapidsmpf::shuffler::detail {
+
+// Helper function to create a chunk with device data buffer
+Chunk create_chunk_with_device_data(
+    ChunkID chunk_id,
+    PartID part_id,
+    size_t data_size,
+    rmm::cuda_stream_view stream,
+    BufferResource* br
+) {
+    // Create metadata
+    auto metadata =
+        std::make_unique<std::vector<uint8_t>>(std::vector<uint8_t>{1, 2, 3, 4});
+
+    // Create device data buffer
+    auto device_buffer = std::make_unique<rmm::device_buffer>(data_size, stream);
+    std::vector<uint8_t> host_data(data_size);
+    for (size_t i = 0; i < data_size; ++i) {
+        host_data[i] = static_cast<uint8_t>(i % 256);
+    }
+    RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
+        device_buffer->data(), host_data.data(), data_size, cudaMemcpyHostToDevice, stream
+    ));
+    auto event = std::make_shared<Buffer::Event>(stream);
+
+    PackedData packed_data{std::move(metadata), std::move(device_buffer)};
+
+    return Chunk::from_packed_data(
+        chunk_id, part_id, std::move(packed_data), std::move(event), stream, br
+    );
+}
+
+constexpr size_t nranks = 8;
+constexpr size_t nparts = 100;
+
+template <typename T>
+struct KeyMapFn {};
+
+template <>
+struct KeyMapFn<Rank> {
+    Rank operator()(PartID pid) const {
+        return pid % nranks;
+    }
+};
+
+template <>
+struct KeyMapFn<PartID> {
+    PartID operator()(PartID pid) const {
+        return pid;
+    }
+};
+
+// Benchmark template for PostBox
+template <typename PostBoxType>
+static void BM_PostBoxMultiThreaded(benchmark::State& state) {
+    const auto num_chunks = static_cast<size_t>(state.range(0));
+    const auto data_size = static_cast<size_t>(state.range(1));
+
+    // Setup
+    auto device_mr = std::make_unique<rmm::mr::cuda_memory_resource>();
+    auto br = std::make_unique<BufferResource>(
+        *device_mr,
+        std::unordered_map<MemoryType, BufferResource::MemoryAvailable>{},
+        std::nullopt
+    );
+    auto stream = cudf::get_default_stream();
+
+    // Create PostBox with identity key mapping
+    PostBoxType postbox(KeyMapFn<typename PostBoxType::key_type>(), num_chunks);
+
+    // Synchronization primitives
+    std::atomic<size_t> chunks_inserted{0};
+    std::atomic<size_t> chunks_extracted{0};
+
+    auto insertion_finished = [&] { return chunks_inserted.load() == num_chunks; };
+    auto extract_finished = [&] { return chunks_extracted.load() == num_chunks; };
+
+    int64_t search_and_insert_count = 0;
+
+    for (auto _ : state) {
+        // Reset counters
+        chunks_inserted = 0;
+        chunks_extracted = 0;
+
+        // Thread 1: Insert chunks with device data buffers
+        std::thread insert_thread([&]() {
+            for (size_t i = 0; i < num_chunks; ++i) {
+                auto chunk = create_chunk_with_device_data(
+                    i, static_cast<PartID>(i % nparts), data_size, stream, br.get()
+                );
+                postbox.insert(std::move(chunk));
+                chunks_inserted.fetch_add(1);
+            }
+        });
+
+        // Thread 2: Search for device data buffers, extract half, modify and reinsert
+        std::thread search_thread([&]() {
+            while (!insertion_finished() || !extract_finished()) {
+                // Search for device data buffers
+                auto device_chunks = postbox.search(MemoryType::DEVICE);
+
+                // Extract half of them
+                size_t extract_count = device_chunks.size() / 2;
+                for (size_t i = 0; i < extract_count && i < device_chunks.size(); ++i) {
+                    const auto& [key, cid, size] = device_chunks[i];
+
+                    try {
+                        auto chunk = postbox.extract(static_cast<PartID>(key), cid);
+
+                        // Release device data buffer and set empty host data buffer
+                        auto released = chunk.release_data_buffer();
+                        benchmark::DoNotOptimize(released);
+                        auto [reservation, overbooking] =
+                            br->reserve(MemoryType::HOST, data_size, false);
+                        auto host_buffer = br->allocate(
+                            MemoryType::HOST, data_size, stream, reservation
+                        );
+                        std::memset(host_buffer->data(), 0, data_size);
+                        chunk.set_data_buffer(std::move(host_buffer));
+
+                        // Reinsert the chunk
+                        postbox.insert(std::move(chunk));
+
+                        search_and_insert_count++;
+                    } catch (const std::out_of_range&) {
+                        // Chunk was already extracted by another thread
+                        continue;
+                    }
+                }
+            }
+        });
+
+        // Thread 3: Extract all ready chunks
+        std::thread extract_thread([&]() {
+            while (!extract_finished()) {
+                auto ready_chunks = postbox.extract_all_ready();
+                chunks_extracted.fetch_add(ready_chunks.size());
+                benchmark::DoNotOptimize(ready_chunks);
+            }
+        });
+
+        // Wait for all threads to finish
+        insert_thread.join();
+        search_thread.join();
+        extract_thread.join();
+
+        // Verify all chunks were processed
+        if (chunks_inserted.load() != num_chunks || chunks_extracted.load() != num_chunks)
+        {
+            state.SkipWithError("Not all chunks were processed");
+        }
+    }
+    // state.counters["avg_search_and_insert_count"] = search_and_insert_count /
+    // state.iterations();
+
+    state.SetBytesProcessed(
+        int64_t(state.iterations()) * int64_t(num_chunks) * int64_t(data_size)
+    );
+    state.SetItemsProcessed(int64_t(state.iterations()) * int64_t(num_chunks));
+}
+
+// Register benchmarks for PostBox
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox<PartID>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox<Rank>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+
+// Register benchmarks for PostBox2
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<PartID>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<Rank>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+
+}  // namespace rapidsmpf::shuffler::detail
+
+BENCHMARK_MAIN();

--- a/cpp/benchmarks/postbox/bench_postbox.cpp
+++ b/cpp/benchmarks/postbox/bench_postbox.cpp
@@ -185,7 +185,7 @@ static void BM_PostBoxMultiThreaded(benchmark::State& state) {
     state.SetItemsProcessed(int64_t(state.iterations()) * int64_t(num_chunks));
 }
 
-// Warm up run 
+// Warm up run
 BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox<PartID>)
     ->Args({10000, 1024})  // 10k chunks, 1KB each
     ->UseRealTime()
@@ -206,16 +206,43 @@ BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox<Rank>)
     ->UseRealTime()
     ->Unit(benchmark::kMicrosecond);
 
-
 // Register benchmarks for PostBox2
-BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<PartID>)
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<PartID, 2>)
     ->Args({10000, 1024})  // 10k chunks, 1KB each
     ->Args({100000, 1024})  // 100k chunks, 1KB each
     ->Args({1000000, 1024})  // 1M chunks, 1KB each
     ->UseRealTime()
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<Rank>)
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<Rank, 2>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<PartID, 4>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<Rank, 4>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<PartID, 8>)
+    ->Args({10000, 1024})  // 10k chunks, 1KB each
+    ->Args({100000, 1024})  // 100k chunks, 1KB each
+    ->Args({1000000, 1024})  // 1M chunks, 1KB each
+    ->UseRealTime()
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_PostBoxMultiThreaded, PostBox2<Rank, 8>)
     ->Args({10000, 1024})  // 10k chunks, 1KB each
     ->Args({100000, 1024})  // 100k chunks, 1KB each
     ->Args({1000000, 1024})  // 1M chunks, 1KB each

--- a/cpp/benchmarks/postbox/postbox2.hpp
+++ b/cpp/benchmarks/postbox/postbox2.hpp
@@ -126,9 +126,8 @@ class PostBox2 {
         std::vector<Chunk> ret;
 
         for (auto& bucket : pigeonhole_buckets_) {
-            // std::lock_guard const lock(bucket.mtx);
-            std::unique_lock lock(bucket.mtx, std::defer_lock);
-            if (!lock.try_lock()) {
+            std::unique_lock lock(bucket.mtx, std::try_to_lock);
+            if (!lock.owns_lock()) {
                 continue;
             }
 
@@ -231,7 +230,7 @@ class PostBox2 {
     }
 
   private:
-    static constexpr size_t kNumBuckets = 16;  ///< Number of buckets.
+    static constexpr size_t kNumBuckets = 8;  ///< Number of buckets.
 
     /// Get the index of the bucket for a given key.
     constexpr inline size_t bucket_index(KeyType key) {

--- a/cpp/benchmarks/postbox/postbox2.hpp
+++ b/cpp/benchmarks/postbox/postbox2.hpp
@@ -1,0 +1,269 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <array>
+#include <functional>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <rapidsmpf/buffer/buffer.hpp>
+#include <rapidsmpf/communicator/communicator.hpp>
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/shuffler/chunk.hpp>
+#include <rapidsmpf/utils.hpp>
+
+namespace rapidsmpf::shuffler::detail {
+
+/**
+ * @brief A thread-safe container for managing and retrieving data chunks by partition and
+ * chunk ID.
+ *
+ * @tparam KeyType The type of the key used to map chunks.
+ */
+template <typename KeyType>
+class PostBox2 {
+  public:
+    using key_type = KeyType;  ///< The type of the key used to map chunks.
+
+    /**
+     * @brief Construct a new PostBox2.
+     *
+     * @tparam Fn The type of the function that maps a partition ID to a key.
+     * @param key_map_fn A function that maps a partition ID to a key.
+     * @param num_keys_hint The number of keys to reserve space for.
+     *
+     * @note The `key_map_fn` must be convertible to a function that takes a `PartID` and
+     * returns a `KeyType`.
+     */
+    template <typename Fn>
+    PostBox2(Fn&& key_map_fn, size_t num_keys_hint = 0)
+        : key_map_fn_(std::move(key_map_fn)) {
+        if (num_keys_hint > 0) {
+            for (auto& bucket : pigeonhole_buckets_) {
+                bucket.pigeonholes.reserve(num_keys_hint / kNumBuckets);
+            }
+        }
+    }
+
+    /**
+     * @brief Inserts a chunk into the PostBox2.
+     *
+     * @param chunk The chunk to insert.
+     */
+    void insert(Chunk&& chunk) {
+        // check if all partition IDs in the chunk map to the same key
+        KeyType key = key_map_fn_(chunk.part_id(0));
+        for (size_t i = 1; i < chunk.n_messages(); ++i) {
+            RAPIDSMPF_EXPECTS(
+                key == key_map_fn_(chunk.part_id(i)),
+                "PostBox2.insert(): all messages in the chunk must map to the same key"
+            );
+        }
+        auto& bucket = pigeonhole_buckets_[bucket_index(key)];
+        std::lock_guard const lock(bucket.mtx);
+        auto [_, inserted] =
+            bucket.pigeonholes[key].emplace(chunk.chunk_id(), std::move(chunk));
+        RAPIDSMPF_EXPECTS(inserted, "PostBox.insert(): chunk already exist");
+    }
+
+    /**
+     * @brief Extracts a specific chunk from the PostBox2.
+     *
+     * @param pid The ID of the partition containing the chunk.
+     * @param cid The ID of the chunk to be accessed.
+     * @return The extracted chunk.
+     *
+     * @throws std::out_of_range If the chunk is not found.
+     */
+    [[nodiscard]] Chunk extract(PartID pid, ChunkID cid) {
+        KeyType key = key_map_fn_(pid);
+        auto& bucket = pigeonhole_buckets_[bucket_index(key)];
+        std::lock_guard const lock(bucket.mtx);
+        return extract_item(bucket.pigeonholes[key], cid).second;
+    }
+
+    /**
+     * @brief Extracts all chunks associated with a specific partition.
+     *
+     * @param pid The ID of the partition.
+     * @return A map of chunk IDs to chunks for the specified partition.
+     *
+     * @throws std::out_of_range If the partition is not found.
+     */
+    std::unordered_map<ChunkID, Chunk> extract(PartID pid) {
+        KeyType key = key_map_fn_(pid);
+        auto& bucket = pigeonhole_buckets_[bucket_index(key)];
+        std::lock_guard const lock(bucket.mtx);
+        return extract_value(bucket.pigeonholes, key);
+    }
+
+    /**
+     * @brief Extracts all chunks associated with a specific key.
+     *
+     * @param key The key.
+     * @return A map of chunk IDs to chunks for the specified key.
+     *
+     * @throws std::out_of_range If the key is not found.
+     */
+    std::unordered_map<ChunkID, Chunk> extract_by_key(KeyType key) {
+        auto& bucket = pigeonhole_buckets_[bucket_index(key)];
+        std::lock_guard const lock(bucket.mtx);
+        return extract_value(bucket.pigeonholes, key);
+    }
+
+    /**
+     * @brief Extracts all ready chunks from the PostBox2.
+     *
+     * @return A vector of all ready chunks in the PostBox2.
+     */
+    std::vector<Chunk> extract_all_ready() {
+        std::vector<Chunk> ret;
+
+        for (auto& bucket : pigeonhole_buckets_) {
+            // std::lock_guard const lock(bucket.mtx);
+            std::unique_lock lock(bucket.mtx, std::defer_lock);
+            if (!lock.try_lock()) {
+                continue;
+            }
+
+            // Iterate through the outer map
+            auto pid_it = bucket.pigeonholes.begin();
+            while (pid_it != bucket.pigeonholes.end()) {
+                // Iterate through the inner map
+                auto& chunks = pid_it->second;
+                auto chunk_it = chunks.begin();
+                while (chunk_it != chunks.end()) {
+                    if (chunk_it->second.is_ready()) {
+                        ret.push_back(std::move(chunk_it->second));
+                        chunk_it = chunks.erase(chunk_it);
+                    } else {
+                        ++chunk_it;
+                    }
+                }
+
+                // Remove the pid entry if its chunks map is empty
+                if (chunks.empty()) {
+                    pid_it = bucket.pigeonholes.erase(pid_it);
+                } else {
+                    ++pid_it;
+                }
+            }
+        }
+
+        return ret;
+    }
+
+    /**
+     * @brief Checks if the PostBox2 is empty.
+     *
+     * @return `true` if the PostBox2 is empty, `false` otherwise.
+     */
+    [[nodiscard]] bool empty() const {
+        for (auto& bucket : pigeonhole_buckets_) {
+            std::lock_guard const lock(bucket.mtx);
+            if (!bucket.pigeonholes.empty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @brief Searches for chunks of the specified memory type.
+     *
+     * @param mem_type The type of memory to search within.
+     * @return A vector of tuples, where each tuple contains: PartID, ChunkID, and the
+     * size of the chunk.
+     */
+    [[nodiscard]] std::vector<std::tuple<key_type, ChunkID, std::size_t>> search(
+        MemoryType mem_type
+    ) const {
+        std::vector<std::tuple<KeyType, ChunkID, std::size_t>> ret;
+
+        for (auto& bucket : pigeonhole_buckets_) {
+            std::lock_guard const lock(bucket.mtx);
+            for (auto& [key, chunks] : bucket.pigeonholes) {
+                for (auto& [cid, chunk] : chunks) {
+                    if (!chunk.is_control_message(0)
+                        && chunk.data_memory_type() == mem_type)
+                    {
+                        ret.emplace_back(key, cid, chunk.concat_data_size());
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * @brief Returns a description of this instance.
+     * @return The description.
+     */
+    [[nodiscard]] std::string str() const {
+        if (empty()) {
+            return "PostBox()";
+        }
+        std::stringstream ss;
+        ss << "PostBox(";
+        for (auto& bucket : pigeonhole_buckets_) {
+            std::lock_guard const lock(bucket.mtx);
+            for (auto const& [key, chunks] : bucket.pigeonholes) {
+                ss << "k=" << key << ": [";
+                for (auto const& [cid, chunk] : chunks) {
+                    assert(cid == chunk.chunk_id());
+                    if (chunk.is_control_message(0)) {
+                        ss << "EOP" << chunk.expected_num_chunks(0) << ", ";
+                    } else {
+                        ss << cid << ", ";
+                    }
+                }
+                ss << "\b\b], ";
+            }
+        }
+        ss << "\b\b)";
+        return ss.str();
+    }
+
+  private:
+    static constexpr size_t kNumBuckets = 16;  ///< Number of buckets.
+
+    /// Get the index of the bucket for a given key.
+    constexpr inline size_t bucket_index(KeyType key) {
+        return static_cast<size_t>(key) % kNumBuckets;
+    }
+
+    /// A bucket of pigeonholes, that is protected by a mutex.
+    struct PigeonholesBucket {
+        std::unordered_map<KeyType, std::unordered_map<ChunkID, Chunk>> pigeonholes;
+        std::mutex mtx;
+    };
+
+    mutable std::array<PigeonholesBucket, kNumBuckets> pigeonhole_buckets_{
+    };  ///< Array of buckets, each protected by a mutex.
+
+    std::function<key_type(PartID)>
+        key_map_fn_;  ///< Function to map partition IDs to keys.
+};
+
+/**
+ * @brief Overloads the stream insertion operator for the PostBox2 class.
+ *
+ * This function allows a description of a PostBox2 to be written to an output stream.
+ *
+ * @param os The output stream to write to.
+ * @param obj The object to write.
+ * @return A reference to the modified output stream.
+ */
+template <typename KeyType>
+inline std::ostream& operator<<(std::ostream& os, PostBox2<KeyType> const& obj) {
+    os << obj.str();
+    return os;
+}
+
+}  // namespace rapidsmpf::shuffler::detail

--- a/cpp/benchmarks/postbox/postbox2.hpp
+++ b/cpp/benchmarks/postbox/postbox2.hpp
@@ -26,7 +26,7 @@ namespace rapidsmpf::shuffler::detail {
  *
  * @tparam KeyType The type of the key used to map chunks.
  */
-template <typename KeyType>
+template <typename KeyType, size_t kNumBuckets = 8>
 class PostBox2 {
   public:
     using key_type = KeyType;  ///< The type of the key used to map chunks.
@@ -230,8 +230,6 @@ class PostBox2 {
     }
 
   private:
-    static constexpr size_t kNumBuckets = 8;  ///< Number of buckets.
-
     /// Get the index of the bucket for a given key.
     constexpr inline size_t bucket_index(KeyType key) {
         return static_cast<size_t>(key) % kNumBuckets;


### PR DESCRIPTION
This PR evaluates a new PostBox impl with multiple mutexes. The reason for this is, I am trying to concat chunks inside the postbox from a separate thread. Even now, there are several threads accessing the postbox (caller thread, postbox spilling, shuffle progress thread, etc).

The new impl splits the pigenholes map into `N` buckets, and a key is designated a bucket based on `key%N`. Each bucket has its own mutex. 

Benchmark results: 

| MB/s    |         | nBuckets (Throughput MB/s)    |       |       |       |
|---------|---------|-------------|-------|-------|-------|
| KeyType | chunks  | 0 (current) |     2 |     4 |     8 |
| PartID  |   10000 |       46.27 | 49.03 | 50.86 | 48.61 |
| PartID  |  100000 |       47.44 | 45.04 | 49.59 | 50.23 |
| PartID  | 1000000 |       46.15 | 47.71 | 48.02 | 48.88 |
| Rank    |   10000 |       48.08 | 51.77 | 47.76 | 53.10 |
| Rank    |  100000 |       47.16 | 49.63 | 49.35 | 49.70 |
| Rank    | 1000000 |       46.19 | 49.24 | 47.95 | 48.62 |

![PostBox_PartID_](https://github.com/user-attachments/assets/e6da47db-7c99-42a8-8926-1338a5e0d85f)

![PostBox_Rank_](https://github.com/user-attachments/assets/c7fe4515-621a-4050-b7ce-486ac10ba8d8)
