### PR TITLE
Cleanup CUDA 11 entries and ensure custom Docker configs in wheels tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,6 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   conda-python-build:
     needs: [conda-cpp-build]
     secrets: inherit
@@ -52,7 +51,6 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   upload-conda:
     needs: [conda-cpp-build, conda-python-build]
     secrets: inherit
@@ -112,7 +110,6 @@ jobs:
       script: ci/build_wheel_rapidsmpf.sh
       package-name: rapidsmpf
       package-type: python
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   wheel-publish-rapidsmpf:
     needs: wheel-build-rapidsmpf
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,6 +57,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
     with:
       build_type: pull-request
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       script: ci/test_wheel.sh
   conda-cpp-build:
     needs: checks

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,6 @@ jobs:
       script: ci/build_wheel_rapidsmpf.sh
       package-name: rapidsmpf
       package-type: python
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   wheel-test:
     needs: wheel-build-rapidsmpf
     secrets: inherit
@@ -59,14 +58,12 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
   conda-cpp-build:
     needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.08
     with:
       build_type: pull-request
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       script: ci/build_cpp.sh
   conda-cpp-linters:
     secrets: inherit
@@ -82,7 +79,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-25.08
     with:
       build_type: pull-request
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       script: ci/test_cpp.sh
   conda-python-build:
@@ -91,7 +87,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.08
     with:
       build_type: pull-request
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       script: ci/build_python.sh
   conda-python-tests:
     needs: conda-python-build
@@ -99,7 +94,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.08
     with:
       build_type: pull-request
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       run_codecov: false
       script: ci/test_python.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,27 +29,28 @@ jobs:
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       date: ${{ inputs.date }}
       script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
   conda-python-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.08
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       date: ${{ inputs.date }}
+      run_codecov: false
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      run_codecov: false
   wheel-test:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,6 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
   conda-python-tests:
     secrets: inherit
@@ -43,7 +42,6 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       run_codecov: false
   wheel-test:
@@ -55,4 +53,3 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel.sh
-      matrix_filter: map(select(.CUDA_VER | startswith("11") | not))

--- a/conda/recipes/librapidsmpf/conda_build_config.yaml
+++ b/conda/recipes/librapidsmpf/conda_build_config.yaml
@@ -1,11 +1,11 @@
 c_compiler_version:
-  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 13
 
 cxx_compiler_version:
-  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 13
 
 cuda_compiler:
-  - cuda-nvcc  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - cuda-nvcc
 
 cmake_version:
   - ">=3.26.4,!=3.30.0"

--- a/conda/recipes/rapidsmpf/conda_build_config.yaml
+++ b/conda/recipes/rapidsmpf/conda_build_config.yaml
@@ -1,11 +1,11 @@
 c_compiler_version:
-  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 13
 
 cxx_compiler_version:
-  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 13
 
 cuda_compiler:
-  - cuda-nvcc  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - cuda-nvcc
 
 cmake_version:
   - ">=3.26.4,!=3.30.0"


### PR DESCRIPTION
Remove CUDA 11 GHA workflow filters and ensure wheels tests use the same custom Docker configurations required for UCX.