### PR TITLE
Prevent installing OpenMPI with broken CUDA

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -34,6 +34,7 @@ dependencies:
 - numpydoc
 - nvidia-ml-py
 - openmpi
+- openmpi!=5.0.8
 - pre-commit
 - psutil
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -34,6 +34,7 @@ dependencies:
 - numpydoc
 - nvidia-ml-py
 - openmpi
+- openmpi!=5.0.8
 - pre-commit
 - psutil
 - pydata-sphinx-theme

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -155,7 +155,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
+          - openmpi!=5.0.8  # See <https://github.com/rapidsai/rapidsmpf/issues/17, https://github.com/conda-forge/openmpi-feedstock/issues/203>
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
Current OpenMPI package in conda-forge has broken CUDA support, see https://github.com/conda-forge/openmpi-feedstock/issues/203. Prevent installing the current 5.0.8 version until that's fixed.