### PR TITLE
Shuffle.extract(): don't unspill extracted partitions

### DIFF
--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -240,7 +240,12 @@ rapidsmpf::Duration do_run(
             auto packed_chunks = shuffler.extract(finished_partition);
             output_partitions.emplace_back(
                 rapidsmpf::unpack_and_concat(
-                    std::move(packed_chunks), stream, br, statistics
+                    rapidsmpf::unspill_partitions(
+                        std::move(packed_chunks), stream, br, true, statistics
+                    ),
+                    stream,
+                    br,
+                    statistics
                 )
             );
         }

--- a/cpp/examples/example_shuffle.cpp
+++ b/cpp/examples/example_shuffle.cpp
@@ -117,7 +117,13 @@ int main(int argc, char** argv) {
         // Unpack (deserialize) and concatenate the chunks into a single table using a
         // convenience function.
         local_outputs.push_back(
-            rapidsmpf::unpack_and_concat(std::move(packed_chunks), stream, &br)
+            rapidsmpf::unpack_and_concat(
+                rapidsmpf::unspill_partitions(
+                    std::move(packed_chunks), stream, &br, true
+                ),
+                stream,
+                &br
+            )
         );
     }
     // At this point, `local_outputs` contains the local result of the shuffle.

--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -325,7 +325,7 @@ class Buffer {
         if (auto ref = std::get_if<DeviceStorageT>(&storage_)) {
             return *ref;
         } else {
-            RAPIDSMPF_FAIL("Buffer is not host memory");
+            RAPIDSMPF_FAIL("Buffer is not device memory");
         }
     }
 

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -150,13 +150,17 @@ partition_and_split(
  * @param partitions The partitions to spill.
  * @param stream CUDA stream used for memory operations.
  * @param br Buffer resource used to reserve host memory and perform the move.
+ * @param statistics The statistics instance to use (disabled by default).
  *
  * @return A vector of `PackedData`, where each buffer resides in host memory.
  *
  * @throws std::overflow_error If host memory reservation fails.
  */
 std::vector<PackedData> spill_partitions(
-    std::vector<PackedData>&& partitions, rmm::cuda_stream_view stream, BufferResource* br
+    std::vector<PackedData>&& partitions,
+    rmm::cuda_stream_view stream,
+    BufferResource* br,
+    std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
 /**
@@ -176,6 +180,7 @@ std::vector<PackedData> spill_partitions(
  * @param br Buffer resource responsible for memory reservation and spills.
  * @param allow_overbooking If false, ensures enough memory is freed to satisfy the
  * reservation; otherwise, allows overbooking even if spilling was insufficient.
+ * @param statistics The statistics instance to use (disabled by default).
  *
  * @return A vector of `PackedData`, each with a buffer in device memory.
  *
@@ -186,7 +191,8 @@ std::vector<PackedData> unspill_partitions(
     std::vector<PackedData>&& partitions,
     rmm::cuda_stream_view stream,
     BufferResource* br,
-    bool allow_overbooking
+    bool allow_overbooking,
+    std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
 
 }  // namespace rapidsmpf

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -159,7 +159,11 @@ void test_shuffler(
     while (!shuffler.finished()) {
         auto finished_partition = shuffler.wait_any(wait_timeout);
         auto packed_chunks = shuffler.extract(finished_partition);
-        auto result = rapidsmpf::unpack_and_concat(std::move(packed_chunks), stream, br);
+        auto result = rapidsmpf::unpack_and_concat(
+            rapidsmpf::unspill_partitions(std::move(packed_chunks), stream, br, true),
+            stream,
+            br
+        );
 
         // We should only receive the partitions assigned to this rank.
         EXPECT_EQ(shuffler.partition_owner(comm, finished_partition), comm->rank());

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -734,7 +734,8 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
 
     {
         // Now extract triggers spilling of the partition not being extracted.
-        std::vector<rapidsmpf::PackedData> output_chunks = shuffler.extract(0);
+        std::vector<rapidsmpf::PackedData> output_chunks =
+            rapidsmpf::unspill_partitions(shuffler.extract(0), stream, &br, true);
         EXPECT_EQ(mr.get_main_record().num_current_allocs(), 1);
 
         // And insert also triggers spilling. We end up with zero device allocations.

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -745,9 +745,11 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
     }
 
     // Extract and unspill both partitions.
-    std::vector<rapidsmpf::PackedData> out0 = shuffler.extract(0);
+    std::vector<rapidsmpf::PackedData> out0 =
+        rapidsmpf::unspill_partitions(shuffler.extract(0), stream, &br, true);
     EXPECT_EQ(mr.get_main_record().num_current_allocs(), 1);
-    std::vector<rapidsmpf::PackedData> out1 = shuffler.extract(1);
+    std::vector<rapidsmpf::PackedData> out1 =
+        rapidsmpf::unspill_partitions(shuffler.extract(1), stream, &br, true);
     EXPECT_EQ(mr.get_main_record().num_current_allocs(), 2);
 
     // Disable spilling and insert the first partition.

--- a/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
@@ -23,6 +23,7 @@ from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.integrations.cudf.partition import (
     partition_and_pack,
     unpack_and_concat,
+    unspill_partitions,
 )
 from rapidsmpf.progress_thread import ProgressThread
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
@@ -204,7 +205,12 @@ def bulk_mpi_shuffle(
         while not shuffler.finished():
             partition_id = shuffler.wait_any()
             table = unpack_and_concat(
-                shuffler.extract(partition_id),
+                unspill_partitions(
+                    shuffler.extract(partition_id),
+                    stream=DEFAULT_STREAM,
+                    br=br,
+                    allow_overbooking=True,
+                ),
                 br=br,
                 stream=DEFAULT_STREAM,
             )

--- a/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
@@ -210,6 +210,7 @@ def bulk_mpi_shuffle(
                     stream=DEFAULT_STREAM,
                     br=br,
                     allow_overbooking=True,
+                    statistics=statistics,
                 ),
                 br=br,
                 stream=DEFAULT_STREAM,

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -20,6 +20,7 @@ from rapidsmpf.integrations.cudf.partition import (
     partition_and_pack,
     split_and_pack,
     unpack_and_concat,
+    unspill_partitions,
 )
 from rapidsmpf.testing import pylibcudf_to_cudf_dataframe
 
@@ -136,7 +137,12 @@ class DaskCudfIntegration:
         column_names = options["column_names"]
         shuffler.wait_on(partition_id)
         table = unpack_and_concat(
-            shuffler.extract(partition_id),
+            unspill_partitions(
+                shuffler.extract(partition_id),
+                stream=DEFAULT_STREAM,
+                br=ctx.br,
+                allow_overbooking=True,
+            ),
             br=ctx.br,
             stream=DEFAULT_STREAM,
         )

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -142,6 +142,7 @@ class DaskCudfIntegration:
                 stream=DEFAULT_STREAM,
                 br=ctx.br,
                 allow_overbooking=True,
+                statistics=ctx.statistics,
             ),
             br=ctx.br,
             stream=DEFAULT_STREAM,

--- a/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
@@ -239,6 +239,7 @@ class BulkRayShufflerActor(BaseShufflingActor):
                     stream=DEFAULT_STREAM,
                     br=self.br,
                     allow_overbooking=True,
+                    statistics=self.stats,
                 ),
                 br=self.br,
                 stream=DEFAULT_STREAM,

--- a/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
@@ -20,6 +20,7 @@ from rapidsmpf.buffer.resource import BufferResource, LimitAvailableMemory
 from rapidsmpf.integrations.cudf.partition import (
     partition_and_pack,
     unpack_and_concat,
+    unspill_partitions,
 )
 from rapidsmpf.integrations.ray import setup_ray_ucxx_cluster
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
@@ -233,7 +234,12 @@ class BulkRayShufflerActor(BaseShufflingActor):
             partition_id = self.shuffler.wait_any()
             packed_chunks = self.shuffler.extract(partition_id)
             partition = unpack_and_concat(
-                packed_chunks,
+                unspill_partitions(
+                    packed_chunks,
+                    stream=DEFAULT_STREAM,
+                    br=self.br,
+                    allow_overbooking=True,
+                ),
                 br=self.br,
                 stream=DEFAULT_STREAM,
             )

--- a/python/rapidsmpf/rapidsmpf/examples/ray/ray_shuffle_example.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/ray_shuffle_example.py
@@ -16,6 +16,7 @@ from rapidsmpf.buffer.resource import BufferResource
 from rapidsmpf.integrations.cudf.partition import (
     partition_and_pack,
     unpack_and_concat,
+    unspill_partitions,
 )
 from rapidsmpf.integrations.ray import setup_ray_ucxx_cluster
 from rapidsmpf.testing import assert_eq
@@ -141,7 +142,9 @@ class ShufflingActor(BaseShufflingActor):
             partition_id = shuffler.wait_any()
             packed_chunks = shuffler.extract(partition_id)
             partition = unpack_and_concat(
-                packed_chunks,
+                unspill_partitions(
+                    packed_chunks, stream=stream, br=br, allow_overbooking=True
+                ),
                 br=br,
                 stream=stream,
             )

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pxd
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pxd
@@ -7,6 +7,7 @@ from pylibcudf.table cimport Table
 from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource
 
 from rapidsmpf.buffer.resource cimport BufferResource
+from rapidsmpf.statistics cimport Statistics
 
 
 cpdef dict partition_and_pack(
@@ -27,6 +28,7 @@ cpdef list spill_partitions(
     partitions,
     stream,
     BufferResource br,
+    Statistics statistics = *,
 )
 
 cpdef list unspill_partitions(
@@ -34,4 +36,5 @@ cpdef list unspill_partitions(
     stream,
     BufferResource br,
     bool_t allow_overbooking,
+    Statistics statistics = *,
 )

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
@@ -30,11 +30,13 @@ def unpack_and_concat(
 ) -> Table: ...
 def spill_partitions(
     partitions: Iterable[PackedData],
+    *,
     stream: Stream,
     br: BufferResource,
 ) -> list[PackedData]: ...
 def unspill_partitions(
     partitions: Iterable[PackedData],
+    *,
     stream: Stream,
     br: BufferResource,
     allow_overbooking: bool,

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
@@ -9,6 +9,7 @@ from rmm.pylibrmm.stream import Stream
 
 from rapidsmpf.buffer.packed_data import PackedData
 from rapidsmpf.buffer.resource import BufferResource
+from rapidsmpf.statistics import Statistics
 
 def partition_and_pack(
     table: Table,
@@ -33,6 +34,7 @@ def spill_partitions(
     *,
     stream: Stream,
     br: BufferResource,
+    statistics: Statistics | None = None,
 ) -> list[PackedData]: ...
 def unspill_partitions(
     partitions: Iterable[PackedData],
@@ -40,4 +42,5 @@ def unspill_partitions(
     stream: Stream,
     br: BufferResource,
     allow_overbooking: bool,
+    statistics: Statistics | None = None,
 ) -> list[PackedData]: ...

--- a/python/rapidsmpf/rapidsmpf/tests/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_shuffler.py
@@ -15,6 +15,7 @@ from rapidsmpf.buffer.resource import BufferResource
 from rapidsmpf.integrations.cudf.partition import (
     partition_and_pack,
     unpack_and_concat,
+    unspill_partitions,
 )
 from rapidsmpf.progress_thread import ProgressThread
 from rapidsmpf.shuffler import (
@@ -88,7 +89,9 @@ def test_shuffler_single_nonempty_partition(
             my_partitions.remove(partition_id)
         packed_chunks = shuffler.extract(partition_id)
         partition = unpack_and_concat(
-            packed_chunks,
+            unspill_partitions(
+                packed_chunks, stream=DEFAULT_STREAM, br=br, allow_overbooking=True
+            ),
             br=br,
             stream=DEFAULT_STREAM,
         )
@@ -193,7 +196,9 @@ def test_shuffler_uniform(
         partition_id = shuffler.wait_any()
         packed_chunks = shuffler.extract(partition_id)
         partition = unpack_and_concat(
-            packed_chunks,
+            unspill_partitions(
+                packed_chunks, stream=DEFAULT_STREAM, br=br, allow_overbooking=True
+            ),
             br=br,
             stream=DEFAULT_STREAM,
         )


### PR DESCRIPTION
Instead of implicit unspilling, use `unspill_partitions()`.