### PR TITLE
Separate shuffler's communication into separate interface

### DIFF
--- a/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
+++ b/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
@@ -29,9 +29,9 @@ namespace rapidsmpf::shuffler {
  * to drive the communication forward while maintaining full control over the
  * underlying communication patterns and optimizations.
  */
-class ShufflerCommunicationInterface {
+class CommunicationInterface {
   public:
-    virtual ~ShufflerCommunicationInterface() = default;
+    virtual ~CommunicationInterface() = default;
 
     /**
      * @brief Submit outgoing chunks for communication.
@@ -78,23 +78,23 @@ class ShufflerCommunicationInterface {
 };
 
 /**
- * @brief Tag implementation of ShufflerCommunicationInterface.
+ * @brief Tag implementation of CommunicationInterface.
  *
  * This implementation owns and manages all communication state that was previously
  * held in the Progress class. It replicates the exact current communication behavior
  * while providing a self-contained, stateful communication manager.
  */
-class TagShufflerCommunication : public ShufflerCommunicationInterface {
+class TagCommunicationInterface : public CommunicationInterface {
   public:
     /**
-     * @brief Constructor for TagShufflerCommunication.
+     * @brief Constructor for TagCommunicationInterface.
      *
      * @param comm The communicator to use for operations.
      * @param op_id The operation ID for tagging messages.
      * @param rank The current rank (for logging and validation).
      * @param statistics The statistics to use for tracking communication operations.
      */
-    TagShufflerCommunication(
+    TagCommunicationInterface(
         std::shared_ptr<Communicator> comm,
         OpID op_id,
         Rank rank,

--- a/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
+++ b/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
@@ -75,13 +75,6 @@ class ShufflerCommunicationInterface {
      * @return True if no pending operations remain, false otherwise.
      */
     virtual bool is_idle() const = 0;
-
-    /**
-     * @brief Get communication statistics for monitoring.
-     *
-     * @return A map of statistic names to values.
-     */
-    virtual std::unordered_map<std::string, std::size_t> get_statistics() const = 0;
 };
 
 /**
@@ -99,8 +92,14 @@ class TagShufflerCommunication : public ShufflerCommunicationInterface {
      * @param comm The communicator to use for operations.
      * @param op_id The operation ID for tagging messages.
      * @param rank The current rank (for logging and validation).
+     * @param statistics The statistics to use for tracking communication operations.
      */
-    TagShufflerCommunication(std::shared_ptr<Communicator> comm, OpID op_id, Rank rank);
+    TagShufflerCommunication(
+        std::shared_ptr<Communicator> comm,
+        OpID op_id,
+        Rank rank,
+        std::shared_ptr<Statistics> statistics
+    );
 
     void submit_outgoing_chunks(
         std::vector<detail::Chunk>&& chunks,
@@ -115,8 +114,6 @@ class TagShufflerCommunication : public ShufflerCommunicationInterface {
     ) override;
 
     bool is_idle() const override;
-
-    std::unordered_map<std::string, std::size_t> get_statistics() const override;
 
   private:
     // Core communication infrastructure
@@ -141,7 +138,7 @@ class TagShufflerCommunication : public ShufflerCommunicationInterface {
         ready_ack_receives_;  ///< Receives matching ready for data messages.
 
     // Statistics tracking
-    mutable std::unordered_map<std::string, std::size_t> statistics_;
+    std::shared_ptr<Statistics> statistics_;
 
     // Helper methods for the communication protocol phases
     void send_metadata_phase(

--- a/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
+++ b/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
@@ -1,0 +1,231 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <rapidsmpf/buffer/buffer.hpp>
+#include <rapidsmpf/buffer/resource.hpp>
+#include <rapidsmpf/communicator/communicator.hpp>
+#include <rapidsmpf/shuffler/chunk.hpp>
+
+namespace rapidsmpf::shuffler {
+
+/**
+ * @brief Abstract interface for shuffler communication operations.
+ *
+ * This interface abstracts the communication patterns used in the shuffler's main
+ * progress loop. It provides a clean separation between the shuffler logic and the
+ * underlying communication implementation, allowing for different communication
+ * strategies while maintaining the same high-level shuffler behavior.
+ *
+ * The communication pattern involves:
+ * 1. Sending serialized chunk metadata to notify receivers about incoming data
+ * 2. Receiving serialized chunk metadata from other ranks
+ * 3. Sending "ready for data" acknowledgments to indicate readiness to receive GPU data
+ * 4. Receiving "ready for data" acknowledgments from receivers
+ * 5. Sending GPU data buffers to receivers
+ * 6. Receiving GPU data buffers from senders
+ */
+class ShufflerCommunicationInterface {
+  public:
+    virtual ~ShufflerCommunicationInterface() = default;
+
+    /**
+     * @brief Send serialized chunk metadata to a destination rank.
+     *
+     * This is step 1 of the communication protocol - notifying the receiver about an
+     * incoming chunk and its metadata.
+     *
+     * @param serialized_metadata The serialized chunk metadata buffer.
+     * @param dest_rank The destination rank to send to.
+     * @param br Buffer resource for managing the send operation.
+     * @return A future representing the ongoing send operation.
+     */
+    virtual std::unique_ptr<Communicator::Future> send_chunk_metadata(
+        std::unique_ptr<std::vector<uint8_t>> serialized_metadata,
+        Rank dest_rank,
+        BufferResource* br
+    ) = 0;
+
+    /**
+     * @brief Receive any available serialized chunk metadata.
+     *
+     * This is step 2 of the communication protocol - receiving chunk metadata from
+     * any sender rank.
+     *
+     * @return A pair containing the received metadata buffer and the source rank.
+     *         Returns {nullptr, invalid_rank} if no message is available.
+     */
+    virtual std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank>
+    receive_chunk_metadata() = 0;
+
+    /**
+     * @brief Send a "ready for data" acknowledgment to a source rank.
+     *
+     * This is step 3 of the communication protocol - informing the sender that we
+     * are ready to receive the GPU data for a specific chunk.
+     *
+     * @param ready_msg The ready-for-data message containing the chunk ID.
+     * @param dest_rank The destination rank to send the acknowledgment to.
+     * @param br Buffer resource for managing the send operation.
+     * @return A future representing the ongoing send operation.
+     */
+    virtual std::unique_ptr<Communicator::Future> send_ready_for_data(
+        std::unique_ptr<std::vector<uint8_t>> ready_msg,
+        Rank dest_rank,
+        BufferResource* br
+    ) = 0;
+
+    /**
+     * @brief Post a receive operation for a "ready for data" acknowledgment.
+     *
+     * This is step 4 of the communication protocol - setting up to receive
+     * acknowledgments from receivers indicating they are ready for GPU data.
+     *
+     * @param source_rank The source rank to receive from.
+     * @param buffer Buffer to receive the acknowledgment into.
+     * @return A future representing the ongoing receive operation.
+     */
+    virtual std::unique_ptr<Communicator::Future> receive_ready_for_data(
+        Rank source_rank, std::unique_ptr<Buffer> buffer
+    ) = 0;
+
+    /**
+     * @brief Send GPU data buffer to a destination rank.
+     *
+     * This is step 5 of the communication protocol - sending the actual GPU data
+     * after receiving a ready-for-data acknowledgment.
+     *
+     * @param data_buffer The GPU data buffer to send.
+     * @param dest_rank The destination rank to send to.
+     * @return A future representing the ongoing send operation.
+     */
+    virtual std::unique_ptr<Communicator::Future> send_gpu_data(
+        std::unique_ptr<Buffer> data_buffer, Rank dest_rank
+    ) = 0;
+
+    /**
+     * @brief Post a receive operation for GPU data from a source rank.
+     *
+     * This is step 6 of the communication protocol - receiving the actual GPU data
+     * after sending a ready-for-data acknowledgment.
+     *
+     * @param source_rank The source rank to receive from.
+     * @param data_buffer Buffer to receive the GPU data into.
+     * @return A future representing the ongoing receive operation.
+     */
+    virtual std::unique_ptr<Communicator::Future> receive_gpu_data(
+        Rank source_rank, std::unique_ptr<Buffer> data_buffer
+    ) = 0;
+
+    /**
+     * @brief Test completion of multiple futures and return completed ones.
+     *
+     * @param futures Container of futures to test, completed futures are removed.
+     * @return Vector of completed futures.
+     */
+    virtual std::vector<std::unique_ptr<Communicator::Future>> test_some(
+        std::vector<std::unique_ptr<Communicator::Future>>& futures
+    ) = 0;
+
+    /**
+     * @brief Test completion of futures mapped by a key type.
+     *
+     * @tparam KeyType The type of the key used in the map.
+     * @param futures_map Map of futures to test, completed futures are removed.
+     * @return Vector of keys whose futures completed.
+     */
+    template <typename KeyType>
+    std::vector<KeyType> test_some(
+        std::unordered_map<KeyType, std::unique_ptr<Communicator::Future>>& futures_map
+    ) {
+        std::vector<KeyType> completed_keys;
+        for (auto it = futures_map.begin(); it != futures_map.end();) {
+            if (it->second->is_ready()) {
+                completed_keys.push_back(it->first);
+                it = futures_map.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        return completed_keys;
+    }
+
+    /**
+     * @brief Extract the GPU data buffer from a completed future.
+     *
+     * @param future The completed future to extract data from.
+     * @return The GPU data buffer.
+     */
+    virtual std::unique_ptr<Buffer> get_gpu_data(
+        std::unique_ptr<Communicator::Future> future
+    ) = 0;
+};
+
+/**
+ * @brief Default implementation of ShufflerCommunicationInterface.
+ *
+ * This implementation uses the existing communicator API and replicates the current
+ * communication behavior of the shuffler. It serves as both a reference implementation
+ * and maintains backward compatibility with existing code.
+ */
+class DefaultShufflerCommunication : public ShufflerCommunicationInterface {
+  public:
+    /**
+     * @brief Constructor for DefaultShufflerCommunication.
+     *
+     * @param comm The communicator to use for operations.
+     * @param op_id The operation ID for tagging messages.
+     */
+    DefaultShufflerCommunication(std::shared_ptr<Communicator> comm, OpID op_id);
+
+    std::unique_ptr<Communicator::Future> send_chunk_metadata(
+        std::unique_ptr<std::vector<uint8_t>> serialized_metadata,
+        Rank dest_rank,
+        BufferResource* br
+    ) override;
+
+    std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank>
+    receive_chunk_metadata() override;
+
+    std::unique_ptr<Communicator::Future> send_ready_for_data(
+        std::unique_ptr<std::vector<uint8_t>> ready_msg,
+        Rank dest_rank,
+        BufferResource* br
+    ) override;
+
+    std::unique_ptr<Communicator::Future> receive_ready_for_data(
+        Rank source_rank, std::unique_ptr<Buffer> buffer
+    ) override;
+
+    std::unique_ptr<Communicator::Future> send_gpu_data(
+        std::unique_ptr<Buffer> data_buffer, Rank dest_rank
+    ) override;
+
+    std::unique_ptr<Communicator::Future> receive_gpu_data(
+        Rank source_rank, std::unique_ptr<Buffer> data_buffer
+    ) override;
+
+    std::vector<std::unique_ptr<Communicator::Future>> test_some(
+        std::vector<std::unique_ptr<Communicator::Future>>& futures
+    ) override;
+
+    std::unique_ptr<Buffer> get_gpu_data(
+        std::unique_ptr<Communicator::Future> future
+    ) override;
+
+  private:
+    std::shared_ptr<Communicator> comm_;
+    Tag ready_for_data_tag_;
+    Tag metadata_tag_;
+    Tag gpu_data_tag_;
+};
+
+}  // namespace rapidsmpf::shuffler

--- a/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
+++ b/cpp/include/rapidsmpf/shuffler/communication_interface.hpp
@@ -85,24 +85,22 @@ class ShufflerCommunicationInterface {
 };
 
 /**
- * @brief Default implementation of ShufflerCommunicationInterface.
+ * @brief Tag implementation of ShufflerCommunicationInterface.
  *
  * This implementation owns and manages all communication state that was previously
  * held in the Progress class. It replicates the exact current communication behavior
  * while providing a self-contained, stateful communication manager.
  */
-class DefaultShufflerCommunication : public ShufflerCommunicationInterface {
+class TagShufflerCommunication : public ShufflerCommunicationInterface {
   public:
     /**
-     * @brief Constructor for DefaultShufflerCommunication.
+     * @brief Constructor for TagShufflerCommunication.
      *
      * @param comm The communicator to use for operations.
      * @param op_id The operation ID for tagging messages.
      * @param rank The current rank (for logging and validation).
      */
-    DefaultShufflerCommunication(
-        std::shared_ptr<Communicator> comm, OpID op_id, Rank rank
-    );
+    TagShufflerCommunication(std::shared_ptr<Communicator> comm, OpID op_id, Rank rank);
 
     void submit_outgoing_chunks(
         std::vector<detail::Chunk>&& chunks,

--- a/cpp/include/rapidsmpf/shuffler/shuffler.hpp
+++ b/cpp/include/rapidsmpf/shuffler/shuffler.hpp
@@ -18,6 +18,7 @@
 #include <rapidsmpf/nvtx.hpp>
 #include <rapidsmpf/progress_thread.hpp>
 #include <rapidsmpf/shuffler/chunk.hpp>
+#include <rapidsmpf/shuffler/communication_interface.hpp>
 #include <rapidsmpf/shuffler/finish_counter.hpp>
 #include <rapidsmpf/shuffler/postbox.hpp>
 #include <rapidsmpf/statistics.hpp>
@@ -88,6 +89,8 @@ class Shuffler {
      * @param br Buffer resource used to allocate temporary and the shuffle result.
      * @param statistics The statistics instance to use (disabled by default).
      * @param partition_owner Function to determine partition ownership.
+     * @param comm_interface Optional custom communication interface. If not provided,
+     * uses the default implementation.
      */
     Shuffler(
         std::shared_ptr<Communicator> comm,
@@ -97,7 +100,8 @@ class Shuffler {
         rmm::cuda_stream_view stream,
         BufferResource* br,
         std::shared_ptr<Statistics> statistics = Statistics::disabled(),
-        PartitionOwner partition_owner = round_robin
+        PartitionOwner partition_owner = round_robin,
+        std::unique_ptr<ShufflerCommunicationInterface> comm_interface = nullptr
     );
 
     ~Shuffler();
@@ -247,6 +251,7 @@ class Shuffler {
                                              ///< ready to be extracted by the user.
 
     std::shared_ptr<Communicator> comm_;
+    std::unique_ptr<ShufflerCommunicationInterface> comm_interface_;
     std::shared_ptr<ProgressThread> progress_thread_;
     ProgressThread::FunctionID progress_thread_function_id_;
     OpID const op_id_;

--- a/cpp/include/rapidsmpf/shuffler/shuffler.hpp
+++ b/cpp/include/rapidsmpf/shuffler/shuffler.hpp
@@ -101,7 +101,7 @@ class Shuffler {
         BufferResource* br,
         std::shared_ptr<Statistics> statistics = Statistics::disabled(),
         PartitionOwner partition_owner = round_robin,
-        std::unique_ptr<ShufflerCommunicationInterface> comm_interface = nullptr
+        std::unique_ptr<CommunicationInterface> comm_interface = nullptr
     );
 
     ~Shuffler();
@@ -251,7 +251,7 @@ class Shuffler {
                                              ///< ready to be extracted by the user.
 
     std::shared_ptr<Communicator> comm_;
-    std::unique_ptr<ShufflerCommunicationInterface> comm_interface_;
+    std::unique_ptr<CommunicationInterface> comm_interface_;
     std::shared_ptr<ProgressThread> progress_thread_;
     ProgressThread::FunctionID progress_thread_function_id_;
     OpID const op_id_;

--- a/cpp/src/shuffler/communication_interface.cpp
+++ b/cpp/src/shuffler/communication_interface.cpp
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rapidsmpf/shuffler/communication_interface.hpp>
+
+namespace rapidsmpf::shuffler {
+
+DefaultShufflerCommunication::DefaultShufflerCommunication(
+    std::shared_ptr<Communicator> comm, OpID op_id
+)
+    : comm_(std::move(comm)),
+      ready_for_data_tag_{op_id, 1},
+      metadata_tag_{op_id, 2},
+      gpu_data_tag_{op_id, 3} {}
+
+std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::send_chunk_metadata(
+    std::unique_ptr<std::vector<uint8_t>> serialized_metadata,
+    Rank dest_rank,
+    BufferResource* br
+) {
+    return comm_->send(std::move(serialized_metadata), dest_rank, metadata_tag_, br);
+}
+
+std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank>
+DefaultShufflerCommunication::receive_chunk_metadata() {
+    return comm_->recv_any(metadata_tag_);
+}
+
+std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::send_ready_for_data(
+    std::unique_ptr<std::vector<uint8_t>> ready_msg, Rank dest_rank, BufferResource* br
+) {
+    return comm_->send(std::move(ready_msg), dest_rank, ready_for_data_tag_, br);
+}
+
+std::unique_ptr<Communicator::Future>
+DefaultShufflerCommunication::receive_ready_for_data(
+    Rank source_rank, std::unique_ptr<Buffer> buffer
+) {
+    return comm_->recv(source_rank, ready_for_data_tag_, std::move(buffer));
+}
+
+std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::send_gpu_data(
+    std::unique_ptr<Buffer> data_buffer, Rank dest_rank
+) {
+    return comm_->send(std::move(data_buffer), dest_rank, gpu_data_tag_);
+}
+
+std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::receive_gpu_data(
+    Rank source_rank, std::unique_ptr<Buffer> data_buffer
+) {
+    return comm_->recv(source_rank, gpu_data_tag_, std::move(data_buffer));
+}
+
+std::vector<std::unique_ptr<Communicator::Future>>
+DefaultShufflerCommunication::test_some(
+    std::vector<std::unique_ptr<Communicator::Future>>& futures
+) {
+    return comm_->test_some(futures);
+}
+
+std::unique_ptr<Buffer> DefaultShufflerCommunication::get_gpu_data(
+    std::unique_ptr<Communicator::Future> future
+) {
+    return comm_->get_gpu_data(std::move(future));
+}
+
+}  // namespace rapidsmpf::shuffler

--- a/cpp/src/shuffler/communication_interface.cpp
+++ b/cpp/src/shuffler/communication_interface.cpp
@@ -3,67 +3,216 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <algorithm>
+#include <utility>
+
 #include <rapidsmpf/shuffler/communication_interface.hpp>
+#include <rapidsmpf/utils.hpp>
 
 namespace rapidsmpf::shuffler {
 
 DefaultShufflerCommunication::DefaultShufflerCommunication(
-    std::shared_ptr<Communicator> comm, OpID op_id
+    std::shared_ptr<Communicator> comm, OpID op_id, Rank rank
 )
     : comm_(std::move(comm)),
+      rank_(rank),
       ready_for_data_tag_{op_id, 1},
       metadata_tag_{op_id, 2},
-      gpu_data_tag_{op_id, 3} {}
+      gpu_data_tag_{op_id, 3} {
+    statistics_["metadata_sent"] = 0;
+    statistics_["metadata_received"] = 0;
+    statistics_["data_sent"] = 0;
+    statistics_["data_received"] = 0;
+    statistics_["ready_signals_sent"] = 0;
+    statistics_["ready_signals_received"] = 0;
+}
 
-std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::send_chunk_metadata(
-    std::unique_ptr<std::vector<uint8_t>> serialized_metadata,
-    Rank dest_rank,
+void DefaultShufflerCommunication::submit_outgoing_chunks(
+    std::vector<detail::Chunk>&& chunks,
+    std::function<Rank(PartID)> partition_owner,
     BufferResource* br
 ) {
-    return comm_->send(std::move(serialized_metadata), dest_rank, metadata_tag_, br);
+    // Store chunks for sending and initiate metadata transmission
+    for (auto&& chunk : chunks) {
+        auto dst = partition_owner(chunk.part_id(0));
+        RAPIDSMPF_EXPECTS(dst != rank_, "sending chunk to ourselves");
+
+        fire_and_forget_.push_back(
+            comm_->send(chunk.serialize(), dst, metadata_tag_, br)
+        );
+        statistics_["metadata_sent"]++;
+
+        if (chunk.concat_data_size() > 0) {
+            RAPIDSMPF_EXPECTS(
+                outgoing_chunks_.insert({chunk.chunk_id(), std::move(chunk)}).second,
+                "outgoing chunk already exists"
+            );
+            ready_ack_receives_[dst].push_back(comm_->recv(
+                dst,
+                ready_for_data_tag_,
+                br->move(
+                    std::make_unique<std::vector<std::uint8_t>>(
+                        detail::ReadyForDataMessage::byte_size
+                    )
+                )
+            ));
+        }
+    }
 }
 
-std::pair<std::unique_ptr<std::vector<uint8_t>>, Rank>
-DefaultShufflerCommunication::receive_chunk_metadata() {
-    return comm_->recv_any(metadata_tag_);
-}
-
-std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::send_ready_for_data(
-    std::unique_ptr<std::vector<uint8_t>> ready_msg, Rank dest_rank, BufferResource* br
+std::vector<detail::Chunk> DefaultShufflerCommunication::process_communication(
+    std::function<std::unique_ptr<Buffer>(std::size_t)> allocate_buffer_fn,
+    rmm::cuda_stream_view stream,
+    BufferResource* br
 ) {
-    return comm_->send(std::move(ready_msg), dest_rank, ready_for_data_tag_, br);
+    // Process all phases of the communication protocol
+    receive_metadata_phase();
+    setup_data_receives_phase(allocate_buffer_fn, stream, br);
+    process_ready_acks_phase();
+    auto completed_chunks = complete_data_transfers_phase();
+    cleanup_completed_operations();
+
+    return completed_chunks;
 }
 
-std::unique_ptr<Communicator::Future>
-DefaultShufflerCommunication::receive_ready_for_data(
-    Rank source_rank, std::unique_ptr<Buffer> buffer
-) {
-    return comm_->recv(source_rank, ready_for_data_tag_, std::move(buffer));
+bool DefaultShufflerCommunication::is_idle() const {
+    return fire_and_forget_.empty() && incoming_chunks_.empty()
+           && outgoing_chunks_.empty() && in_transit_chunks_.empty()
+           && in_transit_futures_.empty()
+           && std::all_of(
+               ready_ack_receives_.begin(),
+               ready_ack_receives_.end(),
+               [](const auto& kv) { return kv.second.empty(); }
+           );
 }
 
-std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::send_gpu_data(
-    std::unique_ptr<Buffer> data_buffer, Rank dest_rank
-) {
-    return comm_->send(std::move(data_buffer), dest_rank, gpu_data_tag_);
+std::unordered_map<std::string, std::size_t>
+DefaultShufflerCommunication::get_statistics() const {
+    return statistics_;
 }
 
-std::unique_ptr<Communicator::Future> DefaultShufflerCommunication::receive_gpu_data(
-    Rank source_rank, std::unique_ptr<Buffer> data_buffer
-) {
-    return comm_->recv(source_rank, gpu_data_tag_, std::move(data_buffer));
+void DefaultShufflerCommunication::receive_metadata_phase() {
+    while (true) {
+        auto const [msg, src] = comm_->recv_any(metadata_tag_);
+        if (!msg)
+            break;
+
+        auto chunk = detail::Chunk::deserialize(*msg, false);
+        statistics_["metadata_received"]++;
+        incoming_chunks_.insert({src, std::move(chunk)});
+    }
 }
 
-std::vector<std::unique_ptr<Communicator::Future>>
-DefaultShufflerCommunication::test_some(
-    std::vector<std::unique_ptr<Communicator::Future>>& futures
+void DefaultShufflerCommunication::setup_data_receives_phase(
+    std::function<std::unique_ptr<Buffer>(std::size_t)> allocate_buffer_fn,
+    rmm::cuda_stream_view stream,
+    BufferResource* br
 ) {
-    return comm_->test_some(futures);
+    for (auto it = incoming_chunks_.begin(); it != incoming_chunks_.end();) {
+        auto& [src, chunk] = *it;
+
+        if (chunk.concat_data_size() > 0) {
+            if (!chunk.is_data_buffer_set()) {
+                chunk.set_data_buffer(allocate_buffer_fn(chunk.concat_data_size()));
+            }
+
+            if (!chunk.is_ready()) {
+                ++it;
+                continue;
+            }
+
+            // Extract the chunk and set up for data transfer
+            auto src_rank = src;
+            auto chunk_id = chunk.chunk_id();
+            auto data_buffer = chunk.release_data_buffer();
+            auto [extracted_src, extracted_chunk] = extract_item(incoming_chunks_, it++);
+
+            auto future = comm_->recv(src_rank, gpu_data_tag_, std::move(data_buffer));
+            RAPIDSMPF_EXPECTS(
+                in_transit_futures_.insert({chunk_id, std::move(future)}).second,
+                "in transit future already exists"
+            );
+            RAPIDSMPF_EXPECTS(
+                in_transit_chunks_.insert({chunk_id, std::move(extracted_chunk)}).second,
+                "in transit chunk already exists"
+            );
+
+            fire_and_forget_.push_back(comm_->send(
+                detail::ReadyForDataMessage{chunk_id}.pack(),
+                src_rank,
+                ready_for_data_tag_,
+                br
+            ));
+            statistics_["ready_signals_sent"]++;
+        } else {
+            // Control/metadata-only chunk - will be handled in
+            // complete_data_transfers_phase
+            ++it;
+        }
+    }
 }
 
-std::unique_ptr<Buffer> DefaultShufflerCommunication::get_gpu_data(
-    std::unique_ptr<Communicator::Future> future
-) {
-    return comm_->get_gpu_data(std::move(future));
+void DefaultShufflerCommunication::process_ready_acks_phase() {
+    for (auto& [dst, futures] : ready_ack_receives_) {
+        auto finished = comm_->test_some(futures);
+        for (auto&& future : finished) {
+            auto const msg_data = comm_->get_gpu_data(std::move(future));
+            auto msg = detail::ReadyForDataMessage::unpack(
+                const_cast<Buffer const&>(*msg_data).host()
+            );
+            auto chunk = extract_value(outgoing_chunks_, msg.cid);
+            statistics_["ready_signals_received"]++;
+            statistics_["data_sent"]++;
+
+            fire_and_forget_.push_back(
+                comm_->send(chunk.release_data_buffer(), dst, gpu_data_tag_)
+            );
+        }
+    }
+}
+
+std::vector<detail::Chunk> DefaultShufflerCommunication::complete_data_transfers_phase() {
+    std::vector<detail::Chunk> completed_chunks;
+
+    // Handle completed data transfers
+    if (!in_transit_futures_.empty()) {
+        std::vector<std::pair<detail::ChunkID, std::unique_ptr<Communicator::Future>>>
+            finished;
+        for (auto it = in_transit_futures_.begin(); it != in_transit_futures_.end();) {
+            if (it->second->is_ready()) {
+                finished.emplace_back(it->first, std::move(it->second));
+                it = in_transit_futures_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        for (auto&& [cid, future] : finished) {
+            auto chunk = extract_value(in_transit_chunks_, cid);
+            chunk.set_data_buffer(comm_->get_gpu_data(std::move(future)));
+            statistics_["data_received"]++;
+            completed_chunks.push_back(std::move(chunk));
+        }
+    }
+
+    // Handle control/metadata-only chunks from incoming_chunks_
+    for (auto it = incoming_chunks_.begin(); it != incoming_chunks_.end();) {
+        auto& [src, chunk] = *it;
+        if (chunk.concat_data_size() == 0) {
+            auto [src, chunk] = extract_item(incoming_chunks_, it++);
+            completed_chunks.push_back(std::move(chunk));
+        } else {
+            ++it;
+        }
+    }
+
+    return completed_chunks;
+}
+
+void DefaultShufflerCommunication::cleanup_completed_operations() {
+    if (!fire_and_forget_.empty()) {
+        std::ignore = comm_->test_some(fire_and_forget_);
+    }
 }
 
 }  // namespace rapidsmpf::shuffler

--- a/cpp/src/shuffler/communication_interface.cpp
+++ b/cpp/src/shuffler/communication_interface.cpp
@@ -65,12 +65,18 @@ std::vector<detail::Chunk> DefaultShufflerCommunication::process_communication(
     rmm::cuda_stream_view stream,
     BufferResource* br
 ) {
+    auto const t0 = std::chrono::steady_clock::now();
+
     // Process all phases of the communication protocol
     receive_metadata_phase();
     setup_data_receives_phase(allocate_buffer_fn, stream, br);
     process_ready_acks_phase();
     auto completed_chunks = complete_data_transfers_phase();
     cleanup_completed_operations();
+
+    statistics_.add_duration_stat(
+        "comms-interface-process-communication-total", Clock::now() - t0
+    );
 
     return completed_chunks;
 }

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -310,9 +310,10 @@ Shuffler::Shuffler(
       },
       comm_{std::move(comm)},
       comm_interface_{
-          comm_interface
-              ? std::move(comm_interface)
-              : std::make_unique<TagShufflerCommunication>(comm_, op_id, comm_->rank())
+          comm_interface ? std::move(comm_interface)
+                         : std::make_unique<TagShufflerCommunication>(
+                               comm_, op_id, comm_->rank(), statistics
+                           )
       },
       progress_thread_{std::move(progress_thread)},
       op_id_{op_id},

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -310,10 +310,9 @@ Shuffler::Shuffler(
       },
       comm_{std::move(comm)},
       comm_interface_{
-          comm_interface ? std::move(comm_interface)
-                         : std::make_unique<DefaultShufflerCommunication>(
-                               comm_, op_id, comm_->rank()
-                           )
+          comm_interface
+              ? std::move(comm_interface)
+              : std::make_unique<TagShufflerCommunication>(comm_, op_id, comm_->rank())
       },
       progress_thread_{std::move(progress_thread)},
       op_id_{op_id},

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -292,7 +292,7 @@ Shuffler::Shuffler(
     BufferResource* br,
     std::shared_ptr<Statistics> statistics,
     PartitionOwner partition_owner,
-    std::unique_ptr<ShufflerCommunicationInterface> comm_interface
+    std::unique_ptr<CommunicationInterface> comm_interface
 )
     : total_num_partitions{total_num_partitions},
       partition_owner{partition_owner},
@@ -311,7 +311,7 @@ Shuffler::Shuffler(
       comm_{std::move(comm)},
       comm_interface_{
           comm_interface ? std::move(comm_interface)
-                         : std::make_unique<TagShufflerCommunication>(
+                         : std::make_unique<TagCommunicationInterface>(
                                comm_, op_id, comm_->rank(), statistics
                            )
       },

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -183,7 +183,7 @@ class Shuffler::Progress {
 
             if (!ready_chunks.empty()) {
                 std::vector<detail::Chunk> chunks_to_submit;
-                for (auto&& [_, chunk] : ready_chunks) {
+                for (auto&& chunk : ready_chunks) {
                     auto dst =
                         shuffler_.partition_owner(shuffler_.comm_, chunk.part_id(0));
                     log.trace("submitting chunk to ", dst, ": ", chunk);


### PR DESCRIPTION
Attempt to move communication operations from the `Shuffler::ProgressThread` into a new `CommunicationInterface` abstract class to handle all communication. This approach has the benefit of making a more distinct and easier to understand separation of the communication routine from the shuffler, making the progress operator considerably smaller, simultaneously allowing extensions to the communication interface disjoint from the shuffler, for example, to allow implementing an Active Message-based communicator for the shuffler. Currently implement only a `TagCommunicationInterface`.