### PR TITLE
Remove need for wildcard receive in readyfordata ack

### DIFF
--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -190,7 +190,7 @@ Duration run(
     }
 
     while (!futures.empty()) {
-        comm->test_some(futures);
+        std::ignore = comm->test_some(futures);
     }
 
     return Clock::now() - t0_elapsed;

--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -190,13 +190,7 @@ Duration run(
     }
 
     while (!futures.empty()) {
-        std::vector<std::size_t> finished = comm->test_some(futures);
-        // Sort the indexes into descending order.
-        std::sort(finished.begin(), finished.end(), std::greater<>());
-        // And erase from the right.
-        for (auto i : finished) {
-            futures.erase(futures.begin() + static_cast<std::ptrdiff_t>(i));
-        }
+        comm->test_some(futures);
     }
 
     return Clock::now() - t0_elapsed;

--- a/cpp/include/rapidsmpf/communicator/communicator.hpp
+++ b/cpp/include/rapidsmpf/communicator/communicator.hpp
@@ -443,7 +443,7 @@ class Communicator {
      * futures are erased from the vector.
      * @return Completed futures.
      */
-    std::vector<std::unique_ptr<Future>> virtual test_some(
+    [[nodiscard]] virtual std::vector<std::unique_ptr<Future>> test_some(
         std::vector<std::unique_ptr<Future>>& future_vector
     ) = 0;
 

--- a/cpp/include/rapidsmpf/communicator/communicator.hpp
+++ b/cpp/include/rapidsmpf/communicator/communicator.hpp
@@ -439,11 +439,12 @@ class Communicator {
     /**
      * @brief Tests for completion of multiple futures.
      *
-     * @param future_vector Vector of Future objects.
-     * @return Indices of completed futures.
+     * @param[inout] future_vector Vector of Future objects. Completed
+     * futures are erased from the vector.
+     * @return Completed futures.
      */
-    std::vector<std::size_t> virtual test_some(
-        std::vector<std::unique_ptr<Future>> const& future_vector
+    std::vector<std::unique_ptr<Future>> virtual test_some(
+        std::vector<std::unique_ptr<Future>>& future_vector
     ) = 0;
 
     /**

--- a/cpp/include/rapidsmpf/communicator/mpi.hpp
+++ b/cpp/include/rapidsmpf/communicator/mpi.hpp
@@ -153,8 +153,8 @@ class MPI final : public Communicator {
     /**
      * @copydoc Communicator::test_some
      */
-    std::vector<std::size_t> test_some(
-        std::vector<std::unique_ptr<Communicator::Future>> const& future_vector
+    std::vector<std::unique_ptr<Communicator::Future>> test_some(
+        std::vector<std::unique_ptr<Communicator::Future>>& future_vector
     ) override;
 
     // clang-format off

--- a/cpp/include/rapidsmpf/communicator/single.hpp
+++ b/cpp/include/rapidsmpf/communicator/single.hpp
@@ -105,8 +105,8 @@ class Single final : public Communicator {
      * @throws std::runtime_error if called (single-process communicators should never
      * send messages).
      */
-    std::vector<std::size_t> test_some(
-        std::vector<std::unique_ptr<Communicator::Future>> const& future_vector
+    std::vector<std::unique_ptr<Communicator::Future>> test_some(
+        std::vector<std::unique_ptr<Communicator::Future>>& future_vector
     ) override;
 
     // clang-format off

--- a/cpp/include/rapidsmpf/communicator/ucxx.hpp
+++ b/cpp/include/rapidsmpf/communicator/ucxx.hpp
@@ -177,8 +177,8 @@ class UCXX final : public Communicator {
     /**
      * @copydoc Communicator::test_some
      */
-    std::vector<std::size_t> test_some(
-        std::vector<std::unique_ptr<Communicator::Future>> const& future_vector
+    std::vector<std::unique_ptr<Communicator::Future>> test_some(
+        std::vector<std::unique_ptr<Communicator::Future>>& future_vector
     ) override;
 
     // clang-format off

--- a/cpp/include/rapidsmpf/shuffler/chunk.hpp
+++ b/cpp/include/rapidsmpf/shuffler/chunk.hpp
@@ -385,6 +385,13 @@ class ReadyForDataMessage {
     ChunkID cid;  ///< Chunk ID associated with the message.
 
     /**
+     * @brief The size of the message in bytes when serialized.
+     *
+     * @return The size of the message in bytes.
+     */
+    static constexpr size_t byte_size = sizeof(ChunkID);
+
+    /**
      * @brief Serializes the message into a byte array.
      *
      * @return A serialized byte vector representing the message.

--- a/cpp/src/communicator/mpi.cpp
+++ b/cpp/src/communicator/mpi.cpp
@@ -214,11 +214,7 @@ std::vector<std::unique_ptr<Communicator::Future>> MPI::test_some(
         indices.begin(),
         indices.begin() + num_completed,
         std::back_inserter(completed),
-        [&](std::size_t i) {
-            std::unique_ptr<Communicator::Future> fut{nullptr};
-            std::swap(fut, future_vector[i]);
-            return fut;
-        }
+        [&](std::size_t i) { return std::move(future_vector[i]); }
     );
     std::erase(future_vector, nullptr);
     return completed;

--- a/cpp/src/communicator/single.cpp
+++ b/cpp/src/communicator/single.cpp
@@ -30,8 +30,8 @@ std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank> Single::recv_any(Tag) {
     return {nullptr, 0};
 }
 
-std::vector<std::size_t>
-Single::test_some(std::vector<std::unique_ptr<Communicator::Future>> const&) {
+std::vector<std::unique_ptr<Communicator::Future>>
+Single::test_some(std::vector<std::unique_ptr<Communicator::Future>>&) {
     RAPIDSMPF_FAIL("Unexpected test_some from self", std::runtime_error);
 }
 

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -1162,9 +1162,7 @@ std::vector<std::unique_ptr<Communicator::Future>> UCXX::test_some(
     std::vector<std::unique_ptr<Communicator::Future>> completed;
     completed.reserve(indices.size());
     std::ranges::transform(indices, std::back_inserter(completed), [&](std::size_t i) {
-        std::unique_ptr<Communicator::Future> fut{nullptr};
-        std::swap(fut, future_vector[i]);
-        return fut;
+        return std::move(future_vector[i]);
     });
     std::erase(future_vector, nullptr);
     return completed;

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -379,7 +379,7 @@ class Shuffler::Progress {
 
             // Check if we can free some of the outstanding futures.
             if (!fire_and_forget_.empty()) {
-                shuffler_.comm_->test_some(fire_and_forget_);
+                std::ignore = shuffler_.comm_->test_some(fire_and_forget_);
             }
             stats.add_duration_stat(
                 "event-loop-check-future-finish", Clock::now() - t0_check_future_finish

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -201,7 +201,7 @@ class Shuffler::Progress {
                         dst,
                         ready_for_data_tag,
                         shuffler_.br_->move(std::make_unique<std::vector<std::uint8_t>>(
-                            sizeof(ReadyForDataMessage)
+                            ReadyForDataMessage::byte_size
                         ))
                     ));
                 }

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -11,6 +11,7 @@
 #include <rapidsmpf/buffer/packed_data.hpp>
 #include <rapidsmpf/buffer/resource.hpp>
 #include <rapidsmpf/communicator/communicator.hpp>
+#include <rapidsmpf/nvtx.hpp>
 #include <rapidsmpf/shuffler/shuffler.hpp>
 #include <rapidsmpf/utils.hpp>
 
@@ -159,6 +160,7 @@ class Shuffler::Progress {
      * @return The progress state of the shuffler.
      */
     ProgressThread::ProgressState operator()() {
+        RAPIDSMPF_NVTX_SCOPED_RANGE("Shuffler.Progress", p_iters++);
         auto const t0_event_loop = Clock::now();
 
         // Tags for each stage of the shuffle
@@ -170,195 +172,227 @@ class Shuffler::Progress {
         auto& stats = *shuffler_.statistics_;
 
         // Check for new chunks in the inbox and send off their metadata.
-        auto const t0_send_metadata = Clock::now();
-        for (auto&& chunk : shuffler_.outgoing_postbox_.extract_all_ready()) {
-            // All messages in the chunk maps to the same key (checked by the PostBox)
-            // thus we can use the partition ID of the first message in the chunk to
-            // determine the source rank of all of them.
-            auto dst = shuffler_.partition_owner(shuffler_.comm_, chunk.part_id(0));
-            log.trace("send metadata to ", dst, ": ", chunk);
-            RAPIDSMPF_EXPECTS(
-                dst != shuffler_.comm_->rank(), "sending chunk to ourselves"
-            );
-
-            fire_and_forget_.push_back(
-                shuffler_.comm_->send(chunk.serialize(), dst, metadata_tag, shuffler_.br_)
-            );
-            if (chunk.concat_data_size() > 0) {
+        {
+            auto const t0_send_metadata = Clock::now();
+            auto ready_chunks = shuffler_.outgoing_postbox_.extract_all_ready();
+            RAPIDSMPF_NVTX_SCOPED_RANGE("meta_send", ready_chunks.size());
+            for (auto&& chunk : ready_chunks) {
+                // All messages in the chunk maps to the same key (checked by the PostBox)
+                // thus we can use the partition ID of the first message in the chunk to
+                // determine the source rank of all of them.
+                auto dst = shuffler_.partition_owner(shuffler_.comm_, chunk.part_id(0));
+                log.trace("send metadata to ", dst, ": ", chunk);
                 RAPIDSMPF_EXPECTS(
-                    outgoing_chunks_.insert({chunk.chunk_id(), std::move(chunk)}).second,
-                    "outgoing chunk already exist"
+                    dst != shuffler_.comm_->rank(), "sending chunk to ourselves"
                 );
+
+                fire_and_forget_.push_back(shuffler_.comm_->send(
+                    chunk.serialize(), dst, metadata_tag, shuffler_.br_
+                ));
+                if (chunk.concat_data_size() > 0) {
+                    RAPIDSMPF_EXPECTS(
+                        outgoing_chunks_.insert({chunk.chunk_id(), std::move(chunk)})
+                            .second,
+                        "outgoing chunk already exist"
+                    );
+                }
             }
+            stats.add_duration_stat(
+                "event-loop-metadata-send", Clock::now() - t0_send_metadata
+            );
         }
-        stats.add_duration_stat(
-            "event-loop-metadata-send", Clock::now() - t0_send_metadata
-        );
 
         // Receive any incoming metadata of remote chunks and place them in
         // `incoming_chunks_`.
-        auto const t0_metadata_recv = Clock::now();
-        while (true) {
-            auto const [msg, src] = shuffler_.comm_->recv_any(metadata_tag);
-            if (msg) {
-                auto chunk = Chunk::deserialize(*msg, false);
-                log.trace("recv_any from ", src, ": ", chunk);
-                // All messages in the chunk maps to the same Rank (checked by the
-                // PostBox) thus we can use the partition ID of the first message in the
-                // chunk to determine the source rank of all of them.
-                RAPIDSMPF_EXPECTS(
-                    shuffler_.partition_owner(shuffler_.comm_, chunk.part_id(0))
-                        == shuffler_.comm_->rank(),
-                    "receiving chunk not owned by us"
-                );
-                incoming_chunks_.insert({src, std::move(chunk)});
-            } else {
-                break;
+        {
+            auto const t0_metadata_recv = Clock::now();
+            RAPIDSMPF_NVTX_SCOPED_RANGE("meta_recv");
+            int i = 0;
+            while (true) {
+                auto const [msg, src] = shuffler_.comm_->recv_any(metadata_tag);
+                if (msg) {
+                    auto chunk = Chunk::deserialize(*msg, false);
+                    log.trace("recv_any from ", src, ": ", chunk);
+                    // All messages in the chunk maps to the same Rank (checked by the
+                    // PostBox) thus we can use the partition ID of the first message in
+                    // the chunk to determine the source rank of all of them.
+                    RAPIDSMPF_EXPECTS(
+                        shuffler_.partition_owner(shuffler_.comm_, chunk.part_id(0))
+                            == shuffler_.comm_->rank(),
+                        "receiving chunk not owned by us"
+                    );
+                    incoming_chunks_.insert({src, std::move(chunk)});
+                } else {
+                    break;
+                }
+                i++;
             }
+            stats.add_duration_stat(
+                "event-loop-metadata-recv", Clock::now() - t0_metadata_recv
+            );
+            RAPIDSMPF_NVTX_MARKER("meta_recv_iters", i);
         }
-        stats.add_duration_stat(
-            "event-loop-metadata-recv", Clock::now() - t0_metadata_recv
-        );
 
         // Post receives for incoming chunks
-        auto const t0_post_incoming_chunk_recv = Clock::now();
-        for (auto it = incoming_chunks_.begin(); it != incoming_chunks_.end();) {
-            auto& [src, chunk] = *it;
-            log.trace("checking incoming chunk data from ", src, ": ", chunk);
+        {
+            RAPIDSMPF_NVTX_SCOPED_RANGE("post_chunk_recv", incoming_chunks_.size());
+            auto const t0_post_incoming_chunk_recv = Clock::now();
+            for (auto it = incoming_chunks_.begin(); it != incoming_chunks_.end();) {
+                auto& [src, chunk] = *it;
+                log.trace("checking incoming chunk data from ", src, ": ", chunk);
 
-            // If the chunk contains gpu data, we need to receive it. Otherwise, it goes
-            // directly to the ready postbox.
-            if (chunk.concat_data_size() > 0) {
-                if (!chunk.is_data_buffer_set()) {
-                    // Create a new buffer and let the buffer resource decide the memory
-                    // type.
-                    chunk.set_data_buffer(allocate_buffer(
-                        chunk.concat_data_size(), shuffler_.stream_, shuffler_.br_
+                // If the chunk contains gpu data, we need to receive it. Otherwise, it
+                // goes directly to the ready postbox.
+                if (chunk.concat_data_size() > 0) {
+                    if (!chunk.is_data_buffer_set()) {
+                        // Create a new buffer and let the buffer resource decide the
+                        // memory type.
+                        chunk.set_data_buffer(allocate_buffer(
+                            chunk.concat_data_size(), shuffler_.stream_, shuffler_.br_
+                        ));
+                        if (chunk.data_memory_type() == MemoryType::HOST) {
+                            stats.add_bytes_stat(
+                                "spill-bytes-recv-to-host", chunk.concat_data_size()
+                            );
+                        }
+                    }
+
+                    // Check if the buffer is ready to be used
+                    if (!chunk.is_ready()) {
+                        // Buffer is not ready yet, skip to next item
+                        ++it;
+                        continue;
+                    }
+
+                    // At this point we know we can process this item, so extract it.
+                    // Note: extract_item invalidates the iterator, so must increment
+                    // here.
+                    auto [src, chunk] = extract_item(incoming_chunks_, it++);
+
+                    // Setup to receive the chunk into `in_transit_*`.
+                    // transfer the data buffer from the chunk to the future
+                    auto future = shuffler_.comm_->recv(
+                        src, gpu_data_tag, chunk.release_data_buffer()
+                    );
+                    RAPIDSMPF_EXPECTS(
+                        in_transit_futures_.insert({chunk.chunk_id(), std::move(future)})
+                            .second,
+                        "in transit future already exist"
+                    );
+                    RAPIDSMPF_EXPECTS(
+                        in_transit_chunks_.insert({chunk.chunk_id(), std::move(chunk)})
+                            .second,
+                        "in transit chunk already exist"
+                    );
+                    shuffler_.statistics_->add_bytes_stat(
+                        "shuffle-payload-recv", chunk.concat_data_size()
+                    );
+                    // Tell the source of the chunk that we are ready to receive it.
+                    // All partition IDs in the chunk must map to the same key (rank).
+                    fire_and_forget_.push_back(shuffler_.comm_->send(
+                        ReadyForDataMessage{chunk.chunk_id()}.pack(),
+                        src,
+                        ready_for_data_tag,
+                        shuffler_.br_
                     ));
-                    if (chunk.data_memory_type() == MemoryType::HOST) {
-                        stats.add_bytes_stat(
-                            "spill-bytes-recv-to-host", chunk.concat_data_size()
+                } else {  // chunk contains control messages and/or metadata-only messages
+                    // At this point we know we can process this item, so extract it.
+                    // Note: extract_item invalidates the iterator, so must increment
+                    // here.
+                    auto [src, chunk] = extract_item(incoming_chunks_, it++);
+
+                    // iterate over all messages in the chunk
+                    for (size_t i = 0; i < chunk.n_messages(); ++i) {
+                        auto chunk_copy = chunk.get_data(
+                            shuffler_.get_new_cid(), i, shuffler_.stream_, shuffler_.br_
                         );
+                        shuffler_.insert_into_ready_postbox(std::move(chunk_copy));
                     }
                 }
-
-                // Check if the buffer is ready to be used
-                if (!chunk.is_ready()) {
-                    // Buffer is not ready yet, skip to next item
-                    ++it;
-                    continue;
-                }
-
-                // At this point we know we can process this item, so extract it.
-                // Note: extract_item invalidates the iterator, so must increment here.
-                auto [src, chunk] = extract_item(incoming_chunks_, it++);
-
-                // Setup to receive the chunk into `in_transit_*`.
-                // transfer the data buffer from the chunk to the future
-                auto future =
-                    shuffler_.comm_->recv(src, gpu_data_tag, chunk.release_data_buffer());
-                RAPIDSMPF_EXPECTS(
-                    in_transit_futures_.insert({chunk.chunk_id(), std::move(future)})
-                        .second,
-                    "in transit future already exist"
-                );
-                RAPIDSMPF_EXPECTS(
-                    in_transit_chunks_.insert({chunk.chunk_id(), std::move(chunk)})
-                        .second,
-                    "in transit chunk already exist"
-                );
-                shuffler_.statistics_->add_bytes_stat(
-                    "shuffle-payload-recv", chunk.concat_data_size()
-                );
-                // Tell the source of the chunk that we are ready to receive it.
-                // All partition IDs in the chunk must map to the same key (rank).
-                fire_and_forget_.push_back(shuffler_.comm_->send(
-                    ReadyForDataMessage{chunk.chunk_id()}.pack(),
-                    src,
-                    ready_for_data_tag,
-                    shuffler_.br_
-                ));
-            } else {  // chunk contains control messages and/or metadata-only messages
-                // At this point we know we can process this item, so extract it.
-                // Note: extract_item invalidates the iterator, so must increment here.
-                auto [src, chunk] = extract_item(incoming_chunks_, it++);
-
-                // iterate over all messages in the chunk
-                for (size_t i = 0; i < chunk.n_messages(); ++i) {
-                    auto chunk_copy = chunk.get_data(
-                        shuffler_.get_new_cid(), i, shuffler_.stream_, shuffler_.br_
-                    );
-                    shuffler_.insert_into_ready_postbox(std::move(chunk_copy));
-                }
             }
-        }
 
-        stats.add_duration_stat(
-            "event-loop-post-incoming-chunk-recv",
-            Clock::now() - t0_post_incoming_chunk_recv
-        );
+            stats.add_duration_stat(
+                "event-loop-post-incoming-chunk-recv",
+                Clock::now() - t0_post_incoming_chunk_recv
+            );
+        }
 
         // Receive any incoming ready-for-data messages and start sending the
         // requested data.
-        auto const t0_init_gpu_data_send = Clock::now();
-        while (true) {
-            auto const [msg, src] = shuffler_.comm_->recv_any(ready_for_data_tag);
-            if (msg) {
-                auto ready_for_data_msg = ReadyForDataMessage::unpack(msg);
-                auto chunk = extract_value(outgoing_chunks_, ready_for_data_msg.cid);
-                log.trace(
-                    "recv_any from ", src, ": ", ready_for_data_msg, ", sending: ", chunk
-                );
-                shuffler_.statistics_->add_bytes_stat(
-                    "shuffle-payload-send", chunk.concat_data_size()
-                );
-                fire_and_forget_.push_back(
-                    shuffler_.comm_->send(chunk.release_data_buffer(), src, gpu_data_tag)
-                );
-            } else {
-                break;
+        {
+            auto const t0_init_gpu_data_send = Clock::now();
+            RAPIDSMPF_NVTX_SCOPED_RANGE("init_gpu_send");
+            int i = 0;
+            while (true) {
+                auto const [msg, src] = shuffler_.comm_->recv_any(ready_for_data_tag);
+                if (msg) {
+                    auto ready_for_data_msg = ReadyForDataMessage::unpack(msg);
+                    auto chunk = extract_value(outgoing_chunks_, ready_for_data_msg.cid);
+                    log.trace(
+                        "recv_any from ",
+                        src,
+                        ": ",
+                        ready_for_data_msg,
+                        ", sending: ",
+                        chunk
+                    );
+                    shuffler_.statistics_->add_bytes_stat(
+                        "shuffle-payload-send", chunk.concat_data_size()
+                    );
+                    fire_and_forget_.push_back(shuffler_.comm_->send(
+                        chunk.release_data_buffer(), src, gpu_data_tag
+                    ));
+                } else {
+                    break;
+                }
+                i++;
             }
+            stats.add_duration_stat(
+                "event-loop-init-gpu-data-send", Clock::now() - t0_init_gpu_data_send
+            );
+            RAPIDSMPF_NVTX_MARKER("init_gpu_send_iters", i);
         }
-        stats.add_duration_stat(
-            "event-loop-init-gpu-data-send", Clock::now() - t0_init_gpu_data_send
-        );
 
         // Check if any data in transit is finished.
-        auto const t0_check_future_finish = Clock::now();
-        if (!in_transit_futures_.empty()) {
-            std::vector<ChunkID> finished =
-                shuffler_.comm_->test_some(in_transit_futures_);
-            for (auto cid : finished) {
-                auto chunk = extract_value(in_transit_chunks_, cid);
-                auto future = extract_value(in_transit_futures_, cid);
-                chunk.set_data_buffer(shuffler_.comm_->get_gpu_data(std::move(future)));
-
-                for (size_t i = 0; i < chunk.n_messages(); ++i) {
-                    shuffler_.insert_into_ready_postbox(chunk.get_data(
-                        shuffler_.get_new_cid(), i, shuffler_.stream_, shuffler_.br_
-                    ));
-                }
-            }
-        }
-
-        // Check if we can free some of the outstanding futures.
-        if (!fire_and_forget_.empty()) {
-            std::vector<std::size_t> finished =
-                shuffler_.comm_->test_some(fire_and_forget_);
-            if (!finished.empty()) {
-                // Sort the indexes into `fire_and_forget` in descending order.
-                std::ranges::sort(finished, std::greater<>());
-                // And erase from the right.
-                for (auto i : finished) {
-                    fire_and_forget_.erase(
-                        fire_and_forget_.begin() + static_cast<std::ptrdiff_t>(i)
+        {
+            auto const t0_check_future_finish = Clock::now();
+            RAPIDSMPF_NVTX_SCOPED_RANGE("check_fut_finish", in_transit_futures_.size());
+            if (!in_transit_futures_.empty()) {
+                std::vector<ChunkID> finished =
+                    shuffler_.comm_->test_some(in_transit_futures_);
+                for (auto cid : finished) {
+                    auto chunk = extract_value(in_transit_chunks_, cid);
+                    auto future = extract_value(in_transit_futures_, cid);
+                    chunk.set_data_buffer(shuffler_.comm_->get_gpu_data(std::move(future))
                     );
+
+                    for (size_t i = 0; i < chunk.n_messages(); ++i) {
+                        shuffler_.insert_into_ready_postbox(chunk.get_data(
+                            shuffler_.get_new_cid(), i, shuffler_.stream_, shuffler_.br_
+                        ));
+                    }
                 }
             }
+
+            // Check if we can free some of the outstanding futures.
+            if (!fire_and_forget_.empty()) {
+                std::vector<std::size_t> finished =
+                    shuffler_.comm_->test_some(fire_and_forget_);
+                if (!finished.empty()) {
+                    // Sort the indexes into `fire_and_forget` in descending order.
+                    std::ranges::sort(finished, std::greater<>());
+                    // And erase from the right.
+                    for (auto i : finished) {
+                        fire_and_forget_.erase(
+                            fire_and_forget_.begin() + static_cast<std::ptrdiff_t>(i)
+                        );
+                    }
+                }
+            }
+            stats.add_duration_stat(
+                "event-loop-check-future-finish", Clock::now() - t0_check_future_finish
+            );
         }
-        stats.add_duration_stat(
-            "event-loop-check-future-finish", Clock::now() - t0_check_future_finish
-        );
 
         stats.add_duration_stat("event-loop-total", Clock::now() - t0_event_loop);
 
@@ -386,6 +420,8 @@ class Shuffler::Progress {
         in_transit_chunks_;  ///< Chunks currently in transit.
     std::unordered_map<detail::ChunkID, std::unique_ptr<Communicator::Future>>
         in_transit_futures_;  ///< Futures corresponding to in-transit chunks.
+
+    int64_t p_iters = 0;  ///< Number of progress iterations (for NVTX)
 };
 
 std::vector<PartID> Shuffler::local_partitions(


### PR DESCRIPTION
When we send a message to a destination rank that we have a chunk for them, we know we're going to receive an ack, so pre-post the receive and explicitly manage those messages. This removes a wildcard tag match loop, and ensures the ready for data messages have matching receives available which will probably enable eager protocol optimisations in the underlying comms library.