### PR TITLE
Disable scanning for C++ files

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -24,6 +24,11 @@ project(
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
+# For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
+# version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
+# gcc>=14. We can remove this once we upgrade to a newer sccache version.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 # Write the version header
 rapids_cmake_write_version_file(include/rapidsmpf/version_config.hpp)
 

--- a/python/librapidsmpf/CMakeLists.txt
+++ b/python/librapidsmpf/CMakeLists.txt
@@ -19,6 +19,11 @@ project(
   LANGUAGES CXX CUDA
 )
 
+# For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
+# version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
+# gcc>=14. We can remove this once we upgrade to a newer sccache version.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 find_package(RAPIDSMPF "${RAPIDS_VERSION}")
 
 if(RAPIDSMPF_FOUND)

--- a/python/rapidsmpf/CMakeLists.txt
+++ b/python/rapidsmpf/CMakeLists.txt
@@ -31,6 +31,11 @@ target_link_options(maybe_asan INTERFACE "$<$<BOOL:${RAPIDSMPF_PYTHON_ASAN}>:-fs
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
+# version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
+# gcc>=14. We can remove this once we upgrade to a newer sccache version.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 find_package(rapidsmpf REQUIRED "${RAPIDS_VERSION}")
 
 if(RAPIDSMPF_HAVE_UCXX)


### PR DESCRIPTION
Building 25.10 wheels packages fail due to the use of GCC 14, https://github.com/rapidsai/kvikio/pull/749/ implements a fix for that case that will probably fix it here as well.