### PR TITLE
Fixing empty chunk extraction (#376)

### DIFF
--- a/cpp/include/rapidsmpf/buffer/packed_data.hpp
+++ b/cpp/include/rapidsmpf/buffer/packed_data.hpp
@@ -46,7 +46,16 @@ struct PackedData {
         );
     }
 
-    PackedData() = delete;
+    /**
+     * @brief Construct an empty PackedData object.
+     *
+     * This constructor initializes both the metadata and GPU data to empty
+     * buffers.
+     */
+    PackedData()
+        : metadata{std::make_unique<std::vector<std::uint8_t>>()},
+          gpu_data{std::make_unique<rmm::device_buffer>()} {}
+
     ~PackedData() = default;
 
     /// @brief PackedData is moveable

--- a/cpp/include/rapidsmpf/buffer/packed_data.hpp
+++ b/cpp/include/rapidsmpf/buffer/packed_data.hpp
@@ -75,7 +75,7 @@ struct PackedData {
      *
      * @return True if the packed data is empty, false otherwise.
      */
-    [[nodiscard]] inline bool empty() const {
+    [[nodiscard]] bool empty() const {
         return metadata->empty() && gpu_data->size() == 0;
     }
 };

--- a/cpp/include/rapidsmpf/buffer/packed_data.hpp
+++ b/cpp/include/rapidsmpf/buffer/packed_data.hpp
@@ -10,6 +10,8 @@
 
 #include <rmm/device_buffer.hpp>
 
+#include <rapidsmpf/error.hpp>
+
 namespace rapidsmpf {
 
 /**
@@ -19,10 +21,10 @@ namespace rapidsmpf {
  * the data should be interpreted.
  */
 struct PackedData {
-    std::unique_ptr<std::vector<std::uint8_t>> metadata{nullptr};  ///< The metadata
-    std::unique_ptr<rmm::device_buffer> gpu_data{nullptr};  ///< The gpu data
+    std::unique_ptr<std::vector<std::uint8_t>> metadata;  ///< The metadata
+    std::unique_ptr<rmm::device_buffer> gpu_data;  ///< The gpu data
 
-    PackedData() : metadata{nullptr}, gpu_data{nullptr} {}
+    PackedData() = delete;
 
     /**
      * @brief Construct packed data from metadata and gpu data, taking ownership.
@@ -34,7 +36,12 @@ struct PackedData {
         std::unique_ptr<std::vector<std::uint8_t>>&& meta,
         std::unique_ptr<rmm::device_buffer>&& data
     )
-        : metadata{std::move(meta)}, gpu_data{std::move(data)} {}
+        : metadata{std::move(meta)}, gpu_data{std::move(data)} {
+        RAPIDSMPF_EXPECTS(
+            metadata != nullptr || gpu_data != nullptr,
+            "Metadata or GPU data must be non-null"
+        );
+    }
 
     ~PackedData() = default;
     /// @brief PackedData is moveable

--- a/cpp/include/rapidsmpf/buffer/packed_data.hpp
+++ b/cpp/include/rapidsmpf/buffer/packed_data.hpp
@@ -24,8 +24,6 @@ struct PackedData {
     std::unique_ptr<std::vector<std::uint8_t>> metadata;  ///< The metadata
     std::unique_ptr<rmm::device_buffer> gpu_data;  ///< The gpu data
 
-    PackedData() = delete;
-
     /**
      * @brief Construct packed data from metadata and gpu data, taking ownership.
      *
@@ -41,11 +39,19 @@ struct PackedData {
             metadata != nullptr || gpu_data != nullptr,
             "Metadata or GPU data must be non-null"
         );
+
+        RAPIDSMPF_EXPECTS(
+            (metadata->size() > 0 || gpu_data->size() == 0),
+            "Empty Metadata and non-empty GPU data is not allowed"
+        );
     }
 
+    PackedData() = delete;
     ~PackedData() = default;
+
     /// @brief PackedData is moveable
     PackedData(PackedData&&) = default;
+
     /**
      * @brief Move assignment
      *
@@ -54,6 +60,15 @@ struct PackedData {
     PackedData& operator=(PackedData&&) = default;
     PackedData(PackedData const&) = delete;
     PackedData& operator=(PackedData&) = delete;
+
+    /**
+     * @brief Check if the packed data is empty.
+     *
+     * @return True if the packed data is empty, false otherwise.
+     */
+    [[nodiscard]] inline bool empty() const {
+        return metadata->empty() && gpu_data->size() == 0;
+    }
 };
 
 }  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
+++ b/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
@@ -159,15 +159,14 @@ class FinishCounter {
 
     /// @brief Information about a local partition.
     struct PartitionInfo {
-        Rank rank_count;  ///< number of ranks that have reported their chunk count.
-        ChunkID chunk_goal;  ///< the goal of a partition. This keeps increasing until all
-                             ///< ranks have reported their chunk count.
-        ChunkID finished_chunk_count;  ///< The finished chunk counter of each partition.
-                                       ///< The goal of a partition has been
-                                       ///< reached when its counter equals the goalpost.
+        Rank rank_count{0};  ///< number of ranks that have reported their chunk count.
+        ChunkID chunk_goal{0};  ///< the goal of a partition. This keeps increasing until
+                                ///< all ranks have reported their chunk count.
+        ChunkID finished_chunk_count{0
+        };  ///< The finished chunk counter of each partition. The goal of a partition has
+            ///< been reached when its counter equals the goalpost.
 
-        constexpr PartitionInfo()
-            : rank_count(0), chunk_goal(0), finished_chunk_count(0) {}
+        constexpr PartitionInfo() = default;
 
         constexpr void move_goalpost(ChunkID nchunks, Rank nranks) {
             RAPIDSMPF_EXPECTS(nchunks != 0, "the goalpost was moved by 0 chunks");

--- a/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
+++ b/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
@@ -191,7 +191,7 @@ class FinishCounter {
 
         [[nodiscard]] constexpr ChunkID data_chunk_goal() const {
             // there will always be a control message from each rank indicating how many
-            // chunks its sending. Chunk goal contains this control message for each rank.
+            // chunks it's sending. Chunk goal contains this control message for each rank.
             return chunk_goal - static_cast<ChunkID>(rank_count);
         }
     };

--- a/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
+++ b/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
@@ -94,14 +94,14 @@ class FinishCounter {
      *
      * @param timeout Optional timeout (ms) to wait.
      *
-     * @return The partition ID of a finished partition and the number of data chunks that
-     * have been finished.
+     * @return The partition ID of a finished partition and a boolean indicating if the
+     * partition contains data.
      *
      * @throw std::out_of_range If all partitions have already been waited on.
      * std::runtime_error If timeout was set and no partitions have been finished by the
      * expiration.
      */
-    std::pair<PartID, ChunkID> wait_any(
+    std::pair<PartID, bool> wait_any(
         std::optional<std::chrono::milliseconds> timeout = {}
     );
 
@@ -116,13 +116,13 @@ class FinishCounter {
      * @param pid The desired partition ID.
      * @param timeout Optional timeout (ms) to wait.
      *
-     * @return The number of data chunks that have been finished.
+     * @return A boolean indicating if the partition contains data.
      *
      * @throw std::out_of_range If the desired partition is unavailable.
      * std::runtime_error If timeout was set and requested partition has been finished by
      * the expiration.
      */
-    ChunkID wait_on(PartID pid, std::optional<std::chrono::milliseconds> timeout = {});
+    bool wait_on(PartID pid, std::optional<std::chrono::milliseconds> timeout = {});
 
     /**
      * @brief Returns a vector of partition ids that are finished and haven't been waited
@@ -136,14 +136,14 @@ class FinishCounter {
      *
      * @note It is the caller's responsibility to process all returned partition IDs.
      *
-     * @return A pair of vectors of finished partitions and the number of data chunks
-     * that have been finished for each partition.
+     * @return A pair of vectors of finished partitions and a boolean indicating if the
+     * partition contains data for each partition.
      *
      * @throw std::out_of_range If all partitions have been waited on.
      * std::runtime_error If timeout was set and no partitions have been finished by the
      * expiration.
      */
-    std::pair<std::vector<PartID>, std::vector<ChunkID>> wait_some(
+    std::pair<std::vector<PartID>, std::vector<bool>> wait_some(
         std::optional<std::chrono::milliseconds> timeout = {}
     );
 

--- a/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
+++ b/cpp/include/rapidsmpf/shuffler/finish_counter.hpp
@@ -57,10 +57,10 @@ class FinishCounter {
      * rank and partition. It should only be called once per rank and partition.
      *
      * @param pid The partition ID the goalpost is assigned to.
-     * @param nchunks The number of chunks required.
+     * @param nchunks The number of chunks required. (Requires nchunks > 0)
      *
      * @throw std::logic_error If the goalpost is moved more than once for the same rank
-     * and partition.
+     * and partition, or if nchunks is 0.
      */
     void move_goalpost(PartID pid, ChunkID nchunks);
 
@@ -166,6 +166,9 @@ class FinishCounter {
                                        ///< The goal of a partition has been
                                        ///< reached when its counter equals the goalpost.
 
+        constexpr PartitionInfo()
+            : rank_count(0), chunk_goal(0), finished_chunk_count(0) {}
+
         constexpr void move_goalpost(ChunkID nchunks, Rank nranks) {
             RAPIDSMPF_EXPECTS(nchunks != 0, "the goalpost was moved by 0 chunks");
             RAPIDSMPF_EXPECTS(
@@ -191,7 +194,9 @@ class FinishCounter {
 
         [[nodiscard]] constexpr ChunkID data_chunk_goal() const {
             // there will always be a control message from each rank indicating how many
-            // chunks it's sending. Chunk goal contains this control message for each rank.
+            // chunks it's sending. Chunk goal contains this control message for each
+            // rank. Therefore, to get the data chunk goal, we need to subtract the number
+            // of ranks that have reported their chunk count from the chunk goal.
             return chunk_goal - static_cast<ChunkID>(rank_count);
         }
     };

--- a/cpp/include/rapidsmpf/shuffler/postbox.hpp
+++ b/cpp/include/rapidsmpf/shuffler/postbox.hpp
@@ -52,6 +52,16 @@ class PostBox {
     void insert(Chunk&& chunk);
 
     /**
+     * @brief Marks a partition as empty.
+     *
+     * @param pid The ID of the partition to mark as empty.
+     *
+     * @throws std::logic_error If the partition ID is already in the postbox and is not
+     * empty.
+     */
+    void mark_empty(PartID pid);
+
+    /**
      * @brief Extracts a specific chunk from the PostBox.
      *
      * @param pid The ID of the partition containing the chunk.

--- a/cpp/include/rapidsmpf/shuffler/shuffler.hpp
+++ b/cpp/include/rapidsmpf/shuffler/shuffler.hpp
@@ -160,9 +160,7 @@ class Shuffler {
      *
      * @return True if all partitions are finished, otherwise False.
      */
-    [[nodiscard]] bool finished() const {
-        return finish_counter_.all_finished();
-    }
+    [[nodiscard]] bool finished() const;
 
     /**
      * @brief Wait for any partition to finish.
@@ -171,10 +169,7 @@ class Shuffler {
      *
      * @return The partition ID of the next finished partition.
      */
-    PartID wait_any(std::optional<std::chrono::milliseconds> timeout = {}) {
-        RAPIDSMPF_NVTX_FUNC_RANGE();
-        return finish_counter_.wait_any(std::move(timeout));
-    }
+    PartID wait_any(std::optional<std::chrono::milliseconds> timeout = {});
 
     /**
      * @brief Wait for a specific partition to finish (blocking).
@@ -182,10 +177,7 @@ class Shuffler {
      * @param pid The desired partition ID.
      * @param timeout Optional timeout (ms) to wait.
      */
-    void wait_on(PartID pid, std::optional<std::chrono::milliseconds> timeout = {}) {
-        RAPIDSMPF_NVTX_FUNC_RANGE();
-        finish_counter_.wait_on(pid, std::move(timeout));
-    }
+    void wait_on(PartID pid, std::optional<std::chrono::milliseconds> timeout = {});
 
     /**
      * @brief Wait for at least one partition to finish.
@@ -194,10 +186,7 @@ class Shuffler {
      *
      * @return The partition IDs of all finished partitions.
      */
-    std::vector<PartID> wait_some(std::optional<std::chrono::milliseconds> timeout = {}) {
-        RAPIDSMPF_NVTX_FUNC_RANGE();
-        return finish_counter_.wait_some(std::move(timeout));
-    }
+    std::vector<PartID> wait_some(std::optional<std::chrono::milliseconds> timeout = {});
 
     /**
      * @brief Spills data to device if necessary.

--- a/cpp/src/shuffler/finish_counter.cpp
+++ b/cpp/src/shuffler/finish_counter.cpp
@@ -13,12 +13,9 @@ namespace rapidsmpf::shuffler::detail {
 FinishCounter::FinishCounter(Rank nranks, std::vector<PartID> const& local_partitions)
     : nranks_{nranks} {
     // Initially, none of the partitions are ready to wait on.
+    goalposts_.reserve(local_partitions.size());
     for (auto pid : local_partitions) {
-        // partitions_ready_to_wait_on_.insert({pid, false});
-        goalposts_.emplace(
-            pid,
-            PartitionInfo{.rank_count = 0, .chunk_goal = 0, .finished_chunk_count = 0}
-        );
+        goalposts_.emplace(pid, PartitionInfo{});
     }
 }
 

--- a/cpp/src/shuffler/postbox.cpp
+++ b/cpp/src/shuffler/postbox.cpp
@@ -33,7 +33,7 @@ void PostBox<KeyType>::mark_empty(PartID pid) {
     KeyType key = key_map_fn_(pid);
 
     auto [it, inserted] = pigeonhole_.emplace(key, std::unordered_map<ChunkID, Chunk>{});
-    // if insertion failed, then the parititon in the pigenhole needs to be empty.
+    // if insertion failed, then the partition in the pigenhole needs to be empty.
     // (ex: a pid that has already been marked as empty). Else raise an error.
     RAPIDSMPF_EXPECTS(
         inserted || it->second.empty(),

--- a/cpp/tests/test_chunk.cpp
+++ b/cpp/tests/test_chunk.cpp
@@ -255,10 +255,9 @@ std::tuple<Chunk, std::vector<uint8_t>, std::vector<uint8_t>, size_t> make_mixed
     chunks.push_back(Chunk::from_packed_data(
         0,
         6,
-        PackedData{
-            std::make_unique<std::vector<uint8_t>>(metadata.begin() + 5, metadata.end()),
-            nullptr
-        },
+        create_packed_data(
+            {metadata.begin() + 5, metadata.end()}, {data.data(), 0}, stream
+        ),
         nullptr,
         stream,
         br

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -1019,6 +1019,21 @@ TEST_F(PostBoxTest, InsertAndExtractMultipleChunks) {
     EXPECT_EQ(all_chunks.size(), num_chunks);
 }
 
+TEST_F(PostBoxTest, MarkEmpty) {
+    rapidsmpf::shuffler::PartID pid = 0, pid1 = 1;
+    postbox->mark_empty(pid);
+    EXPECT_NO_THROW(postbox->mark_empty(pid));  // should not raise an error
+
+    postbox->insert(rapidsmpf::shuffler::detail::make_dummy_chunk(
+        rapidsmpf::shuffler::detail::ChunkID{0}, pid1
+    ));
+    EXPECT_THROW(postbox->mark_empty(pid1), std::logic_error);  // should raise an error
+
+    EXPECT_EQ(0, postbox->extract_by_key(pid).size());
+    EXPECT_EQ(1, postbox->extract_by_key(pid1).size());
+    EXPECT_TRUE(postbox->empty());
+}
+
 TEST_F(PostBoxTest, ThreadSafety) {
     constexpr uint32_t num_threads = 4;
     constexpr uint32_t chunks_per_thread = 100;

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -1019,7 +1019,11 @@ TEST_F(PostBoxTest, InsertAndExtractMultipleChunks) {
     EXPECT_EQ(all_chunks.size(), num_chunks);
 }
 
-TEST_F(PostBoxTest, MarkEmpty) {
+TEST(ReadyPostBoxTest, MarkEmpty) {
+    auto postbox = std::make_unique<
+        rapidsmpf::shuffler::detail::PostBox<rapidsmpf::shuffler::PartID>>(std::identity{}
+    );
+
     rapidsmpf::shuffler::PartID pid = 0, pid1 = 1;
     postbox->mark_empty(pid);
     EXPECT_NO_THROW(postbox->mark_empty(pid));  // should not raise an error


### PR DESCRIPTION
This PR fixes https://github.com/rapidsai/rapidsmpf/issues/376. 

Depends on #378 

It also enforces the following conditions for an empty table `PackedData`. 
```c++
TEST(EmptyPartitions, cudf_pack) {
    auto stream = cudf::get_default_stream();
    cudf::table tbl = random_table_with_index(0, 0, 0, 0);
    EXPECT_EQ(0, tbl.num_rows());

    // following conditions should be met for an empty cudf table
    auto packed = cudf::pack(tbl, stream);
    EXPECT_TRUE(packed.metadata);
    EXPECT_TRUE(packed.gpu_data);
    EXPECT_EQ(0, packed.gpu_data->size());
}
```

**`PackedData` Emptiness** 
- For `PackedData` to be empty, both metadata and data `unique_ptr`s should be non-null and empty. 
- Empty packed data will be skipped by the Shuffler (ex: packing `cudf::table({})`). 
- Non-empty metadata and empty data is a valid combination (ex: packing 0 length cudf table). Shuffler will send/ receive the non-empty metadata, but skip sending/ receiving empty data buffers. This is required because, unpacking the packed data into a cudf table needs to metadata buffer to be sent. As a future improvement, we could drop this metadata buffer send, because generally, every table inserted into the shuffler (in every worker) has the same schema. 