### PR TITLE
Drop gil when getting statistics

### DIFF
--- a/python/rapidsmpf/rapidsmpf/statistics.pyx
+++ b/python/rapidsmpf/rapidsmpf/statistics.pyx
@@ -108,8 +108,9 @@ cdef class Statistics:
         cdef size_t count
         cdef double value
         try:
-            count = cpp_get_statistic_count(deref(self._handle), name_)
-            value = cpp_get_statistic_value(deref(self._handle), name_)
+            with nogil:
+                count = cpp_get_statistic_count(deref(self._handle), name_)
+                value = cpp_get_statistic_value(deref(self._handle), name_)
         except IndexError:
             # The C++ implementation throws a std::out_of_range exception
             # which we / Cython translate to a KeyError.

--- a/python/rapidsmpf/rapidsmpf/statistics.pyx
+++ b/python/rapidsmpf/rapidsmpf/statistics.pyx
@@ -29,8 +29,8 @@ cdef extern from *:
         return stats.get_stat(name).value();
     }
     """
-    size_t cpp_get_statistic_count(cpp_Statistics stats, string name) nogil except +
-    double cpp_get_statistic_value(cpp_Statistics stats, string name) nogil except +
+    size_t cpp_get_statistic_count(cpp_Statistics stats, string name) except + nogil
+    double cpp_get_statistic_value(cpp_Statistics stats, string name) except + nogil
 
 cdef class Statistics:
     """

--- a/python/rapidsmpf/rapidsmpf/statistics.pyx
+++ b/python/rapidsmpf/rapidsmpf/statistics.pyx
@@ -29,8 +29,8 @@ cdef extern from *:
         return stats.get_stat(name).value();
     }
     """
-    size_t cpp_get_statistic_count(cpp_Statistics stats, string name) except +
-    double cpp_get_statistic_value(cpp_Statistics stats, string name) except +
+    size_t cpp_get_statistic_count(cpp_Statistics stats, string name) nogil except +
+    double cpp_get_statistic_value(cpp_Statistics stats, string name) nogil except +
 
 cdef class Statistics:
     """


### PR DESCRIPTION
Although these functions may throw, we must still drop the gil because they acquire a lock internally. If we don't then two threads attempting to access the statistics at the same time might deadlock.