### PR TITLE
`PackedData` is memory-type agnostic

### DIFF
--- a/cpp/benchmarks/bench_partition.cpp
+++ b/cpp/benchmarks/bench_partition.cpp
@@ -78,8 +78,8 @@ static void BM_PartitionAndPack(benchmark::State& state) {
             num_partitions,
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,
-            &br,
-            stream
+            stream,
+            &br
         );
         benchmark::DoNotOptimize(pack_partitions);
         cudaStreamSynchronize(stream);
@@ -134,8 +134,8 @@ static void BM_PartitionAndPackCurrentImpl(benchmark::State& state) {
                 total_npartitions,
                 cudf::hash_id::HASH_MURMUR3,
                 cudf::DEFAULT_HASH_SEED,
-                &br,
-                stream
+                stream,
+                &br
             );
             benchmark::DoNotOptimize(pack_partitions);
         }

--- a/cpp/benchmarks/bench_partition.cpp
+++ b/cpp/benchmarks/bench_partition.cpp
@@ -63,6 +63,7 @@ static void BM_PartitionAndPack(benchmark::State& state) {
         std::make_unique<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>(
             cuda_mr.get(), pool_size
         );
+    rapidsmpf::BufferResource br{*pool_mr};
 
     // Create input table
     auto table = create_int_table(num_rows, stream);
@@ -77,8 +78,8 @@ static void BM_PartitionAndPack(benchmark::State& state) {
             num_partitions,
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,
-            stream,
-            *pool_mr
+            &br,
+            stream
         );
         benchmark::DoNotOptimize(pack_partitions);
         cudaStreamSynchronize(stream);
@@ -117,6 +118,7 @@ static void BM_PartitionAndPackCurrentImpl(benchmark::State& state) {
         std::make_unique<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>(
             cuda_mr.get(), pool_size
         );
+    rapidsmpf::BufferResource br{*pool_mr};
 
     // Create input table
     auto table = create_int_table(num_rows, stream);
@@ -132,8 +134,8 @@ static void BM_PartitionAndPackCurrentImpl(benchmark::State& state) {
                 total_npartitions,
                 cudf::hash_id::HASH_MURMUR3,
                 cudf::DEFAULT_HASH_SEED,
-                stream,
-                *pool_mr
+                &br,
+                stream
             );
             benchmark::DoNotOptimize(pack_partitions);
         }

--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -239,7 +239,7 @@ rapidsmpf::Duration do_run(
             auto finished_partition = shuffler.wait_any();
             auto packed_chunks = shuffler.extract(finished_partition);
             output_partitions.emplace_back(rapidsmpf::unpack_and_concat(
-                std::move(packed_chunks), stream, br->device_mr(), statistics
+                std::move(packed_chunks), br, stream, statistics
             ));
         }
         stream.synchronize();
@@ -256,8 +256,8 @@ rapidsmpf::Duration do_run(
                 static_cast<std::int32_t>(total_num_partitions),
                 cudf::hash_id::HASH_MURMUR3,
                 cudf::DEFAULT_HASH_SEED,
-                stream,
-                br->device_mr()
+                br,
+                stream
             );
             RAPIDSMPF_EXPECTS(
                 std::count_if(
@@ -382,8 +382,8 @@ rapidsmpf::Duration run_hash_partition_inline(
             static_cast<std::int32_t>(total_num_partitions),
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,
+            br,
             stream,
-            br->device_mr(),
             statistics
         );
     };
@@ -446,8 +446,8 @@ rapidsmpf::Duration run_hash_partition_with_datagen(
                     static_cast<std::int32_t>(total_num_partitions),
                     cudf::hash_id::HASH_MURMUR3,
                     cudf::DEFAULT_HASH_SEED,
-                    stream,
-                    br->device_mr()
+                    br,
+                    stream
                 );
             }
         );

--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -240,7 +240,7 @@ rapidsmpf::Duration do_run(
             auto packed_chunks = shuffler.extract(finished_partition);
             output_partitions.emplace_back(
                 rapidsmpf::unpack_and_concat(
-                    std::move(packed_chunks), br, stream, statistics
+                    std::move(packed_chunks), stream, br, statistics
                 )
             );
         }
@@ -258,8 +258,8 @@ rapidsmpf::Duration do_run(
                 static_cast<std::int32_t>(total_num_partitions),
                 cudf::hash_id::HASH_MURMUR3,
                 cudf::DEFAULT_HASH_SEED,
-                br,
-                stream
+                stream,
+                br
             );
             RAPIDSMPF_EXPECTS(
                 std::count_if(
@@ -384,8 +384,8 @@ rapidsmpf::Duration run_hash_partition_inline(
             static_cast<std::int32_t>(total_num_partitions),
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,
-            br,
             stream,
+            br,
             statistics
         );
     };
@@ -445,8 +445,8 @@ rapidsmpf::Duration run_hash_partition_with_datagen(
                     static_cast<std::int32_t>(total_num_partitions),
                     cudf::hash_id::HASH_MURMUR3,
                     cudf::DEFAULT_HASH_SEED,
-                    br,
-                    stream
+                    stream,
+                    br
                 );
             }
         );

--- a/cpp/examples/example_shuffle.cpp
+++ b/cpp/examples/example_shuffle.cpp
@@ -85,8 +85,8 @@ int main(int argc, char** argv) {
             static_cast<int>(total_num_partitions),
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,
-            &br,
-            stream
+            stream,
+            &br
         );
 
     // Now, we can insert the packed partitions into the shuffler. This operation is
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
         // Unpack (deserialize) and concatenate the chunks into a single table using a
         // convenience function.
         local_outputs.push_back(
-            rapidsmpf::unpack_and_concat(std::move(packed_chunks), &br, stream)
+            rapidsmpf::unpack_and_concat(std::move(packed_chunks), stream, &br)
         );
     }
     // At this point, `local_outputs` contains the local result of the shuffle.

--- a/cpp/examples/example_shuffle.cpp
+++ b/cpp/examples/example_shuffle.cpp
@@ -85,8 +85,8 @@ int main(int argc, char** argv) {
             static_cast<int>(total_num_partitions),
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,
-            stream,
-            mr
+            &br,
+            stream
         );
 
     // Now, we can insert the packed partitions into the shuffler. This operation is
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
         // Unpack (deserialize) and concatenate the chunks into a single table using a
         // convenience function.
         local_outputs.push_back(
-            rapidsmpf::unpack_and_concat(std::move(packed_chunks), stream, mr)
+            rapidsmpf::unpack_and_concat(std::move(packed_chunks), &br, stream)
         );
     }
     // At this point, `local_outputs` contains the local result of the shuffle.

--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -276,7 +276,7 @@ class Buffer {
      * @brief Construct a Buffer from host memory.
      *
      * @param host_buffer A unique pointer to a vector containing host memory.
-     * @param br Buffer resource for memory allocation.
+     * @param br Buffer resource for gpu data allocations.
      *
      * @throws std::invalid_argument if `host_buffer` is null.
      */
@@ -287,7 +287,7 @@ class Buffer {
      *
      * @param device_buffer A unique pointer to a device buffer.
      * @param stream CUDA stream used for the device buffer allocation.
-     * @param br Buffer resource for memory allocation.
+     * @param br Buffer resource for gpu data allocations.
      * @param event The shared event to use for the buffer.
      *
      * @throws std::invalid_argument if `device_buffer` is null.

--- a/cpp/include/rapidsmpf/buffer/packed_data.hpp
+++ b/cpp/include/rapidsmpf/buffer/packed_data.hpp
@@ -37,8 +37,8 @@ struct PackedData {
     PackedData(
         std::unique_ptr<std::vector<std::uint8_t>> metadata,
         std::unique_ptr<rmm::device_buffer> gpu_data,
-        BufferResource* br,
         rmm::cuda_stream_view stream,
+        BufferResource* br,
         std::shared_ptr<Buffer::Event> event = nullptr
     )
         : PackedData(std::move(metadata), br->move(std::move(gpu_data), stream, event)) {}

--- a/cpp/include/rapidsmpf/buffer/packed_data.hpp
+++ b/cpp/include/rapidsmpf/buffer/packed_data.hpp
@@ -25,15 +25,30 @@ namespace rapidsmpf {
 struct PackedData {
     std::unique_ptr<std::vector<std::uint8_t>> metadata;  ///< The metadata
     std::unique_ptr<Buffer> gpu_data;  ///< The gpu data
-
+    /// @brief Default constructor
     PackedData() = default;
 
+    /**
+     * @brief Construct from metadata and gpu data.
+     *
+     * @param metadata Host-side metadata describing the GPU data.
+     * @param gpu_data Pointer to GPU data.
+     */
     PackedData(
         std::unique_ptr<std::vector<std::uint8_t>> metadata,
         std::unique_ptr<Buffer> gpu_data
     )
         : metadata{std::move(metadata)}, gpu_data{std::move(gpu_data)} {}
 
+    /**
+     * @brief Construct from metadata and device buffer, taking ownership.
+     *
+     * @param metadata Host-side metadata.
+     * @param gpu_data Raw GPU buffer to be moved into a wrapped buffer.
+     * @param stream CUDA stream used during the move.
+     * @param br Buffer resource for gpu data allocations.
+     * @param event Optional event to associate with the gpu data.
+     */
     PackedData(
         std::unique_ptr<std::vector<std::uint8_t>> metadata,
         std::unique_ptr<rmm::device_buffer> gpu_data,
@@ -42,16 +57,6 @@ struct PackedData {
         std::shared_ptr<Buffer::Event> event = nullptr
     )
         : PackedData(std::move(metadata), br->move(std::move(gpu_data), stream, event)) {}
-
-    PackedData(
-        std::unique_ptr<std::vector<std::uint8_t>> metadata,
-        std::unique_ptr<rmm::device_buffer> gpu_data,
-        BufferResource* br
-    )
-        : metadata{std::move(metadata)} {
-        auto stream = gpu_data->stream();
-        this->gpu_data = br->move(std::move(gpu_data), stream);
-    }
 
     ~PackedData() = default;
 

--- a/cpp/include/rapidsmpf/buffer/packed_data.hpp
+++ b/cpp/include/rapidsmpf/buffer/packed_data.hpp
@@ -26,6 +26,8 @@ struct PackedData {
     std::unique_ptr<std::vector<std::uint8_t>> metadata;  ///< The metadata
     std::unique_ptr<Buffer> gpu_data;  ///< The gpu data
 
+    PackedData() = default;
+
     PackedData(
         std::unique_ptr<std::vector<std::uint8_t>> metadata,
         std::unique_ptr<Buffer> gpu_data
@@ -51,16 +53,6 @@ struct PackedData {
         this->gpu_data = br->move(std::move(gpu_data), stream);
     }
 
-    // /**
-    //  * @brief Construct an empty PackedData object.
-    //  *
-    //  * This constructor initializes both the metadata and GPU data to empty
-    //  * buffers.
-    //  */
-    // PackedData()
-    //     : metadata{std::make_unique<std::vector<std::uint8_t>>()},
-    //       gpu_data{std::make_unique<rmm::device_buffer>()} {}
-
     ~PackedData() = default;
 
     /// @brief PackedData is moveable
@@ -79,8 +71,15 @@ struct PackedData {
      * @brief Check if the packed data is empty.
      *
      * @return True if the packed data is empty, false otherwise.
+     *
+     * @throw std::invalid_argument if metadata and gpu_data is null and non-null.
      */
     [[nodiscard]] bool empty() const {
+        RAPIDSMPF_EXPECTS(
+            (!metadata) == (!gpu_data),
+            "the metadata and gpu_data pointers cannot be null and non-null",
+            std::invalid_argument
+        );
         return metadata->empty() && gpu_data->size == 0;
     }
 };

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -323,6 +323,22 @@ class BufferResource {
     );
 
     /**
+     * @brief Move a Buffer to a device buffer without allowing memory type conversion.
+     *
+     * This overload assumes the buffer is already in device memory. No copy will be
+     * performed. Moving between different memory types is not allowed and will result in
+     * an exception.
+     *
+     * @param buffer The buffer to move.
+     * @return A unique pointer to the resulting device buffer.
+     *
+     * @throws std::invalid_argument if the buffer is not already in device memory.
+     */
+    std::unique_ptr<rmm::device_buffer> move_to_device_buffer(
+        std::unique_ptr<Buffer> buffer
+    );
+
+    /**
      * @brief Move a Buffer to a host vector.
      *
      * If and only if moving between different memory types will this perform a copy.
@@ -340,6 +356,22 @@ class BufferResource {
         std::unique_ptr<Buffer> buffer,
         rmm::cuda_stream_view stream,
         MemoryReservation& reservation
+    );
+
+    /**
+     * @brief Move a Buffer to a host vector without allowing memory type conversion.
+     *
+     * This overload assumes the buffer is already in host memory. No copy will be
+     * performed. Moving between different memory types is not allowed and will result in
+     * an exception.
+     *
+     * @param buffer The buffer to move.
+     * @return A unique pointer to the resulting host vector.
+     *
+     * @throws std::invalid_argument if the buffer is not already in host memory.
+     */
+    std::unique_ptr<std::vector<uint8_t>> move_to_host_vector(
+        std::unique_ptr<Buffer> buffer
     );
 
     /**

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -46,8 +46,8 @@ partition_and_split(
     int num_partitions,
     cudf::hash_id hash_function,
     uint32_t seed,
-    BufferResource* br,
     rmm::cuda_stream_view stream,
+    BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
@@ -78,8 +78,8 @@ partition_and_split(
     int num_partitions,
     cudf::hash_id hash_function,
     uint32_t seed,
-    BufferResource* br,
     rmm::cuda_stream_view stream,
+    BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
@@ -105,8 +105,8 @@ partition_and_split(
 [[nodiscard]] std::unordered_map<shuffler::PartID, PackedData> split_and_pack(
     cudf::table_view const& table,
     std::vector<cudf::size_type> const& splits,
-    BufferResource* br,
     rmm::cuda_stream_view stream,
+    BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
@@ -129,8 +129,8 @@ partition_and_split(
  */
 [[nodiscard]] std::unique_ptr<cudf::table> unpack_and_concat(
     std::vector<PackedData>&& partitions,
-    BufferResource* br,
     rmm::cuda_stream_view stream,
+    BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -29,7 +29,7 @@ namespace rapidsmpf {
  * @param hash_function Hash function to use.
  * @param seed Seed value to the hash function.
  * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr Device memory resource used to allocate the returned table's device memory.
+ * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
  *
  * @return A vector of each partition and a table that owns the device memory.
@@ -61,8 +61,8 @@ partition_and_split(
  * @param hash_function Hash function to use.
  * @param seed Seed value to the hash function.
  * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr Device memory resource used to allocate the returned table's device memory.
- *  @param statistics The statistics instance to use (disabled by default).
+ * @param br Buffer resource for memory allocations.
+ * @param statistics The statistics instance to use (disabled by default).
  *
  * @return A map of partition IDs and their packed tables.
  *
@@ -91,7 +91,7 @@ partition_and_split(
  * @param splits The split points, equivalent to cudf::split(), i.e. one less than
  * the number of result partitions.
  * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr Device memory resource used to allocate the returned table's device memory.
+ * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
  *
  * @return A map of partition IDs and their packed tables.
@@ -118,8 +118,8 @@ partition_and_split(
  *
  * @param partitions The packed input tables.
  * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr Device memory resource used to allocate the returned table's device memory.
- *  @param statistics The statistics instance to use (disabled by default).
+ * @param br Buffer resource for memory allocations.
+ * @param statistics The statistics instance to use (disabled by default).
  *
  * @return The unpacked and concatenated result.
  *

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -13,6 +13,7 @@
 #include <cudf/table/table.hpp>
 
 #include <rapidsmpf/buffer/packed_data.hpp>
+#include <rapidsmpf/buffer/resource.hpp>
 #include <rapidsmpf/shuffler/shuffler.hpp>
 #include <rapidsmpf/statistics.hpp>
 
@@ -45,8 +46,8 @@ partition_and_split(
     int num_partitions,
     cudf::hash_id hash_function,
     uint32_t seed,
+    BufferResource* br,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
@@ -77,8 +78,8 @@ partition_and_split(
     int num_partitions,
     cudf::hash_id hash_function,
     uint32_t seed,
+    BufferResource* br,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
@@ -104,8 +105,8 @@ partition_and_split(
 [[nodiscard]] std::unordered_map<shuffler::PartID, PackedData> split_and_pack(
     cudf::table_view const& table,
     std::vector<cudf::size_type> const& splits,
+    BufferResource* br,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
@@ -128,8 +129,8 @@ partition_and_split(
  */
 [[nodiscard]] std::unique_ptr<cudf::table> unpack_and_concat(
     std::vector<PackedData>&& partitions,
+    BufferResource* br,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 

--- a/cpp/include/rapidsmpf/shuffler/chunk.hpp
+++ b/cpp/include/rapidsmpf/shuffler/chunk.hpp
@@ -250,9 +250,6 @@ class Chunk {
      * @param chunk_id The ID of the chunk.
      * @param part_id The ID of the partition.
      * @param packed_data The packed data.
-     * @param event The CUDA event.
-     * @param stream The CUDA stream.
-     * @param br The buffer resource.
      * @return The chunk.
      */
     static Chunk from_packed_data(

--- a/cpp/include/rapidsmpf/shuffler/chunk.hpp
+++ b/cpp/include/rapidsmpf/shuffler/chunk.hpp
@@ -256,12 +256,7 @@ class Chunk {
      * @return The chunk.
      */
     static Chunk from_packed_data(
-        ChunkID chunk_id,
-        PartID part_id,
-        PackedData&& packed_data,
-        std::shared_ptr<Buffer::Event> event,
-        rmm::cuda_stream_view stream,
-        BufferResource* br
+        ChunkID chunk_id, PartID part_id, PackedData&& packed_data
     );
 
     /**

--- a/cpp/include/rapidsmpf/shuffler/shuffler.hpp
+++ b/cpp/include/rapidsmpf/shuffler/shuffler.hpp
@@ -234,9 +234,7 @@ class Shuffler {
      * @param stream The CUDA stream for BufferResource memory operations.
      * @param event The event to use for the new chunk.
      */
-    [[nodiscard]] detail::Chunk create_chunk(
-        PartID pid, PackedData&& packed_data, std::shared_ptr<Buffer::Event> event
-    );
+    [[nodiscard]] detail::Chunk create_chunk(PartID pid, PackedData&& packed_data);
 
   public:
     PartID const total_num_partitions;  ///< Total number of partition in the shuffle.

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -141,6 +141,17 @@ std::unique_ptr<rmm::device_buffer> BufferResource::move_to_device_buffer(
     );
 }
 
+std::unique_ptr<rmm::device_buffer> BufferResource::move_to_device_buffer(
+    std::unique_ptr<Buffer> buffer
+) {
+    RAPIDSMPF_EXPECTS(
+        buffer->mem_type() == MemoryType::DEVICE,
+        "cannot move between memory types without a reservation",
+        std::invalid_argument
+    );
+    return std::move(buffer->device());
+}
+
 std::unique_ptr<std::vector<uint8_t>> BufferResource::move_to_host_vector(
     std::unique_ptr<Buffer> buffer,
     rmm::cuda_stream_view stream,
@@ -149,6 +160,17 @@ std::unique_ptr<std::vector<uint8_t>> BufferResource::move_to_host_vector(
     return std::move(
         move(MemoryType::HOST, std::move(buffer), stream, reservation)->host()
     );
+}
+
+std::unique_ptr<std::vector<uint8_t>> BufferResource::move_to_host_vector(
+    std::unique_ptr<Buffer> buffer
+) {
+    RAPIDSMPF_EXPECTS(
+        buffer->mem_type() == MemoryType::HOST,
+        "cannot move between memory types without a reservation",
+        std::invalid_argument
+    );
+    return std::move(buffer->host());
 }
 
 std::unique_ptr<Buffer> BufferResource::copy(

--- a/cpp/src/integrations/cudf/partition.cpp
+++ b/cpp/src/integrations/cudf/partition.cpp
@@ -131,12 +131,7 @@ std::unique_ptr<cudf::table> unpack_and_concat(
     unpacked.reserve(partitions.size());
     references.reserve(partitions.size());
     for (auto& packed_data : partitions) {
-        RAPIDSMPF_EXPECTS(
-            (!packed_data.metadata) == (!packed_data.gpu_data),
-            "the metadata and gpu_data pointers cannot be null and non-null",
-            std::invalid_argument
-        );
-        if (packed_data.metadata) {
+        if (!packed_data.empty()) {
             unpacked.push_back(cudf::unpack(references.emplace_back(
                 std::move(packed_data.metadata),
                 br->move_to_device_buffer(std::move(packed_data.gpu_data))

--- a/cpp/src/shuffler/chunk.cpp
+++ b/cpp/src/shuffler/chunk.cpp
@@ -94,26 +94,18 @@ Chunk Chunk::get_data(
 }
 
 Chunk Chunk::from_packed_data(
-    ChunkID chunk_id,
-    PartID part_id,
-    PackedData&& packed_data,
-    std::shared_ptr<Buffer::Event> event,
-    rmm::cuda_stream_view stream,
-    BufferResource* br
+    ChunkID chunk_id, PartID part_id, PackedData&& packed_data
 ) {
     RAPIDSMPF_EXPECTS(packed_data.metadata != nullptr, "packed_data.metadata is nullptr");
     RAPIDSMPF_EXPECTS(packed_data.gpu_data != nullptr, "packed_data.gpu_data is nullptr");
-
-    return {
+    return Chunk{
         chunk_id,
         {part_id},
         {0},  // expected_num_chunks
         {static_cast<uint32_t>(packed_data.metadata->size())},
-        {packed_data.gpu_data->size()},
+        {packed_data.gpu_data->size},
         std::move(packed_data.metadata),
-        packed_data.gpu_data->size() > 0
-            ? br->move(std::move(packed_data.gpu_data), stream, std::move(event))
-            : br->allocate_empty_host_buffer()
+        std::move(packed_data.gpu_data),
     };
 }
 

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -95,7 +95,7 @@ std::unique_ptr<Buffer> allocate_buffer(
  * threads trying to extract a chunk that is in the process of being spilled, will fail.
  * To avoid this, the Shuffler uses `outbox_spillling_mutex_` to serialize extractions.
  *
- * @param br Buffer resource for memory allocation.
+ * @param br Buffer resource for gpu data allocations.
  * @param log A logger for recording events and debugging information.
  * @param statistics The statistics instance to use.
  * @param stream CUDA stream to use for memory and kernel operations.

--- a/python/rapidsmpf/rapidsmpf/benchmarks/streaming_benchmark.py
+++ b/python/rapidsmpf/rapidsmpf/benchmarks/streaming_benchmark.py
@@ -172,7 +172,9 @@ def streaming_shuffle(
         # NOTE: This will require part_size amount of GPU memory.
         chunks: dict[int, PackedData] = {}
         for i in range(output_nparts):
-            chunks[i] = PackedData.from_cudf_packed_columns(pack(dummy_table))
+            chunks[i] = PackedData.from_cudf_packed_columns(
+                pack(dummy_table), DEFAULT_STREAM, br
+            )
 
         if p > 0 and insert_delay_ms > 0:
             time.sleep(insert_delay_ms / 1000)

--- a/python/rapidsmpf/rapidsmpf/buffer/packed_data.pxd
+++ b/python/rapidsmpf/rapidsmpf/buffer/packed_data.pxd
@@ -4,16 +4,22 @@
 from libc.stdint cimport uint8_t
 from libcpp.memory cimport unique_ptr
 from libcpp.vector cimport vector
+from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
+
+from rapidsmpf.buffer.resource cimport cpp_BufferResource
 
 
 cdef extern from "<rapidsmpf/buffer/packed_data.hpp>" nogil:
     cdef cppclass cpp_PackedData "rapidsmpf::PackedData":
-        unique_ptr[vector[uint8_t]] metadata
-        unique_ptr[device_buffer] gpu_data
+        cpp_PackedData(
+            unique_ptr[vector[uint8_t]] metadata,
+            unique_ptr[device_buffer] gpu_data,
+            cpp_BufferResource* br,
+            cuda_stream_view stream,
+        ) except +
 
-        cpp_PackedData(unique_ptr[vector[uint8_t]] metadata,
-                       unique_ptr[device_buffer] gpu_data)
+        cpp_PackedData() except +
 
 
 cdef class PackedData:

--- a/python/rapidsmpf/rapidsmpf/buffer/packed_data.pxd
+++ b/python/rapidsmpf/rapidsmpf/buffer/packed_data.pxd
@@ -15,8 +15,8 @@ cdef extern from "<rapidsmpf/buffer/packed_data.hpp>" nogil:
         cpp_PackedData(
             unique_ptr[vector[uint8_t]] metadata,
             unique_ptr[device_buffer] gpu_data,
-            cpp_BufferResource* br,
             cuda_stream_view stream,
+            cpp_BufferResource* br,
         ) except +
 
         cpp_PackedData() except +

--- a/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyi
+++ b/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyi
@@ -1,11 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
-
 from pylibcudf.contiguous_split import PackedColumns as CudfPackedColumns
+from rmm.pylibrmm.stream import Stream
+
+from rapidsmpf.buffer.resource import BufferResource
 
 class PackedData:
     def __init__(self) -> None: ...
     @classmethod
     def from_cudf_packed_columns(
-        cls, packed_columns: CudfPackedColumns
+        cls,
+        packed_columns: CudfPackedColumns,
+        stream: Stream,
+        br: BufferResource,
     ) -> PackedData: ...

--- a/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/buffer/packed_data.pyx
@@ -20,7 +20,7 @@ cdef class PackedData:
 
     @classmethod
     def from_cudf_packed_columns(
-        cls, PackedColumns packed_columns, BufferResource br, stream
+        cls, PackedColumns packed_columns, stream, BufferResource br
     ):
         """
         Constructs a PackedData from CudfPackedColumns by taking the ownership of the
@@ -42,8 +42,8 @@ cdef class PackedData:
         """
         if stream is None:
             raise ValueError("stream cannot be None")
-        cdef cpp_BufferResource* _br = br.ptr()
         cdef cuda_stream_view _stream = Stream(stream).view()
+        cdef cpp_BufferResource* _br = br.ptr()
         cdef PackedData ret = cls.__new__(cls)
         with nogil:
             if not (packed_columns.c_obj != NULL and
@@ -57,8 +57,8 @@ cdef class PackedData:
             ret.c_obj = make_unique[cpp_PackedData](
                 move(deref(packed_columns.c_obj).metadata),
                 move(deref(packed_columns.c_obj).gpu_data),
-                _br,
                 _stream,
+                _br,
             )
         return ret
 

--- a/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
@@ -166,6 +166,7 @@ def bulk_mpi_shuffle(
                 columns,
             )
     else:
+        br = BufferResource(rmm.mr.get_current_device_resource())
         progress_thread = ProgressThread(comm)
 
         shuffler = Shuffler(
@@ -190,8 +191,8 @@ def bulk_mpi_shuffle(
                 table,
                 columns_to_hash=columns_to_hash,
                 num_partitions=total_num_partitions,
+                br=br,
                 stream=DEFAULT_STREAM,
-                device_mr=rmm.mr.get_current_device_resource(),
             )
             shuffler.insert_chunks(packed_inputs)
 
@@ -204,8 +205,8 @@ def bulk_mpi_shuffle(
             partition_id = shuffler.wait_any()
             table = unpack_and_concat(
                 shuffler.extract(partition_id),
+                br=br,
                 stream=DEFAULT_STREAM,
-                device_mr=rmm.mr.get_current_device_resource(),
             )
             write_func(
                 table,

--- a/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
@@ -116,6 +116,7 @@ class BulkRayShufflerActor(BaseShufflingActor):
             buffer_resource=br,
             statistics=self.stats,
         )
+        self.br = br
 
     def cleanup(self) -> None:
         """Cleanup the UCXX communication and the shuffle operation."""
@@ -188,8 +189,8 @@ class BulkRayShufflerActor(BaseShufflingActor):
             table,
             columns_to_hash=columns_to_hash,
             num_partitions=self.total_nparts,
+            br=self.br,
             stream=DEFAULT_STREAM,
-            device_mr=rmm.mr.get_current_device_resource(),
         )
         self.shuffler.insert_chunks(packed_inputs)
 
@@ -233,8 +234,8 @@ class BulkRayShufflerActor(BaseShufflingActor):
             packed_chunks = self.shuffler.extract(partition_id)
             partition = unpack_and_concat(
                 packed_chunks,
+                br=self.br,
                 stream=DEFAULT_STREAM,
-                device_mr=rmm.mr.get_current_device_resource(),
             )
             yield partition_id, partition
 

--- a/python/rapidsmpf/rapidsmpf/examples/ray/ray_shuffle_example.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/ray_shuffle_example.py
@@ -12,6 +12,7 @@ import ray
 import cudf
 import rmm
 
+from rapidsmpf.buffer.resource import BufferResource
 from rapidsmpf.integrations.cudf.partition import (
     partition_and_pack,
     unpack_and_concat,
@@ -89,6 +90,7 @@ class ShufflingActor(BaseShufflingActor):
         column_names = list(df.columns)
 
         mr = rmm.mr.get_current_device_resource()  # use the current device resource
+        br = BufferResource(mr)
         stream = DEFAULT_STREAM  # use the default stream
 
         # Calculate the expected output partitions on all ranks
@@ -96,8 +98,8 @@ class ShufflingActor(BaseShufflingActor):
             partition_id: pylibcudf_to_cudf_dataframe(
                 unpack_and_concat(
                     [packed],
+                    br=br,
                     stream=stream,
-                    device_mr=mr,
                 ),
                 column_names=column_names,
             )
@@ -105,8 +107,8 @@ class ShufflingActor(BaseShufflingActor):
                 cudf_to_pylibcudf_table(df),
                 columns_to_hash=columns_to_hash,
                 num_partitions=self._total_nparts,
+                br=br,
                 stream=stream,
-                device_mr=mr,
             ).items()
         }
 
@@ -125,8 +127,8 @@ class ShufflingActor(BaseShufflingActor):
                 cudf_to_pylibcudf_table(local_df.iloc[i : i + self._batch_size]),
                 columns_to_hash=columns_to_hash,
                 num_partitions=self._total_nparts,
+                br=br,
                 stream=stream,
-                device_mr=mr,
             )
             shuffler.insert_chunks(packed_inputs)
 
@@ -140,8 +142,8 @@ class ShufflingActor(BaseShufflingActor):
             packed_chunks = shuffler.extract(partition_id)
             partition = unpack_and_concat(
                 packed_chunks,
+                br=br,
                 stream=stream,
-                device_mr=mr,
             )
             assert_eq(
                 pylibcudf_to_cudf_dataframe(partition, column_names=column_names),

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pxd
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pxd
@@ -5,17 +5,19 @@
 from pylibcudf.table cimport Table
 from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource
 
+from rapidsmpf.buffer.resource cimport BufferResource
+
 
 cpdef dict partition_and_pack(
     Table table,
     columns_to_hash,
     int num_partitions,
+    BufferResource br,
     stream,
-    DeviceMemoryResource device_mr,
 )
 
 cpdef Table unpack_and_concat(
     partitions,
+    BufferResource br,
     stream,
-    DeviceMemoryResource device_mr,
 )

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pxd
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pxd
@@ -12,12 +12,12 @@ cpdef dict partition_and_pack(
     Table table,
     columns_to_hash,
     int num_partitions,
-    BufferResource br,
     stream,
+    BufferResource br,
 )
 
 cpdef Table unpack_and_concat(
     partitions,
-    BufferResource br,
     stream,
+    BufferResource br,
 )

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
@@ -14,17 +14,17 @@ def partition_and_pack(
     table: Table,
     columns_to_hash: Iterable[int],
     num_partitions: int,
-    br: BufferResource,
     stream: Stream,
+    br: BufferResource,
 ) -> dict[int, PackedData]: ...
 def split_and_pack(
     table: Table,
     splits: Iterable[int],
-    br: BufferResource,
     stream: Stream,
+    br: BufferResource,
 ) -> dict[int, PackedData]: ...
 def unpack_and_concat(
     partitions: Iterable[PackedData],
-    br: BufferResource,
     stream: Stream,
+    br: BufferResource,
 ) -> Table: ...

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
@@ -5,26 +5,26 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from pylibcudf.table import Table
-from rmm.pylibrmm.memory_resource import DeviceMemoryResource
 from rmm.pylibrmm.stream import Stream
 
 from rapidsmpf.buffer.packed_data import PackedData
+from rapidsmpf.buffer.resource import BufferResource
 
 def partition_and_pack(
     table: Table,
     columns_to_hash: Iterable[int],
     num_partitions: int,
+    br: BufferResource,
     stream: Stream,
-    device_mr: DeviceMemoryResource,
 ) -> dict[int, PackedData]: ...
 def split_and_pack(
     table: Table,
     splits: Iterable[int],
+    br: BufferResource,
     stream: Stream,
-    device_mr: DeviceMemoryResource,
 ) -> dict[int, PackedData]: ...
 def unpack_and_concat(
     partitions: Iterable[PackedData],
+    br: BufferResource,
     stream: Stream,
-    device_mr: DeviceMemoryResource,
 ) -> Table: ...

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyx
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyx
@@ -64,8 +64,8 @@ cpdef dict partition_and_pack(
         The number of partitions to create.
     stream
         The CUDA stream used for memory operations.
-    device_mr
-        Reference to the RMM device memory resource used for device allocations.
+    br
+        Buffer resource for gpu data allocations.
 
     Returns
     -------
@@ -129,8 +129,8 @@ cpdef dict split_and_pack(
         the number of result partitions.
     stream
         The CUDA stream used for memory operations.
-    device_mr
-        Reference to the RMM device memory resource used for device allocations.
+    br
+        Buffer resource for gpu data allocations.
 
     Returns
     -------
@@ -194,8 +194,8 @@ cpdef Table unpack_and_concat(
         The packed input tables to unpack and concatenate.
     stream
         The CUDA stream used for memory operations.
-    device_mr
-        Reference to the RMM device memory resource used for device allocations.
+    br
+        Buffer resource for gpu data allocations.
 
     Returns
     -------

--- a/python/rapidsmpf/rapidsmpf/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/shuffler.pyx
@@ -234,9 +234,7 @@ cdef class Shuffler:
         for i in range(_ret.size()):
             ret.append(
                 PackedData.from_librapidsmpf(
-                    make_unique[cpp_PackedData](
-                        move(_ret.at(i).metadata), move(_ret.at(i).gpu_data)
-                    )
+                    make_unique[cpp_PackedData](move(_ret[i]))
                 )
             )
         return ret


### PR DESCRIPTION
The gpu data of `PackedData` is now a `Buffer`, which can both host or device memory.

This means that we don't have to _unspill_ gpu data before inserting it into the shuffler. But for now, `Shuffler::extract()` unspill the buffer so consumers like `unpack_and_concat()` doesn't have to provide a memory reservation.

The shuffler and the partitioning functions how takes a `BufferResource` instead of a memory resource. 