### PR TITLE
Fix minor blocker for cudf-polars "single" shuffler compatibility 

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
@@ -75,7 +75,7 @@ def get_dask_worker_rank(dask_worker: distributed.Worker | None = None) -> int:
     return comm.rank
 
 
-def global_rmpf_barrier(dependencies: Sequence[None]) -> None:
+def global_rmpf_barrier(*dependencies: Sequence[None]) -> None:
     """
     Global barrier for RapidsMPF shuffle.
 

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/shuffler.py
@@ -252,7 +252,7 @@ def rapidsmpf_shuffle_graph(
     # Add global barrier task
     graph[(global_barrier_1_name, 0)] = (
         global_rmpf_barrier,
-        list(graph.keys()),
+        *graph.keys(),
     )
 
     # Add worker barrier tasks
@@ -271,7 +271,7 @@ def rapidsmpf_shuffle_graph(
     # Add global barrier task
     graph[(global_barrier_2_name, 0)] = (
         global_rmpf_barrier,
-        list(worker_barriers.values()),
+        *worker_barriers.values(),
     )
 
     # Add extraction tasks

--- a/python/rapidsmpf/rapidsmpf/integrations/single.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/single.py
@@ -192,7 +192,7 @@ def rapidsmpf_shuffle_graph(
         _barrier,
         (shuffle_id,),
         partition_count_out,
-        list(graph.keys()),
+        *graph.keys(),
     )
 
     # Add extraction tasks


### PR DESCRIPTION
The synchronous cudf-polars scheduler does **not** iterate though `list` objects to search for graph keys. This PR makes some minor changes to the `rapidsmpf_shuffle_graph` functions so that `list` traversal is unnecessary.