### PR TITLE
Remove eager threshold warning

### DIFF
--- a/cpp/src/communicator/mpi.cpp
+++ b/cpp/src/communicator/mpi.cpp
@@ -149,7 +149,6 @@ std::unique_ptr<Communicator::Future> MPI::recv(
 }
 
 std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank> MPI::recv_any(Tag tag) {
-    Logger& log = logger();
     int msg_available;
     MPI_Status probe_status;
     RAPIDSMPF_MPI(MPI_Iprobe(MPI_ANY_SOURCE, tag, comm_, &msg_available, &probe_status));

--- a/cpp/src/communicator/mpi.cpp
+++ b/cpp/src/communicator/mpi.cpp
@@ -181,14 +181,6 @@ std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank> MPI::recv_any(Tag tag) {
         static_cast<std::size_t>(size) == msg->size(),
         "incorrect size of the MPI_Recv message"
     );
-    if (msg->size() > 2048) {  // TODO: use the actual eager threshold.
-        log.warn(
-            "block-receiving a messager larger than the normal ",
-            "eager threshold (",
-            msg->size(),
-            " bytes)"
-        );
-    }
     return {std::move(msg), probe_status.MPI_SOURCE};
 }
 

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -1119,7 +1119,6 @@ std::unique_ptr<Communicator::Future> UCXX::recv(
 }
 
 std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank> UCXX::recv_any(Tag tag) {
-    Logger& log = logger();
     auto probe = shared_resources_->get_worker()->tagProbe(
         ::ucxx::Tag(static_cast<int>(tag)), UserTagMask
     );

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -1137,12 +1137,6 @@ std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank> UCXX::recv_any(Tag tag) {
     );
 
     while (!req->isCompleted()) {
-        log.warn(
-            "block-receiving a messager larger than the normal ",
-            "eager threshold (",
-            msg->size(),
-            " bytes)"
-        );
         progress_worker();
     }
 


### PR DESCRIPTION
The eager threshold warning has recently started to fill logs with thousands of messages, see #366 . That warning is not accurate since we don't really check that at runtime, primarily because MPI doesn't provide a way to retrieve that information programatically. However, the warning was likely introduced as a form to identify an unintentional data message being received where just metadata is expected and is thus not really a problem, although depending on the metadata size the actual threshold may indeed cause increased latency.

The reason why the warning started to show up now is because the metadata size was indeed increased in #291 , the change is intentional and correct, thus we can safely remove the warning.

Closes #366 .