### PR TITLE
WIP: remove cuspatial references, reduce unnecessary CI runs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   pr-builder:
     needs:
+      - changed-files
       - checks
       - conda-cpp-build
       - conda-cpp-linters
@@ -29,6 +30,33 @@ jobs:
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
+  changed-files:
+    secrets: inherit
+    needs: telemetry-setup
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@branch-25.08
+    with:
+      files_yaml: |
+        test_cpp:
+          - '**'
+          - '!.devcontainer/**'
+          - '!.pre-commit-config.yaml'
+          - '!.shellcheckrc'
+          - '!CONTRIBUTING.md'
+          - '!README.md'
+          - '!ci/release/update-version.sh'
+          - '!docs/**'
+          - '!python/**'
+        test_python:
+          - '**'
+          - '!.clang-tidy'
+          - '!.devcontainer/**'
+          - '!.pre-commit-config.yaml'
+          - '!.shellcheckrc'
+          - '!CONTRIBUTING.md'
+          - '!README.md'
+          - '!ci/release/update-version.sh'
+          - '!cpp/.clang-format'
+          - '!docs/**'
   checks:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.08
@@ -62,6 +90,7 @@ jobs:
       package-name: rapidsmpf-singlecomm
       package-type: python
   wheel-test:
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     needs: wheel-build-rapidsmpf
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.08
@@ -85,6 +114,7 @@ jobs:
       script: "ci/cpp_linters.sh"
       node_type: "cpu16"
   conda-cpp-tests:
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     needs: conda-cpp-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-25.08
@@ -100,6 +130,7 @@ jobs:
       build_type: pull-request
       script: ci/build_python.sh
   conda-python-tests:
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     needs: conda-python-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.08

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -57,7 +57,7 @@ IncludeCategories:
     Priority: 30 # CUDA includes
   - Regex: '^<(thrust|cub|cuda)/'
     Priority: 40 # CCCL includes
-  - Regex: '^<(cudf.*|rmm|cugraph|cuml|cuspatial|raft|kvikio)'
+  - Regex: '^<(cudf.*|rmm|cugraph|cuml|raft|kvikio)'
     Priority: 50 # RAPIDS includes
   - Regex: '^<rapidsmpf/'
     Priority: 60


### PR DESCRIPTION
Removes a reference to `cuspatial` in `clang-format` configuration, as part of an effort to remove `cuspatial` references across RAPIDS now that that project is no longer actively maintained (https://github.com/rapidsai/build-planning/issues/197).

While doing that, I noticed that this project is currently running its entire CI suite on every PR. Since the `cuspatial` changes were so minimal, I hope you won't mind that I'm bundling another changeset in here... using https://github.com/rapidsai/shared-workflows/blob/branch-25.08/.github/workflows/changed-files.yaml to achieve behavior like "do not run all the test jobs on PRs that only changed a README".

That's something we've rolled out across RAPIDS (https://github.com/rapidsai/build-planning/issues/94), to reduce overall usage of our shared pool of GPU CI runners, and to reduce the time it takes to get small things like docs-only PRs merged.

Example related PR: https://github.com/rapidsai/cudf/pull/19380