### PR TITLE
Prevent chunk ID overwrite on reception

### DIFF
--- a/cpp/include/rapidsmpf/shuffler/chunk.hpp
+++ b/cpp/include/rapidsmpf/shuffler/chunk.hpp
@@ -330,15 +330,17 @@ class Chunk {
     /**
      * @brief Concatenate multiple chunks into a single chunk.
      *
-     * @param chunks Vector of chunks to concatenate. The chunks will be moved from this
-     * vector.
+     * @param chunks Vector of chunks to concatenate.
      * @param chunk_id The ID for the resulting concatenated chunk.
      * @param stream The CUDA stream to use for copying data.
      * @param br The buffer resource to use for memory allocation.
      * @param preferred_mem_type The preferred memory type to use for the concatenated
      * data buffer.
      * @return Chunk The concatenated chunk.
-     * @throws std::logic_error if the input vector is empty.
+     * @throws std::logic_error if the input vector is empty or the concatenated chunk
+     * contains duplicate partition IDs.
+     *
+     * @note The chunks vector should contain unique partition IDs.
      */
     static Chunk concat(
         std::vector<Chunk>&& chunks,
@@ -362,7 +364,8 @@ class Chunk {
 
     ChunkID const chunk_id_;  ///< The ID of the chunk.
     std::vector<PartID> const
-        part_ids_;  ///< The partition IDs of the messages in the chunk.
+        part_ids_;  ///< The partition IDs of the messages in the
+                    ///< chunk. These partition IDs should be unique.
     std::vector<size_t> const expected_num_chunks_;  ///< The expected number of chunks of
                                                      ///< the messages in the chunk.
     std::vector<uint32_t> const

--- a/cpp/src/shuffler/chunk.cpp
+++ b/cpp/src/shuffler/chunk.cpp
@@ -192,6 +192,18 @@ bool Chunk::validate_format(std::vector<uint8_t> const& serialized_buf) {
         return false;
     }
 
+    // Check if the partition IDs are unique
+    std::unordered_set<PartID> seen_pids;
+    seen_pids.reserve(n);
+    auto const* pids = serialized_buf.data() + sizeof(ChunkID) + sizeof(size_t);
+    for (size_t i = 0; i < n; ++i) {
+        PartID pid;
+        std::memcpy(&pid, pids + i * sizeof(PartID), sizeof(PartID));
+        if (!seen_pids.emplace(pid).second) {
+            return false;
+        }
+    }
+
     // For each message, validate the metadata and data sizes
     uint8_t const* meta_offsets_start =
         serialized_buf.data()
@@ -307,9 +319,26 @@ Chunk Chunk::concat(
     uint64_t curr_data_offset = 0;
     size_t curr_msg_offset = 0;
 
+    // Check that the partition IDs are unique (incrementally checking each chunk using
+    // the lambda)
+    std::unordered_set<PartID> seen_pids;
+    seen_pids.reserve(total_messages);
+    auto check_pids_unique = [&](auto const& chunk) {
+        for (auto const& pid : chunk.part_ids_) {
+            RAPIDSMPF_EXPECTS(
+                seen_pids.emplace(pid).second,
+                "Duplicate partition ID " + std::to_string(pid) + " in chunk "
+                    + std::to_string(chunk.chunk_id())
+            );
+        }
+    };
+
     // Process each chunk
     for (auto& chunk : chunks) {
         size_t chunk_messages = chunk.n_messages();
+
+        check_pids_unique(chunk);
+
         // Copy partition IDs and expected number of chunks
         std::memcpy(
             part_ids.data() + curr_msg_offset,

--- a/cpp/src/shuffler/postbox.cpp
+++ b/cpp/src/shuffler/postbox.cpp
@@ -23,8 +23,10 @@ void PostBox<KeyType>::insert(Chunk&& chunk) {
         );
     }
     std::lock_guard const lock(mutex_);
-    auto [_, inserted] = pigeonhole_[key].insert({chunk.chunk_id(), std::move(chunk)});
-    RAPIDSMPF_EXPECTS(inserted, "PostBox.insert(): chunk already exist");
+    RAPIDSMPF_EXPECTS(
+        pigeonhole_[key].emplace(chunk.chunk_id(), std::move(chunk)).second,
+        "PostBox.insert(): chunk already exist"
+    );
 }
 
 template <typename KeyType>

--- a/cpp/tests/test_chunk.cpp
+++ b/cpp/tests/test_chunk.cpp
@@ -221,7 +221,10 @@ TEST_F(ChunkTest, ChunkConcatPackedData) {
 }
 
 std::tuple<Chunk, std::vector<uint8_t>, std::vector<uint8_t>, size_t> make_mixed_chunk(
-    ChunkID chunk_id, rmm::cuda_stream_view stream, BufferResource* br
+    ChunkID chunk_id,
+    rmm::cuda_stream_view stream,
+    BufferResource* br,
+    PartID part_id_offset = 0
 ) {
     std::vector<Chunk> chunks;
 
@@ -230,11 +233,13 @@ std::tuple<Chunk, std::vector<uint8_t>, std::vector<uint8_t>, size_t> make_mixed
     std::vector<uint8_t> data{6, 7, 8, 9, 10};
 
     // Create chunks with mixed message types
-    chunks.push_back(Chunk::from_finished_partition(0, 1, 10));  // control message
+    chunks.push_back(
+        Chunk::from_finished_partition(0, 1 + part_id_offset, 10)
+    );  // control message
     chunks.push_back(
         Chunk::from_packed_data(
             0,
-            2,
+            2 + part_id_offset,
             create_packed_data({metadata.data(), 3}, {data.data(), 3}, stream),
             nullptr,
             stream,
@@ -244,18 +249,20 @@ std::tuple<Chunk, std::vector<uint8_t>, std::vector<uint8_t>, size_t> make_mixed
     chunks.push_back(
         Chunk::from_packed_data(
             0,
-            3,
+            3 + part_id_offset,
             create_packed_data({metadata.data() + 5, 0}, {data.data() + 5, 0}, stream),
             nullptr,
             stream,
             br
         )
     );  // empty packed data - non-null
-    chunks.push_back(Chunk::from_finished_partition(0, 4, 20));  // control message
+    chunks.push_back(
+        Chunk::from_finished_partition(0, 4 + part_id_offset, 20)
+    );  // control message
     chunks.push_back(
         Chunk::from_packed_data(
             0,
-            5,
+            5 + part_id_offset,
             create_packed_data({metadata.data() + 3, 2}, {data.data() + 3, 2}, stream),
             nullptr,
             stream,
@@ -265,7 +272,7 @@ std::tuple<Chunk, std::vector<uint8_t>, std::vector<uint8_t>, size_t> make_mixed
     chunks.push_back(
         Chunk::from_packed_data(
             0,
-            6,
+            6 + part_id_offset,
             create_packed_data(
                 {metadata.begin() + 5, metadata.end()}, {data.data(), 0}, stream
             ),
@@ -341,7 +348,7 @@ TEST_F(ChunkTest, ChunkConcatMixedMessagesMultiple) {
     auto [concat_chunk1, metadata1, data1, count1] =
         make_mixed_chunk(0, stream, br.get());
     auto [concat_chunk2, metadata2, data2, count2] =
-        make_mixed_chunk(1, stream, br.get());
+        make_mixed_chunk(1, stream, br.get(), static_cast<PartID>(count1));
 
     std::vector<Chunk> chunks;
     chunks.push_back(std::move(concat_chunk1));


### PR DESCRIPTION
Currently, there is a harmless bug on the receive path, where we overwrite the chunk ID of a received chunk at the destination rank. This happens when we create a chunk copy from a received multi-message chunk (we pass `get_new_cid()` as the new chunk ID, which generates a unique incremental chunk ID at the destination). 

This masks the chunk origin rank information. It is not an issue currently because we dont use chunk values, other than using it for uniqueness validation. But we would need origin information to order chunks in the Allgather operation. 

This PR guarantees that Partition IDs are unique within a multi-message chunk, and reuses the incoming chunk ID for the copies. The rationale is, ready postbox uniquely identifies chunks by their `[partition ID, chunk ID]` pair. We can reuse the same chunk ID because the partition IDs are unique.
