### PR TITLE
Pin OpenMPI >=5.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - ninja
 - numpydoc
 - nvidia-ml-py
-- openmpi
+- openmpi >=5.0
 - pre-commit
 - psutil
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - ninja
 - numpydoc
 - nvidia-ml-py
-- openmpi
+- openmpi >=5.0
 - pre-commit
 - psutil
 - pydata-sphinx-theme

--- a/conda/recipes/librapidsmpf/recipe.yaml
+++ b/conda/recipes/librapidsmpf/recipe.yaml
@@ -59,7 +59,7 @@ cache:
       - cuda-cudart-dev
       - librmm =${{ minor_version }}
       - libcudf =${{ minor_version }}
-      - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
+      - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
       - ucxx ${{ ucxx_version }}
 
 outputs:
@@ -86,14 +86,14 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - cuda-cudart-dev
         - libcudf =${{ minor_version }}
-        - openmpi
+        - openmpi >=5.0
         - ucxx ${{ ucxx_version }}
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - cuda-cudart
         - librmm =${{ minor_version }}
         - libcudf =${{ minor_version }}
-        - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
+        - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
         - ucxx ${{ ucxx_version }}
       ignore_run_exports:
         from_package:
@@ -128,14 +128,14 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - libcudf =${{ minor_version }}
         - librmm =${{ minor_version }}
-        - openmpi
+        - openmpi >=5.0
         - ${{ pin_subpackage("librapidsmpf", exact=True) }}
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - cuda-cudart
         - librmm =${{ minor_version }}
         - libcudf =${{ minor_version }}
-        - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
+        - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
         - ucxx ${{ ucxx_version }}
       ignore_run_exports:
         from_package:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -155,7 +155,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
+          - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
     specific:
       - output_types: conda
         matrices:
@@ -193,7 +193,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
+          - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
           - mpi4py
   build-python:
     common:
@@ -268,7 +268,7 @@ dependencies:
       - output_types: conda
         packages:
           - *cmake_ver
-          - openmpi  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
+          - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
           - valgrind
           - cuda-sanitizer-api
           - click >=8.1


### PR DESCRIPTION
Due to unbound conda-forge pins, in some cases OpenMPI 4.x may be mistakenly installed, which causes problems with ssh. Pinning to `openmpi>=5.0` should be safer, and is anyway the only case that's tested.