### PR TITLE
Set default memory type to pool

### DIFF
--- a/ci/run_cpp_benchmark_smoketests.sh
+++ b/ci/run_cpp_benchmark_smoketests.sh
@@ -15,5 +15,3 @@ export OMPI_MCA_opal_cuda_support=1  # enable CUDA support in OpenMPI
 # Ensure that benchmarks are runnable
 mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m cuda
 mpirun --map-by node --bind-to none -np 3 ./bench_comm -m cuda
-mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m async
-mpirun --map-by node --bind-to none -np 3 ./bench_comm -m async

--- a/ci/run_cpp_benchmark_smoketests.sh
+++ b/ci/run_cpp_benchmark_smoketests.sh
@@ -13,5 +13,7 @@ export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 export OMPI_MCA_opal_cuda_support=1  # enable CUDA support in OpenMPI
 
 # Ensure that benchmarks are runnable
-mpirun --map-by node --bind-to none -np 3 ./bench_shuffle
-mpirun --map-by node --bind-to none -np 3 ./bench_comm
+mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m cuda
+mpirun --map-by node --bind-to none -np 3 ./bench_comm -m cuda
+mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m async
+mpirun --map-by node --bind-to none -np 3 ./bench_comm -m async

--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -171,6 +171,10 @@ Duration run(
         }
     }
 
+    // Wait for all buffers to be ready before proceeding. Since allocations are
+    // stream-ordered, we only need to check the last one in the stream.
+    recv_bufs.back()->wait_for_ready();
+
     auto const t0_elapsed = Clock::now();
 
     Tag const tag{0, 1};

--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -47,7 +47,7 @@ class ArgumentParser {
                               " of  concurrent all-to-all operations (default: 1)\n"
                            << "  -m <mr>    RMM memory resource {cuda, pool, async, "
                               "managed} "
-                              "(default: cuda)\n"
+                              "(default: pool)\n"
                            << "  -r <num>   Number of runs (default: 1)\n"
                            << "  -w <num>   Number of warmup runs (default: 0)\n"
                            << "  -h         Display this help message\n";
@@ -114,6 +114,16 @@ class ArgumentParser {
             }
             RAPIDSMPF_MPI(MPI_Abort(MPI_COMM_WORLD, -1));
         }
+
+        if (rmm_mr == "cuda") {
+            if (rank == 0) {
+                std::cout << "WARNING: using the default cuda memory resource "
+                             "(-m cuda) might leak memory! A limitation in UCX "
+                             "means that device memory send through IPC can "
+                             "never be freed."
+                          << std::endl;
+            }
+        }
     }
 
     void pprint(Communicator& comm) const {
@@ -134,7 +144,7 @@ class ArgumentParser {
 
     std::uint64_t num_runs{1};
     std::uint64_t num_warmups{0};
-    std::string rmm_mr{"cuda"};
+    std::string rmm_mr{"pool"};
     std::string comm_type{"mpi"};
     std::string operation{"all-to-all"};
     std::uint64_t msg_size{1 << 20};

--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -56,7 +56,7 @@ class ArgumentParser {
                               "(default: 1)\n"
                            << "  -m <mr>    RMM memory resource {cuda, pool, async, "
                               "managed} "
-                              "(default: cuda)\n"
+                              "(default: pool)\n"
                            << "  -l <num>   Device memory limit in MiB (default:-1, "
                               "disabled)\n"
                            << "  -i         Use `concat_insert` method, instead of "
@@ -147,9 +147,9 @@ class ArgumentParser {
         if (rmm_mr == "cuda") {
             if (rank == 0) {
                 std::cout << "WARNING: using the default cuda memory resource "
-                             "(-m cuda) might leak memory! A bug in UCX means "
-                             "that device memory received through IPC is never "
-                             "freed. Hopefully, this will be fixed in UCX v1.19."
+                             "(-m cuda) might leak memory! A limitation in UCX "
+                             "means that device memory send through IPC can "
+                             "never be freed."
                           << std::endl;
             }
         }
@@ -194,7 +194,7 @@ class ArgumentParser {
     std::uint64_t num_local_rows{1 << 20};
     rapidsmpf::shuffler::PartID num_local_partitions{1};
     rapidsmpf::shuffler::PartID num_output_partitions{1};
-    std::string rmm_mr{"cuda"};
+    std::string rmm_mr{"pool"};
     std::string comm_type{"mpi"};
     std::uint64_t local_nbytes;
     std::uint64_t total_nbytes;

--- a/python/rapidsmpf/rapidsmpf/statistics.pyx
+++ b/python/rapidsmpf/rapidsmpf/statistics.pyx
@@ -29,8 +29,8 @@ cdef extern from *:
         return stats.get_stat(name).value();
     }
     """
-    size_t cpp_get_statistic_count(cpp_Statistics stats, string name) except +
-    double cpp_get_statistic_value(cpp_Statistics stats, string name) except +
+    size_t cpp_get_statistic_count(cpp_Statistics stats, string name) except + nogil
+    double cpp_get_statistic_value(cpp_Statistics stats, string name) except + nogil
 
 cdef class Statistics:
     """
@@ -108,8 +108,9 @@ cdef class Statistics:
         cdef size_t count
         cdef double value
         try:
-            count = cpp_get_statistic_count(deref(self._handle), name_)
-            value = cpp_get_statistic_value(deref(self._handle), name_)
+            with nogil:
+                count = cpp_get_statistic_count(deref(self._handle), name_)
+                value = cpp_get_statistic_value(deref(self._handle), name_)
         except IndexError:
             # The C++ implementation throws a std::out_of_range exception
             # which we / Cython translate to a KeyError.


### PR DESCRIPTION
Clarify warning when running benchmarks with `-m cuda`, this will cause a "memory leak" when UCX is running with CUDA IPC. This is a known limitation and there's no ETA on being addressed. This happens because UCX needs to map memory allocations with `cuIpcOpenMemHandle`, but it does not support `cuIpcCloseMemHandle`, and thus causing allocations that have been used to transfer over CUDA IPC to never release memory, even after `cudaFree`/`cuMemFree` is called.

Due to the limitation described above, it's probably a better and more sane to make `"pool"` allocator the default, which doesn't require remapping given allocations are never freed until the application terminates.