### PR TITLE
[MINOR] Add an option to use `concat_insert` in shuffle bench 

### DIFF
--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -310,8 +310,7 @@ void do_concat_insert(
     }
 
     // Tell the shuffler that we have no more data.
-    std::vector<rapidsmpf::shuffler::PartID> finished;
-    finished.reserve(total_num_partitions);
+    std::vector<rapidsmpf::shuffler::PartID> finished(total_num_partitions);
     std::iota(finished.begin(), finished.end(), 0);
     shuffler.insert_finished(std::move(finished));
 }

--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -381,7 +381,6 @@ rapidsmpf::Duration run_hash_partition_inline(
     std::vector<cudf::table> input_partitions =
         generate_input_partitions(args, stream, br->device_mr(), std::identity{});
 
-    stream.synchronize();
     RAPIDSMPF_MPI(MPI_Barrier(MPI_COMM_WORLD));
 
     auto make_chunk_fn = [&](cudf::table const& partition) {
@@ -456,7 +455,7 @@ rapidsmpf::Duration run_hash_partition_with_datagen(
                     br->device_mr()
                 );
             });
-    stream.synchronize();
+
     RAPIDSMPF_MPI(MPI_Barrier(MPI_COMM_WORLD));
 
     return do_run(

--- a/cpp/include/rapidsmpf/shuffler/postbox.hpp
+++ b/cpp/include/rapidsmpf/shuffler/postbox.hpp
@@ -85,10 +85,9 @@ class PostBox {
     /**
      * @brief Extracts all ready chunks from the PostBox.
      *
-     * @param limit The maximum number of chunks to extract.
      * @return A vector of all ready chunks in the PostBox.
      */
-    std::vector<Chunk> extract_all_ready(size_t limit = 256);
+    std::vector<Chunk> extract_all_ready();
 
     /**
      * @brief Checks if the PostBox is empty.

--- a/cpp/include/rapidsmpf/shuffler/postbox.hpp
+++ b/cpp/include/rapidsmpf/shuffler/postbox.hpp
@@ -85,9 +85,10 @@ class PostBox {
     /**
      * @brief Extracts all ready chunks from the PostBox.
      *
+     * @param limit The maximum number of chunks to extract.
      * @return A vector of all ready chunks in the PostBox.
      */
-    std::vector<Chunk> extract_all_ready();
+    std::vector<Chunk> extract_all_ready(size_t limit = 256);
 
     /**
      * @brief Checks if the PostBox is empty.

--- a/cpp/src/shuffler/postbox.cpp
+++ b/cpp/src/shuffler/postbox.cpp
@@ -46,10 +46,9 @@ std::unordered_map<ChunkID, Chunk> PostBox<KeyType>::extract_by_key(KeyType key)
 }
 
 template <typename KeyType>
-std::vector<Chunk> PostBox<KeyType>::extract_all_ready(size_t limit) {
+std::vector<Chunk> PostBox<KeyType>::extract_all_ready() {
     std::lock_guard const lock(mutex_);
     std::vector<Chunk> ret;
-    ret.reserve(limit);
 
     // Iterate through the outer map
     auto pid_it = pigeonhole_.begin();
@@ -61,9 +60,6 @@ std::vector<Chunk> PostBox<KeyType>::extract_all_ready(size_t limit) {
             if (chunk_it->second.is_ready()) {
                 ret.emplace_back(std::move(chunk_it->second));
                 chunk_it = chunks.erase(chunk_it);
-                if (ret.size() >= limit) {  // limit is reached
-                    return ret;
-                }
             } else {
                 ++chunk_it;
             }


### PR DESCRIPTION
This PR adds an option to use `concat_insert` in shuffle benchmark. 