### PR TITLE
Refactor worker context initialisation for dask integration

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import threading
 import weakref
+from functools import partial
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar
 
@@ -97,10 +98,10 @@ class WorkerContext:
         The progress thread used by the worker.
     comm
         The communicator connected to all other workers.
-    spill_collection
-        A collection of Python objects that can be spilled to free up device memory.
     statistics
         The statistics used by the worker. If None, statistics is disabled.
+    spill_collection
+        A collection of Python objects that can be spilled to free up device memory.
     shufflers
         A mapping from shuffler IDs to active shuffler instances.
     options
@@ -108,11 +109,11 @@ class WorkerContext:
     """
 
     lock: ClassVar[threading.RLock] = threading.RLock()
-    br: BufferResource | None = None
-    progress_thread: ProgressThread | None = None
-    comm: Communicator | None = None
+    br: BufferResource
+    progress_thread: ProgressThread
+    comm: Communicator
+    statistics: Statistics
     spill_collection: SpillCollection = field(default_factory=SpillCollection)
-    statistics: Statistics | None = None
     shufflers: dict[int, Shuffler] = field(default_factory=dict)
     options: Options = field(default_factory=Options)
 
@@ -148,6 +149,7 @@ class ShufflerIntegration(Protocol[DataFrameT]):
             Other data needed for partitioning. For example,
             this may be boundary values needed for sorting.
         """
+        ...
 
     @staticmethod
     def extract_partition(
@@ -171,6 +173,7 @@ class ShufflerIntegration(Protocol[DataFrameT]):
         -------
         A shuffled DataFrame partition.
         """
+        ...
 
 
 def get_shuffler(
@@ -334,136 +337,160 @@ def extract_partition(
                     del ctx.shufflers[shuffle_id]
 
 
+# Create a spill function that spills the python objects in the spill-
+# collection. This way, we have a central place (the worker) to track
+# and trigger spilling of python objects.
+def spill_func(
+    amount: int,
+    *,
+    staging_buffer: rmm.DeviceBuffer | None,
+    lock: threading.Lock,
+    mr: rmm.mr.DeviceMemoryResource,
+    ctx: WorkerContext,
+) -> int:
+    """
+    Spill a specified amount of data from the Python object spill collection.
+
+    This function attempts to use a preallocated staging device buffer to
+    spill Python objects from the spill collection. If the staging buffer
+    is currently in use, it will fall back to spilling without it.
+
+    Parameters
+    ----------
+    amount
+        The amount of data to spill, in bytes.
+    staging_buffer
+        Optional buffer to stage data through.
+    lock
+        Lock to protect access.
+    mr
+        Memory resource for device allocations.
+    ctx
+        The worker context to spill from.
+
+    Returns
+    -------
+    The actual amount of data spilled, in bytes.
+    """
+    if staging_buffer is not None and lock.acquire(blocking=False):
+        try:
+            return ctx.spill_collection.spill(
+                amount,
+                stream=DEFAULT_STREAM,
+                device_mr=mr,
+                staging_device_buffer=staging_buffer,
+            )
+        finally:
+            lock.release()
+    return ctx.spill_collection.spill(amount, stream=DEFAULT_STREAM, device_mr=mr)
+
+
 def rmpf_worker_setup(
-    get_context: Callable[..., WorkerContext],
     worker: Any,
     option_prefix: str,
     *,
+    comm: Communicator,
     options: Options,
-) -> None:
+) -> WorkerContext:
     """
     Attach RapidsMPF shuffling attributes to a worker process.
 
     Parameters
     ----------
-    get_context
-        Callable function to fetch the worker context.
     worker
         The current worker process.
     option_prefix
         Prefix for config-option names.
+    comm
+        Communicator for shufflers.
     options
         Configuration options.
+
+    Returns
+    -------
+    WorkerContext
+        New worker context set up for shuffling.
 
     Warnings
     --------
     This function creates a new RMM memory pool, and
     sets it as the current device resource.
     """
-    ctx = get_context(worker)
-    with ctx.lock:
-        ctx.options = options
-
-        # Insert RMM resource adaptor on top of the current RMM resource stack.
-        mr = RmmResourceAdaptor(
-            upstream_mr=rmm.mr.get_current_device_resource(),
-            fallback_mr=(
-                # Use a managed memory resource if OOM protection is enabled.
-                rmm.mr.ManagedMemoryResource()
-                if ctx.options.get_or_default(
-                    f"{option_prefix}oom_protection", default_value=False
-                )
-                else None
-            ),
-        )
-        rmm.mr.set_current_device_resource(mr)
-
-        # Print statistics at worker shutdown.
-        if ctx.options.get_or_default(
-            f"{option_prefix}statistics", default_value=False
-        ):
-            ctx.statistics = Statistics(enable=True, mr=mr)
-            weakref.finalize(
-                worker,
-                lambda name, stats: print(name, stats.report()),
-                name=str(worker),
-                stats=ctx.statistics,
+    # Insert RMM resource adaptor on top of the current RMM resource stack.
+    mr = RmmResourceAdaptor(
+        upstream_mr=rmm.mr.get_current_device_resource(),
+        fallback_mr=(
+            # Use a managed memory resource if OOM protection is enabled.
+            rmm.mr.ManagedMemoryResource()
+            if options.get_or_default(
+                f"{option_prefix}oom_protection", default_value=False
             )
+            else None
+        ),
+    )
+    rmm.mr.set_current_device_resource(mr)
 
-        assert ctx.comm is not None
-        ctx.progress_thread = ProgressThread(ctx.comm, ctx.statistics)
-
-        # Create a buffer resource with a limiting availability function.
-        total_memory = rmm.mr.available_device_memory()[1]
-        spill_device = ctx.options.get_or_default(
-            f"{option_prefix}spill_device", default_value=0.50
-        )
-        memory_available = {
-            MemoryType.DEVICE: LimitAvailableMemory(
-                mr, limit=int(total_memory * spill_device)
-            )
-        }
-        ctx.br = BufferResource(
-            mr,
-            memory_available=memory_available,
-            periodic_spill_check=ctx.options.get_or_default(
-                f"{option_prefix}periodic_spill_check", default_value=Optional(1e-3)
-            ).value,
+    # Print statistics at worker shutdown.
+    if options.get_or_default(f"{option_prefix}statistics", default_value=False):
+        statistics = Statistics(enable=True, mr=mr)
+        weakref.finalize(
+            worker,
+            lambda name, stats: print(name, stats.report()),
+            name=str(worker),
+            stats=statistics,
         )
 
-        # If enabled, create a staging device buffer for the spilling to reduce
-        # device memory pressure.
-        # TODO: maybe have a pool of staging buffers?
-        spill_staging_buffer_size = ctx.options.get_or_default(
-            f"{option_prefix}staging_spill_buffer",
-            default_value=OptionalBytes("128 MiB"),
-        ).value
-        spill_staging_buffer = (
-            None
-            if spill_staging_buffer_size is None
-            else rmm.DeviceBuffer(
-                size=spill_staging_buffer_size, stream=DEFAULT_STREAM, mr=mr
-            )
+    # Create a buffer resource with a limiting availability function.
+    total_memory = rmm.mr.available_device_memory()[1]
+    spill_device = options.get_or_default(
+        f"{option_prefix}spill_device", default_value=0.50
+    )
+    memory_available = {
+        MemoryType.DEVICE: LimitAvailableMemory(
+            mr, limit=int(total_memory * spill_device)
         )
-        spill_staging_buffer_lock = threading.Lock()
+    }
+    br = BufferResource(
+        mr,
+        memory_available=memory_available,
+        periodic_spill_check=options.get_or_default(
+            f"{option_prefix}periodic_spill_check", default_value=Optional(1e-3)
+        ).value,
+    )
 
-        # Create a spill function that spills the python objects in the spill-
-        # collection. This way, we have a central place (the worker) to track
-        # and trigger spilling of python objects.
-        def spill_func(amount: int) -> int:
-            """
-            Spill a specified amount of data from the Python object spill collection.
+    # If enabled, create a staging device buffer for the spilling to reduce
+    # device memory pressure.
+    # TODO: maybe have a pool of staging buffers?
+    spill_staging_buffer_size = options.get_or_default(
+        f"{option_prefix}staging_spill_buffer",
+        default_value=OptionalBytes("128 MiB"),
+    ).value
+    spill_staging_buffer = (
+        None
+        if spill_staging_buffer_size is None
+        else rmm.DeviceBuffer(
+            size=spill_staging_buffer_size, stream=DEFAULT_STREAM, mr=mr
+        )
+    )
+    ctx = WorkerContext(
+        br=br,
+        progress_thread=ProgressThread(comm, statistics),
+        comm=comm,
+        statistics=statistics,
+        options=options,
+    )
 
-            This function attempts to use a preallocated staging device buffer to
-            spill Python objects from the spill collection. If the staging buffer
-            is currently in use, it will fall back to spilling without it.
-
-            Parameters
-            ----------
-            amount
-                The amount of data to spill, in bytes.
-
-            Returns
-            -------
-            The actual amount of data spilled, in bytes.
-            """
-            if spill_staging_buffer is not None and spill_staging_buffer_lock.acquire(
-                blocking=False
-            ):
-                try:
-                    return ctx.spill_collection.spill(
-                        amount,
-                        stream=DEFAULT_STREAM,
-                        device_mr=mr,
-                        staging_device_buffer=spill_staging_buffer,
-                    )
-                finally:
-                    spill_staging_buffer_lock.release()
-            return ctx.spill_collection.spill(
-                amount, stream=DEFAULT_STREAM, device_mr=mr
-            )
-
-        # Add the spill function using a negative priority (-10) such that spilling
-        # of internal shuffle buffers (non-python objects) have higher priority than
-        # spilling of the Python objects in the collection.
-        ctx.br.spill_manager.add_spill_function(func=spill_func, priority=-10)
+    # Add the spill function using a negative priority (-10) such that spilling
+    # of internal shuffle buffers (non-python objects) have higher priority than
+    # spilling of the Python objects in the collection.
+    br.spill_manager.add_spill_function(
+        func=partial(
+            spill_func,
+            staging_buffer=spill_staging_buffer,
+            lock=threading.Lock(),
+            mr=mr,
+            ctx=ctx,
+        ),
+        priority=-10,
+    )
+    return ctx

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import threading
 import weakref
-from functools import partial
 from dataclasses import dataclass, field
+from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar
 
 import rmm.mr

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
@@ -50,7 +50,7 @@ def get_worker_context(
     """
     with WorkerContext.lock:
         worker = worker or get_worker()
-        return worker._rapidsmpf_worker_context
+        return worker._rapidsmpf_worker_context  # type: ignore[no-any-return]
 
 
 def get_dask_worker_rank(dask_worker: distributed.Worker | None = None) -> int:

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import ucxx._lib.libucxx as ucx_api
 from distributed import get_client, get_worker, wait
@@ -50,9 +50,7 @@ def get_worker_context(
     """
     with WorkerContext.lock:
         worker = worker or get_worker()
-        if not hasattr(worker, "_rapidsmpf_worker_context"):
-            worker._rapidsmpf_worker_context = WorkerContext()
-        return cast("WorkerContext", worker._rapidsmpf_worker_context)
+        return worker._rapidsmpf_worker_context
 
 
 def get_dask_worker_rank(dask_worker: distributed.Worker | None = None) -> int:
@@ -111,10 +109,12 @@ async def rapidsmpf_ucxx_rank_setup_root(n_ranks: int, options: Options) -> byte
     bytes
         The UCXX address of the root node.
     """
-    ctx = get_worker_context()
-    ctx.comm = new_communicator(n_ranks, None, None, options)
-    ctx.comm.logger.trace(f"Rank {ctx.comm.rank} created")
-    return get_root_ucxx_address(ctx.comm)
+    with WorkerContext.lock:
+        worker = get_worker()
+        comm = new_communicator(n_ranks, None, None, options)
+        worker._rapidsmpf_comm = comm
+        comm.logger.trace(f"Rank {comm.rank} created")
+        return get_root_ucxx_address(comm)
 
 
 async def rapidsmpf_ucxx_rank_setup_node(
@@ -132,15 +132,18 @@ async def rapidsmpf_ucxx_rank_setup_node(
     options
         Configuration options.
     """
-    ctx = get_worker_context()
-    if ctx.comm is None:
-        root_address = ucx_api.UCXAddress.create_from_buffer(root_address_bytes)
-        ctx.comm = new_communicator(n_ranks, None, root_address, options)
-        ctx.comm.logger.trace(f"Rank {ctx.comm.rank} created")
-
-    ctx.comm.logger.trace(f"Rank {ctx.comm.rank} setup barrier")
-    barrier(ctx.comm)
-    ctx.comm.logger.trace(f"Rank {ctx.comm.rank} setup barrier passed")
+    with WorkerContext.lock:
+        worker = get_worker()
+        if not hasattr(worker, "_rapidsmpf_comm"):
+            # Not the root rank
+            root_address = ucx_api.UCXAddress.create_from_buffer(root_address_bytes)
+            comm = new_communicator(n_ranks, None, root_address, options)
+            worker._rapidsmpf_comm = comm
+            comm.logger.trace(f"Rank {comm.rank} created")
+        comm = worker._rapidsmpf_comm
+        comm.logger.trace(f"Rank {comm.rank} setup barrier")
+        barrier(comm)
+        comm.logger.trace(f"Rank {comm.rank} setup barrier passed")
 
 
 def dask_worker_setup(
@@ -172,12 +175,18 @@ def dask_worker_setup(
     -----
     This function is expected to run on a Dask worker.
     """
-    rmpf_worker_setup(
-        get_worker_context,
-        dask_worker,
-        "dask_",
-        options=options,
-    )
+    try:
+        comm = dask_worker._rapidsmpf_comm
+    except AttributeError:
+        raise RuntimeError("Dask cluster not yet bootstrapped") from None
+    with WorkerContext.lock:
+        if not hasattr(dask_worker, "_rapidsmpf_worker_context"):
+            dask_worker._rapidsmpf_worker_context = rmpf_worker_setup(
+                dask_worker,
+                "dask_",
+                comm=comm,
+                options=options,
+            )
 
 
 _initialized_clusters: set[str] = set()

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -67,7 +67,7 @@ def _worker_rmpf_barrier(
     to a specific Dask worker.
     """
     for shuffle_id in shuffle_ids:
-        shuffler = get_shuffler(get_worker_context, shuffle_id)
+        shuffler = get_shuffler(get_worker_context(), shuffle_id)
         for pid in range(partition_count):
             shuffler.insert_finished(pid)
 
@@ -95,7 +95,7 @@ def _stage_shuffler(
     """
     worker = worker or get_worker()
     get_shuffler(
-        get_worker_context,
+        get_worker_context(worker),
         shuffle_id,
         partition_count=partition_count,
         worker=worker,

--- a/python/rapidsmpf/rapidsmpf/integrations/single.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/single.py
@@ -27,7 +27,23 @@ _worker_context: WorkerContext | None = None
 
 
 def get_worker_context() -> WorkerContext:
-    """Retrieve the single-worker ``WorkerContext``."""
+    """
+    Retrieve the single-worker ``WorkerContext``.
+
+    Returns
+    -------
+    The worker context
+
+    Raises
+    ------
+    ValueError
+        If a worker context was never created.
+
+    See Also
+    --------
+    setup_worker
+        Must be called before this function.
+    """
     with WorkerContext.lock:
         if _worker_context is None:
             raise RuntimeError("Must call setup_worker first")

--- a/python/rapidsmpf/rapidsmpf/integrations/single.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/single.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from rapidsmpf.communicator.single import new_communicator
 from rapidsmpf.config import Options

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -336,7 +336,7 @@ def test_many_shuffles_single() -> None:
     do_shuffle(seed=2, num_shuffles=10)
 
     # Check that all shufflers has been cleaned up.
-    ctx = rapidsmpf.integrations.single._get_worker_context()
+    ctx = rapidsmpf.integrations.single.get_worker_context()
     assert len(ctx.shufflers) == 0
 
     # But we cannot shuffle more than `max_num_shuffles` times in a single compute.
@@ -349,7 +349,7 @@ def test_many_shuffles_single() -> None:
     # Cleanup Shufflers to avoid leaking between tests.
     # This shouldn't hang because we just stage shuffles without,
     # without inserting or extracting any data, and so shutdown shouldn't block.
-    context = rapidsmpf.integrations.single._get_worker_context()
+    context = rapidsmpf.integrations.single.get_worker_context()
     for shuffle_id, shuffler in list(context.shufflers.items()):
         if context.shufflers[shuffle_id].finished():
             del context.shufflers[shuffle_id]


### PR DESCRIPTION
Rather than relying on the type system, refactor initialisation of the worker context such that by construction the context is completely initialised by the time a shuffle stage occurs.

- Closes #416