### PR TITLE
Use transition states in PausableThreadLoop

### DIFF
--- a/cpp/include/rapidsmpf/progress_thread.hpp
+++ b/cpp/include/rapidsmpf/progress_thread.hpp
@@ -174,6 +174,8 @@ class ProgressThread {
 
     /**
      * @brief Pause the progress thread.
+     *
+     * @note This blocks until the thread is actually paused.
      */
     void pause();
 

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -682,6 +682,10 @@ TEST_P(ShuffleInsertGroupedTest, InsertPackedData) {
     shuffler->insert_finished(std::vector<rapidsmpf::shuffler::PartID>(pids));
 
     ASSERT_NO_FATAL_FAILURE(verify_shuffler_state(*shuffler));
+
+    // resume progress thread - this will guarantee that shuffler progress function is
+    // marked as done. This is important to ensure that the test does not hang.
+    progress_thread->resume();
 }
 
 TEST_P(ShuffleInsertGroupedTest, InsertPackedDataNoHeadroom) {


### PR DESCRIPTION
Since pausing and stopping a thread does not interrupt the execution of the current iteration of its event loop, to correctly track state, we introduce intermediate stopping and pausing states.

This is somewhat delicate because we were previously making (I think incorrect) assumptions about the state of the thread loop after calling pause. Fix those with some judicious wakes.

- Closes #362