### PR TITLE
Unpin OpenMPI

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -34,7 +34,6 @@ dependencies:
 - numpydoc
 - nvidia-ml-py
 - openmpi
-- openmpi!=5.0.8
 - pre-commit
 - psutil
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -34,7 +34,6 @@ dependencies:
 - numpydoc
 - nvidia-ml-py
 - openmpi
-- openmpi!=5.0.8
 - pre-commit
 - psutil
 - pydata-sphinx-theme

--- a/conda/recipes/librapidsmpf/recipe.yaml
+++ b/conda/recipes/librapidsmpf/recipe.yaml
@@ -59,7 +59,7 @@ cache:
       - cuda-cudart-dev
       - librmm =${{ minor_version }}
       - libcudf =${{ minor_version }}
-      - openmpi !=5.0.8  # See <https://github.com/rapidsai/rapidsmpf/issues/17, https://github.com/conda-forge/openmpi-feedstock/issues/203>
+      - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
       - ucxx ${{ ucxx_version }}
 
 outputs:
@@ -86,14 +86,14 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - cuda-cudart-dev
         - libcudf =${{ minor_version }}
-        - openmpi !=5.0.8  # See https://github.com/conda-forge/openmpi-feedstock/issues/203
+        - openmpi
         - ucxx ${{ ucxx_version }}
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - cuda-cudart
         - librmm =${{ minor_version }}
         - libcudf =${{ minor_version }}
-        - openmpi !=5.0.8  # See <https://github.com/rapidsai/rapidsmpf/issues/17, https://github.com/conda-forge/openmpi-feedstock/issues/203>
+        - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
         - ucxx ${{ ucxx_version }}
       ignore_run_exports:
         from_package:
@@ -128,14 +128,14 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - libcudf =${{ minor_version }}
         - librmm =${{ minor_version }}
-        - openmpi !=5.0.8  # See https://github.com/conda-forge/openmpi-feedstock/issues/203
+        - openmpi
         - ${{ pin_subpackage("librapidsmpf", exact=True) }}
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - cuda-cudart
         - librmm =${{ minor_version }}
         - libcudf =${{ minor_version }}
-        - openmpi !=5.0.8  # See <https://github.com/rapidsai/rapidsmpf/issues/17, https://github.com/conda-forge/openmpi-feedstock/issues/203>
+        - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
         - ucxx ${{ ucxx_version }}
       ignore_run_exports:
         from_package:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -268,7 +268,7 @@ dependencies:
       - output_types: conda
         packages:
           - *cmake_ver
-          - openmpi!=5.0.8  # See <https://github.com/rapidsai/rapidsmpf/issues/17, https://github.com/conda-forge/openmpi-feedstock/issues/203>
+          - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
           - valgrind
           - cuda-sanitizer-api
           - click >=8.1


### PR DESCRIPTION
Revert https://github.com/rapidsai/rapidsmpf/pull/427, this should not be necessary anymore after the fix from https://github.com/conda-forge/openmpi-feedstock/pull/204 .