### PR TITLE
Use RapidsMPF's CUDA macros

### DIFF
--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -11,6 +11,7 @@
 #include <rapidsmpf/communicator/communicator.hpp>
 #include <rapidsmpf/communicator/mpi.hpp>
 #include <rapidsmpf/communicator/ucxx_utils.hpp>
+#include <rapidsmpf/error.hpp>
 #include <rapidsmpf/statistics.hpp>
 
 #include "utils/misc.hpp"
@@ -239,10 +240,11 @@ int main(int argc, char** argv) {
         std::stringstream ss;
         auto const cur_dev = rmm::get_current_cuda_device().value();
         std::string pci_bus_id(16, '\0');  // Preallocate space for the PCI bus ID
-        CUDF_CUDA_TRY(cudaDeviceGetPCIBusId(pci_bus_id.data(), pci_bus_id.size(), cur_dev)
+        RAPIDSMPF_CUDA_TRY(
+            cudaDeviceGetPCIBusId(pci_bus_id.data(), pci_bus_id.size(), cur_dev)
         );
         cudaDeviceProp properties;
-        CUDF_CUDA_TRY(cudaGetDeviceProperties(&properties, 0));
+        RAPIDSMPF_CUDA_TRY(cudaGetDeviceProperties(&properties, 0));
         ss << "Hardware setup: \n";
         ss << "  GPU (" << properties.name << "): \n";
         ss << "    Device number: " << cur_dev << "\n";

--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -527,10 +527,11 @@ int main(int argc, char** argv) {
         std::stringstream ss;
         auto const cur_dev = rmm::get_current_cuda_device().value();
         std::string pci_bus_id(16, '\0');  // Preallocate space for the PCI bus ID
-        CUDF_CUDA_TRY(cudaDeviceGetPCIBusId(pci_bus_id.data(), pci_bus_id.size(), cur_dev)
+        RAPIDSMPF_CUDA_TRY(
+            cudaDeviceGetPCIBusId(pci_bus_id.data(), pci_bus_id.size(), cur_dev)
         );
         cudaDeviceProp properties;
-        CUDF_CUDA_TRY(cudaGetDeviceProperties(&properties, 0));
+        RAPIDSMPF_CUDA_TRY(cudaGetDeviceProperties(&properties, 0));
         ss << "Hardware setup: \n";
         ss << "  GPU (" << properties.name << "): \n";
         ss << "    Device number: " << cur_dev << "\n";

--- a/cpp/tests/test_rmm_resource_adaptor.cpp
+++ b/cpp/tests/test_rmm_resource_adaptor.cpp
@@ -16,6 +16,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 
+#include <rapidsmpf/error.hpp>
 #include <rapidsmpf/rmm_resource_adaptor.hpp>
 
 #include "utils.hpp"

--- a/cpp/tests/test_rmm_resource_adaptor.cpp
+++ b/cpp/tests/test_rmm_resource_adaptor.cpp
@@ -31,13 +31,13 @@ struct throw_at_limit_resource final : public rmm::mr::device_memory_resource {
             throw ExceptionType{"foo"};
         }
         void* ptr{nullptr};
-        RMM_CUDA_TRY_ALLOC(cudaMallocAsync(&ptr, bytes, stream));
+        RAPIDSMPF_CUDA_TRY_ALLOC(cudaMallocAsync(&ptr, bytes, stream));
         allocs.insert(ptr);
         return ptr;
     }
 
     void do_deallocate(void* ptr, std::size_t, rmm::cuda_stream_view) override {
-        RMM_ASSERT_CUDA_SUCCESS(cudaFree(ptr));
+        RAPIDSMPF_CUDA_TRY(cudaFree(ptr));
         allocs.erase(ptr);
     }
 


### PR DESCRIPTION
Macros to test for CUDA errors are generally considered implementation details and should be avoided when including from other projects, instead we should use our internal implementations. See https://github.com/rapidsai/rapidsmpf/issues/123.