### PR TITLE
`FinishCounter` improvements

### DIFF
--- a/cpp/src/shuffler/finish_counter.cpp
+++ b/cpp/src/shuffler/finish_counter.cpp
@@ -15,7 +15,10 @@ FinishCounter::FinishCounter(Rank nranks, std::vector<PartID> const& local_parti
     // Initially, none of the partitions are ready to wait on.
     for (auto pid : local_partitions) {
         // partitions_ready_to_wait_on_.insert({pid, false});
-        goalposts_.emplace(pid, PartitionInfo{0, 0, 0});
+        goalposts_.emplace(
+            pid,
+            PartitionInfo{.rank_count = 0, .chunk_goal = 0, .finished_chunk_count = 0}
+        );
     }
 }
 

--- a/cpp/src/shuffler/finish_counter.cpp
+++ b/cpp/src/shuffler/finish_counter.cpp
@@ -14,35 +14,30 @@ FinishCounter::FinishCounter(Rank nranks, std::vector<PartID> const& local_parti
     : nranks_{nranks} {
     // Initially, none of the partitions are ready to wait on.
     for (auto pid : local_partitions) {
-        partitions_ready_to_wait_on_.insert({pid, false});
+        // partitions_ready_to_wait_on_.insert({pid, false});
+        goalposts_.emplace(pid, PartitionInfo{0, 0, 0});
     }
+}
+
+bool FinishCounter::all_finished() const {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return goalposts_.empty();
 }
 
 void FinishCounter::move_goalpost(PartID pid, ChunkID nchunks) {
     std::unique_lock<std::mutex> lock(mutex_);
-    auto& [rank_counter, chunk_goal] = goalposts_[pid];
-    RAPIDSMPF_EXPECTS(
-        rank_counter++ < nranks_, "the goalpost was moved more than one per rank"
-    );
-    chunk_goal += nchunks;
+    auto& p_info = goalposts_[pid];
+    p_info.move_goalpost(nchunks, nranks_);
 }
 
 void FinishCounter::add_finished_chunk(PartID pid) {
     std::unique_lock<std::mutex> lock(mutex_);
-    auto& finished_chunk = ++finished_chunk_counters_[pid];
-    auto& [rank_counter, chunk_goal] = goalposts_[pid];
+    auto& p_info = goalposts_[pid];
 
-    // The partition is finished if the goalpost has been set by all ranks
-    // and the number of finished chunks has reach the goal.
-    if (rank_counter == nranks_) {
-        if (finished_chunk == chunk_goal) {
-            partitions_ready_to_wait_on_.at(pid) = true;
-            cv_.notify_all();
-        } else {
-            RAPIDSMPF_EXPECTS(
-                finished_chunk < chunk_goal, "finished chunk exceeds the goal"
-            );
-        }
+    p_info.add_finished_chunk(nranks_);
+
+    if (p_info.is_finished(nranks_)) {
+        cv_.notify_all();
     }
 }
 
@@ -84,17 +79,14 @@ PartID FinishCounter::wait_any(std::optional<std::chrono::milliseconds> timeout)
 
     std::unique_lock<std::mutex> lock(mutex_);
     wait_for_if_timeout_else_wait(lock, cv_, timeout, [&] {
-        return partitions_ready_to_wait_on_.empty()
-               || std::ranges::any_of(
-                   partitions_ready_to_wait_on_,
-                   [&](auto const& item) {
-                       auto done = item.second;
-                       if (done) {
-                           finished_key = item.first;
-                       }
-                       return done;
-                   }
-               );
+        return goalposts_.empty()
+               || std::ranges::any_of(goalposts_, [&](auto const& item) {
+                      auto done = item.second.is_finished(nranks_);
+                      if (done) {
+                          finished_key = item.first;
+                      }
+                      return done;
+                  });
     });
 
     RAPIDSMPF_EXPECTS(
@@ -104,7 +96,8 @@ PartID FinishCounter::wait_any(std::optional<std::chrono::milliseconds> timeout)
     );
 
     // We extract the partition to avoid returning the same partition twice.
-    return extract_key(partitions_ready_to_wait_on_, finished_key);
+    goalposts_.erase(finished_key);
+    return finished_key;
 }
 
 void FinishCounter::wait_on(
@@ -112,15 +105,13 @@ void FinishCounter::wait_on(
 ) {
     std::unique_lock<std::mutex> lock(mutex_);
     wait_for_if_timeout_else_wait(lock, cv_, timeout, [&]() {
-        auto it = partitions_ready_to_wait_on_.find(pid);
+        auto it = goalposts_.find(pid);
         RAPIDSMPF_EXPECTS(
-            it != partitions_ready_to_wait_on_.end(),
-            "PartID has already been extracted",
-            std::out_of_range
+            it != goalposts_.end(), "PartID has already been extracted", std::out_of_range
         );
-        return it->second;
+        return it->second.is_finished(nranks_);
     });
-    partitions_ready_to_wait_on_.erase(pid);
+    goalposts_.erase(pid);
 }
 
 std::vector<PartID> FinishCounter::wait_some(
@@ -128,14 +119,12 @@ std::vector<PartID> FinishCounter::wait_some(
 ) {
     std::unique_lock<std::mutex> lock(mutex_);
     RAPIDSMPF_EXPECTS(
-        !partitions_ready_to_wait_on_.empty(),
-        "no more partitions to wait on",
-        std::out_of_range
+        !goalposts_.empty(), "no more partitions to wait on", std::out_of_range
     );
 
     wait_for_if_timeout_else_wait(lock, cv_, timeout, [&]() {
-        return std::ranges::any_of(partitions_ready_to_wait_on_, [](auto const& item) {
-            return item.second;
+        return std::ranges::any_of(goalposts_, [&](auto const& item) {
+            return item.second.is_finished(nranks_);
         });
     });
 
@@ -143,16 +132,31 @@ std::vector<PartID> FinishCounter::wait_some(
     // TODO: hand-writing iteration rather than range-for to avoid
     // needing to rehash the key during extract_key. Needs
     // std::ranges, I think.
-    for (auto it = partitions_ready_to_wait_on_.cbegin();
-         it != partitions_ready_to_wait_on_.cend();)
-    {
+    for (auto it = goalposts_.begin(); it != goalposts_.end();) {
         // extract_key invalidates the iterator
-        auto tmp = it++;
-        if (tmp->second) {
-            result.push_back(extract_key(partitions_ready_to_wait_on_, tmp));
+        auto& [pid, p_info] = *it;
+        if (p_info.is_finished(nranks_)) {
+            result.push_back(pid);
+            it = goalposts_.erase(it);
+        } else {
+            ++it;
         }
     }
     return result;
+}
+
+std::string detail::FinishCounter::str() const {
+    std::unique_lock<std::mutex> lock(mutex_);
+    std::stringstream ss;
+    ss << "FinishCounter(goalposts={";
+    for (auto const& [pid, p_info] : goalposts_) {
+        ss << "p" << pid << ": (rank_count= " << p_info.rank_count
+           << ", chunk_goal= " << p_info.chunk_goal
+           << ", finished_chunk_count= " << p_info.finished_chunk_count
+           << ", is_finished= " << p_info.is_finished(nranks_) << "), ";
+    }
+    ss << (goalposts_.empty() ? "}" : "\b\b}") << ")";
+    return ss.str();
 }
 
 

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -466,8 +466,7 @@ Shuffler::Shuffler(
       progress_thread_{std::move(progress_thread)},
       op_id_{op_id},
       finish_counter_{
-          static_cast<Rank>(comm_->nranks()),
-          local_partitions(comm_, total_num_partitions, partition_owner)
+          comm_->nranks(), local_partitions(comm_, total_num_partitions, partition_owner)
       },
       statistics_{std::move(statistics)} {
     RAPIDSMPF_EXPECTS(comm_ != nullptr, "the communicator pointer cannot be NULL");
@@ -809,28 +808,6 @@ std::string Shuffler::str() const {
     std::stringstream ss;
     ss << "Shuffler(outgoing=" << outgoing_postbox_ << ", received=" << ready_postbox_
        << ", " << finish_counter_;
-    return ss.str();
-}
-
-std::string detail::FinishCounter::str() const {
-    std::unique_lock<std::mutex> lock(mutex_);
-    std::stringstream ss;
-    ss << "FinishCounter(goalposts={";
-    for (auto const& [pid, goal] : goalposts_) {
-        ss << "p" << pid << ": (" << goal.first << ", " << goal.second << "), ";
-    }
-    ss << (goalposts_.empty() ? "}" : "\b\b}");
-    ss << ", finished={";
-    for (auto const& [pid, counter] : finished_chunk_counters_) {
-        ss << "p" << pid << ": " << counter << ", ";
-    }
-    ss << (finished_chunk_counters_.empty() ? "}" : "\b\b}");
-    ss << ", partitions_ready_to_wait_on={";
-    for (auto const& [pid, finished] : partitions_ready_to_wait_on_) {
-        ss << "p" << pid << ": " << finished << ", ";
-    }
-    ss << (partitions_ready_to_wait_on_.empty() ? "}" : "\b\b}");
-    ss << ")";
     return ss.str();
 }
 


### PR DESCRIPTION
This PR improves the `FinishCounter` code flow by merging 3 `unordered_map`s into a single map. Multiple maps seemed redundant, and clunky.  