### PR TITLE
Use `nproc` to determine parallel level in `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ PYTHON_ARGS_FOR_INSTALL=("-m" "pip" "install" "--no-build-isolation" "--no-deps"
 # If INSTALL_PREFIX is not set, check PREFIX, then check
 # CONDA_PREFIX, then fall back to install inside of $LIBRAPIDSMPF_BUILD_DIR
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX:=$LIBRAPIDSMPF_BUILD_DIR/install}}}
-export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
+PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
 
 function hasArg {
     (( NUMARGS != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")


### PR DESCRIPTION
Other RAPIDS projects, such as cuDF, [use `nproc` to determine the `PARALLEL_LEVEL` when building with the `build.sh` script](https://github.com/rapidsai/cudf/blob/84149b11ac65516a6fd9cf05b2592fc95ad441f8/build.sh#L83). This is a better default as it allows better use of available resources.