### PR TITLE
Adding a limit to `PostBox::extract_all*` method

### DIFF
--- a/cpp/include/rapidsmpf/shuffler/postbox.hpp
+++ b/cpp/include/rapidsmpf/shuffler/postbox.hpp
@@ -85,9 +85,10 @@ class PostBox {
     /**
      * @brief Extracts all ready chunks from the PostBox.
      *
+     * @param limit The maximum number of chunks to extract.
      * @return A vector of all ready chunks in the PostBox.
      */
-    std::vector<Chunk> extract_all_ready();
+    std::vector<Chunk> extract_all_ready(size_t limit = 256);
 
     /**
      * @brief Checks if the PostBox is empty.


### PR DESCRIPTION
While analyzing the nsys profiles, I observed that UCX progress thread has many outstanding tag recv operations. This happens because when we extract outgoing data from the postbox, it returns all chunks that are ready to be sent. All of the metadata of these chunks would first get scheduled to be sent. Then its likely that the `comm_->recv_any(metadata_tag)` loop iterates many times.  This blocks/ clogs the comms pipeline with metadata send and recv messages upfront in the progress iteration. 

A simple workaround for this would be to limit the number of ready chunks returned by the `PostBox::extract_all_ready` method. With a limit of 256 chunks, I could see an improvement of ~20% for the 4-worker benchmark run. 

I think this needs a better approach to properly pipeline the steps in the progress iteration. Any thoughts on this would be much appreciated. 

Details [here](https://docs.google.com/document/d/1zwDTQeESLbzCjqCkb5iXnKGh0WEt5zMpUxDIaRN0jLI/edit?tab=t.0) 

