### PR TITLE
Properly track shuffle device memory allocations

### DIFF
--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -302,7 +302,7 @@ std::vector<InputPartitionsT> generate_input_partitions(
         );
 
         // reserve at least size_lb and spill if necessary (no overbooking)
-        auto res = reserve_device_memory_and_spill(br, size_lb, false);
+        auto res = br->reserve_and_spill(rapidsmpf::MemoryType::DEVICE, size_lb, false);
         cudf::table table = with_memory_reservation(std::move(res), [&] {
             return random_table(
                 static_cast<cudf::size_type>(args.num_columns),

--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -287,7 +287,7 @@ template <
 std::vector<InputPartitionsT> generate_input_partitions(
     ArgumentParser const& args,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr,
+    rapidsmpf::BufferResource* br,
     TransformFn&& transform_fn
 ) {
     std::int32_t const min_val = 0;
@@ -296,14 +296,23 @@ std::vector<InputPartitionsT> generate_input_partitions(
     std::vector<InputPartitionsT> input_partitions;
     input_partitions.reserve(args.num_local_partitions);
     for (rapidsmpf::shuffler::PartID i = 0; i < args.num_local_partitions; ++i) {
-        cudf::table table = random_table(
+        size_t size_lb = random_table_size_lower_bound(
             static_cast<cudf::size_type>(args.num_columns),
-            static_cast<cudf::size_type>(args.num_local_rows),
-            min_val,
-            max_val,
-            stream,
-            mr
+            static_cast<cudf::size_type>(args.num_local_rows)
         );
+
+        // reserve at least size_lb and spill if necessary (no overbooking)
+        auto res = reserve_device_memory_and_spill(br, size_lb, false);
+        cudf::table table = with_memory_reservation(std::move(res), [&] {
+            return random_table(
+                static_cast<cudf::size_type>(args.num_columns),
+                static_cast<cudf::size_type>(args.num_local_rows),
+                min_val,
+                max_val,
+                stream,
+                br->device_mr()
+            );
+        });
         input_partitions.emplace_back(transform_fn(std::move(table)));
     }
     stream.synchronize();
@@ -378,7 +387,7 @@ rapidsmpf::Duration run_hash_partition_inline(
         * static_cast<rapidsmpf::shuffler::PartID>(comm->nranks());
 
     std::vector<cudf::table> input_partitions =
-        generate_input_partitions(args, stream, br->device_mr(), std::identity{});
+        generate_input_partitions(args, stream, br, std::identity{});
 
     RAPIDSMPF_MPI(MPI_Barrier(MPI_COMM_WORLD));
 
@@ -442,8 +451,8 @@ rapidsmpf::Duration run_hash_partition_with_datagen(
         * static_cast<rapidsmpf::shuffler::PartID>(comm->nranks());
 
     std::vector<std::unordered_map<rapidsmpf::shuffler::PartID, rapidsmpf::PackedData>>
-        input_partitions = generate_input_partitions(
-            args, stream, br->device_mr(), [&](cudf::table&& table) {
+        input_partitions =
+            generate_input_partitions(args, stream, br, [&](cudf::table&& table) {
                 return rapidsmpf::partition_and_pack(
                     table,
                     {0},
@@ -453,8 +462,7 @@ rapidsmpf::Duration run_hash_partition_with_datagen(
                     stream,
                     br
                 );
-            }
-        );
+            });
 
     RAPIDSMPF_MPI(MPI_Barrier(MPI_COMM_WORLD));
 

--- a/cpp/benchmarks/utils/random_data.hpp
+++ b/cpp/benchmarks/utils/random_data.hpp
@@ -12,6 +12,23 @@
 
 
 /**
+ * @brief The type of random data to generate.
+ */
+using random_data_t = std::int32_t;
+
+/**
+ * @brief The lower bound of the size of a random table.
+ *
+ * @param ncolumns The number of columns in the table.
+ * @param nrows The number of rows in the table.
+ */
+size_t constexpr random_table_size_lower_bound(
+    cudf::size_type ncolumns, cudf::size_type nrows
+) {
+    return static_cast<size_t>(ncolumns * nrows) * sizeof(random_data_t);
+}
+
+/**
  * @brief Generates a random numeric device vector (std::int32_t).
  *
  * Creates a device vector with random integer values uniformly distributed in

--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -29,6 +29,9 @@ enum class MemoryType : int {
     HOST = 1  ///< Host memory
 };
 
+/// @brief The lowest memory type that can be spilled to.
+constexpr MemoryType LowestSpillType = MemoryType::HOST;
+
 /// @brief Array of all the different memory types.
 constexpr std::array<MemoryType, 2> MEMORY_TYPES{{MemoryType::DEVICE, MemoryType::HOST}};
 

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -540,7 +540,7 @@ auto with_memory_reservation(MemoryReservation&& reservation, auto&& f) {
         return std::forward<F>(f)();
     } else {
         static_assert(
-            [] { return false; }(),
+            std::integral_constant<F, false>(),
             "f must be callable with no args or MemoryReservation&"
         );
     }

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -487,7 +487,8 @@ MemoryReservation reserve_or_fail(
  * memory is freed to satisfy the reservation; otherwise, allows overbooking even
  * if spilling was insufficient.
  * @return The memory reservation.
- * @throw std::overflow_error if the buffer resource cannot reserve enough memory
+ * @throw std::overflow_error if allow_overbooking is false and the buffer resource
+ * cannot reserve and spill enough memory.
  */
 MemoryReservation reserve_device_memory_and_spill(
     BufferResource* br, size_t size, bool allow_overbooking
@@ -511,7 +512,8 @@ auto with_memory_reservation(MemoryReservation&& reservation, auto&& f) {
         return std::forward<F>(f)();
     } else {
         static_assert(
-            [] { return false; }(), "f must be callable with either 0 or 1 argument"
+            [] { return false; }(),
+            "f must be callable with no args or MemoryReservation&"
         );
     }
 }

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -523,7 +523,7 @@ MemoryReservation reserve_or_fail(
  * the reservation is released when the function goes out of scope.
  *
  * Similar to `BufferResource::with_reservation`, but this function would not reserve
- * memory, but holds on to the reservation until the function is executed. Is useful in  
+ * memory, but holds on to the reservation until the function is executed. Is useful in
  * situations where the memory reservation is made with spilling.
  *
  * @param reservation moved memory reservation.

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -523,8 +523,8 @@ MemoryReservation reserve_or_fail(
  * the reservation is released when the function goes out of scope.
  *
  * Similar to `BufferResource::with_reservation`, but this function would not reserve
- * memory, but holds on to the reservation until the function is executed. Would be useful
- * in situations where the memory reservation was made with spilling.
+ * memory, but holds on to the reservation until the function is executed. Is useful in  
+ * situations where the memory reservation is made with spilling.
  *
  * @param reservation moved memory reservation.
  * @param f The function to execute.

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -132,8 +132,8 @@ partition_and_split(
  * @return The unpacked and concatenated result.
  *
  * @throw std::overflow_error if the buffer resource cannot reserve enough memory
- * to concatenate all partitions. 
- * @std::logic_error if the partitions are not in device memory.
+ * to concatenate all partitions.
+ * @throw std::logic_error if the partitions are not in device memory.
  *
  * @see partition_and_pack
  * @see cudf::unpack

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -132,8 +132,8 @@ partition_and_split(
  * @return The unpacked and concatenated result.
  *
  * @throw std::overflow_error if the buffer resource cannot reserve enough memory
- * to concatenate all partitions. std::logic_error if the parititons are not in device
- * memory.
+ * to concatenate all partitions. 
+ * @std::logic_error if the partitions are not in device memory.
  *
  * @see partition_and_pack
  * @see cudf::unpack

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -125,6 +125,10 @@ partition_and_split(
  *
  * @return The unpacked and concatenated result.
  *
+ * @throw std::overflow_error if the buffer resource cannot reserve enough memory
+ * to concatenate all partitions. std::logic_error if the parititons are not in device
+ * memory.
+ *
  * @see partition_and_pack
  * @see cudf::unpack
  * @see cudf::concatenate

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -33,6 +33,7 @@ namespace rapidsmpf {
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
+ * @param allow_overbooking If true, allow overbooking (false by default)
  *
  * @return A vector of each partition and a table that owns the device memory.
  *
@@ -50,7 +51,8 @@ partition_and_split(
     uint32_t seed,
     rmm::cuda_stream_view stream,
     BufferResource* br,
-    std::shared_ptr<Statistics> statistics = Statistics::disabled()
+    std::shared_ptr<Statistics> statistics = Statistics::disabled(),
+    bool allow_overbooking = false
 );
 
 
@@ -65,6 +67,7 @@ partition_and_split(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
+ * @param allow_overbooking If true, allow overbooking (false by default)
  *
  * @return A map of partition IDs and their packed tables.
  *
@@ -82,7 +85,8 @@ partition_and_split(
     uint32_t seed,
     rmm::cuda_stream_view stream,
     BufferResource* br,
-    std::shared_ptr<Statistics> statistics = Statistics::disabled()
+    std::shared_ptr<Statistics> statistics = Statistics::disabled(),
+    bool allow_overbooking = false
 );
 
 
@@ -95,6 +99,7 @@ partition_and_split(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
+ * @param allow_overbooking If true, allow overbooking (false by default)
  *
  * @return A map of partition IDs and their packed tables.
  *
@@ -109,7 +114,8 @@ partition_and_split(
     std::vector<cudf::size_type> const& splits,
     rmm::cuda_stream_view stream,
     BufferResource* br,
-    std::shared_ptr<Statistics> statistics = Statistics::disabled()
+    std::shared_ptr<Statistics> statistics = Statistics::disabled(),
+    bool allow_overbooking = false
 );
 
 
@@ -122,7 +128,7 @@ partition_and_split(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
- *
+ * @param allow_overbooking If true, allow overbooking (false by default)
  * @return The unpacked and concatenated result.
  *
  * @throw std::overflow_error if the buffer resource cannot reserve enough memory
@@ -137,7 +143,8 @@ partition_and_split(
     std::vector<PackedData>&& partitions,
     rmm::cuda_stream_view stream,
     BufferResource* br,
-    std::shared_ptr<Statistics> statistics = Statistics::disabled()
+    std::shared_ptr<Statistics> statistics = Statistics::disabled(),
+    bool allow_overbooking = false
 );
 
 /**

--- a/cpp/include/rapidsmpf/integrations/cudf/utils.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/utils.hpp
@@ -57,4 +57,23 @@ std::string str(
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()
 );
 
+/**
+ * @brief Estimate the memory usage of a column.
+ *
+ * @param col The column to estimate the memory usage of.
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @return The estimated memory usage of the column.
+ */
+size_t estimated_memory_usage(cudf::column_view const& col, rmm::cuda_stream_view stream);
+
+/**
+ * @brief Estimate the memory usage of a table.
+ *
+ * @param tbl The table to estimate the memory usage of.
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @return The estimated memory usage of the table.
+ */
+size_t estimated_memory_usage(cudf::table_view const& tbl, rmm::cuda_stream_view stream);
+
+
 }  // namespace rapidsmpf

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -201,6 +201,7 @@ MemoryReservation reserve_or_fail(
 MemoryReservation reserve_device_memory_and_spill(
     BufferResource* br, size_t size, bool allow_overbooking
 ) {
+    // reserve device memory with overbooking
     auto [reservation, ob] = br->reserve(MemoryType::DEVICE, size, true);
 
     if (ob > 0) {  // ask the spill manager to make room for overbooking
@@ -212,7 +213,7 @@ MemoryReservation reserve_device_memory_and_spill(
         );
     }
 
-    return reservation;
+    return std::move(reservation);
 }
 
 }  // namespace rapidsmpf

--- a/cpp/src/integrations/cudf/partition.cpp
+++ b/cpp/src/integrations/cudf/partition.cpp
@@ -120,7 +120,7 @@ partition_and_split(
     auto partition_offsets =
         cudf::host_span<cudf::size_type const>(offsets.data() + 1, offsets.size() - 1);
 
-    // split would not make any copies.
+    // split does not make any copies.
     auto tbl_partitioned =
         cudf::split(partition_table->view(), partition_offsets, stream);
 

--- a/cpp/src/integrations/cudf/utils.cpp
+++ b/cpp/src/integrations/cudf/utils.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <numeric>
-
 #include <type_traits>
 
 #include <cudf/copying.hpp>

--- a/cpp/src/integrations/cudf/utils.cpp
+++ b/cpp/src/integrations/cudf/utils.cpp
@@ -119,12 +119,6 @@ std::string str(
     return ss.str();
 }
 
-/**
- * @brief Calculate the memory usage of a column.
- *
- * @param col The column to calculate the memory usage of.
- * @return The memory usage of the column.
- */
 size_t estimated_memory_usage(
     cudf::column_view const& col, rmm::cuda_stream_view stream
 ) {
@@ -139,12 +133,6 @@ size_t estimated_memory_usage(
     );
 }
 
-/**
- * @brief Calculate the memory usage of a table.
- *
- * @param tbl The table to calculate the memory usage of.
- * @return The memory usage of the table.
- */
 size_t estimated_memory_usage(cudf::table_view const& tbl, rmm::cuda_stream_view stream) {
     return std::transform_reduce(
         tbl.begin(),

--- a/cpp/src/integrations/cudf/utils.cpp
+++ b/cpp/src/integrations/cudf/utils.cpp
@@ -5,7 +5,7 @@
 
 #include <numeric>
 
-#include <cuda/std/type_traits>
+#include <type_traits>
 
 #include <cudf/copying.hpp>
 #include <cudf/lists/lists_column_view.hpp>

--- a/cpp/src/integrations/cudf/utils.cpp
+++ b/cpp/src/integrations/cudf/utils.cpp
@@ -3,7 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <numeric>
+
+#include <cuda/std/type_traits>
+
 #include <cudf/copying.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/structs/structs_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/wrappers/dictionary.hpp>
 
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/utils.hpp>
@@ -37,6 +46,43 @@ struct str_cudf_column_scalar_fn {
         RAPIDSMPF_FAIL("not implemented");
     }
 };
+
+struct cudf_column_data_size_fn {
+    template <typename T>
+        requires(cudf::is_fixed_width<T>())
+    size_t operator()(cudf::column_view const& col, rmm::cuda_stream_view) {
+        return static_cast<size_t>(col.size()) * cudf::size_of(col.type())
+               + bitmask_size(col);
+    }
+
+    // string type specialization
+    template <typename T>
+        requires(std::is_same_v<T, cudf::string_view>)
+    size_t operator()(cudf::column_view const& col, rmm::cuda_stream_view stream) {
+        cudf::strings_column_view sv(col);
+        return static_cast<size_t>(sv.chars_size(stream)) + bitmask_size(col);
+    }
+
+    // compound type specialization except string
+    template <typename T>
+        requires(!std::is_same_v<T, cudf::string_view> && cudf::is_compound<T>())
+    size_t operator()(cudf::column_view const& col, rmm::cuda_stream_view) {
+        // compound types (except string) ie. list, dict, structs dont have a
+        // content::data buffer. Data is stored in children columns. So, just return the
+        // bitmask size.
+        return bitmask_size(col);
+    }
+
+    template <typename T>
+    size_t operator()(cudf::column_view const& col, rmm::cuda_stream_view) {
+        RAPIDSMPF_FAIL("not implemented for type: " + cudf::type_to_name(col.type()));
+    }
+
+    static size_t bitmask_size(cudf::column_view const& col) {
+        return col.has_nulls() ? cudf::bitmask_allocation_size_bytes(col.size()) : 0;
+    }
+};
+
 }  // namespace
 
 std::string str(
@@ -72,6 +118,44 @@ std::string str(
     }
     ss << (tbl.num_columns() == 0 ? "])" : "\b\b])");
     return ss.str();
+}
+
+/**
+ * @brief Calculate the memory usage of a column.
+ *
+ * @param col The column to calculate the memory usage of.
+ * @return The memory usage of the column.
+ */
+size_t estimated_memory_usage(
+    cudf::column_view const& col, rmm::cuda_stream_view stream
+) {
+    return std::transform_reduce(
+        col.child_begin(),
+        col.child_end(),
+        cudf::type_dispatcher(col.type(), cudf_column_data_size_fn{}, col, stream),
+        std::plus{},
+        [&stream](cudf::column_view const& child) {
+            return estimated_memory_usage(child, stream);
+        }
+    );
+}
+
+/**
+ * @brief Calculate the memory usage of a table.
+ *
+ * @param tbl The table to calculate the memory usage of.
+ * @return The memory usage of the table.
+ */
+size_t estimated_memory_usage(cudf::table_view const& tbl, rmm::cuda_stream_view stream) {
+    return std::transform_reduce(
+        tbl.begin(),
+        tbl.end(),
+        size_t{0},
+        std::plus{},
+        [&stream](cudf::column_view const& col) {
+            return estimated_memory_usage(col, stream);
+        }
+    );
 }
 
 }  // namespace rapidsmpf

--- a/cpp/tests/test_cudf_utils.cpp
+++ b/cpp/tests/test_cudf_utils.cpp
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <typeinfo>
+
+#include <gtest/gtest.h>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+#include <rapidsmpf/integrations/cudf/utils.hpp>
+
+using namespace rapidsmpf;
+
+class BaseEstimatedMemoryUsageTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        stream = cudf::get_default_stream();
+    }
+
+    rmm::cuda_stream_view stream;
+};
+
+/**
+ * @brief Templated test suite for testing estimated_memory_usage with different column
+ * types
+ */
+template <typename T>
+class EstimatedMemoryUsageTest : public BaseEstimatedMemoryUsageTest {};
+
+// Define the types to test
+using ColumnTypes =
+    ::testing::Types<int8_t, int16_t, int32_t, int64_t, float, double, bool>;
+
+TYPED_TEST_SUITE(EstimatedMemoryUsageTest, ColumnTypes);
+
+TYPED_TEST(EstimatedMemoryUsageTest, FixedWidthColumnMemoryUsage) {
+    using T = TypeParam;
+    // Test with different sizes
+    std::vector<size_t> test_sizes = {0, 1, 10, 100, 1000, 1000000};
+
+    for (auto size : test_sizes) {
+        SCOPED_TRACE("test size: " + std::to_string(size));
+        std::vector<T> data(size);
+
+        cudf::test::fixed_width_column_wrapper<T> wrapper(data.begin(), data.end());
+        auto column = wrapper.release();
+
+        size_t exp = column->alloc_size();
+        size_t est = rapidsmpf::estimated_memory_usage(column->view(), this->stream);
+
+        EXPECT_EQ(exp, est);
+    }
+}
+
+/**
+ * @brief Test suite for string column memory usage estimation
+ */
+TEST_F(BaseEstimatedMemoryUsageTest, StringType) {
+    // Test with different string data
+    std::vector<std::vector<std::string>> test_cases = {
+        {},  // Empty column
+        {"hello"},  // Single string
+        {"hello", "world", "test"},  // Multiple strings
+        {"", "a", "very long string that should take more memory", "short"
+        },  // Mixed lengths
+        std::vector<std::string>(100, "repeated string")  // Many repeated strings
+    };
+
+    for (const auto& data : test_cases) {
+        // Create a string column
+        cudf::test::strings_column_wrapper wrapper(data.begin(), data.end());
+        auto column = wrapper.release();
+
+        size_t exp = column->alloc_size();
+        size_t est = rapidsmpf::estimated_memory_usage(column->view(), stream);
+
+        EXPECT_EQ(exp, est);
+    }
+}
+
+/**
+ * @brief Test suite for list column memory usage estimation
+ */
+TEST_F(BaseEstimatedMemoryUsageTest, ListType) {
+    // Test with different list data
+    std::vector<std::vector<int32_t>> test_cases = {
+        {},  // Empty column
+        {1, 2, 3},  // Single list
+        {1, 2, 3, 4, 5, 6},  // Multiple values
+        {0, 1, 2, 3, 4, 5},  // Mixed values
+        std::vector<int32_t>(100, 42)  // Many repeated values
+    };
+
+    for (const auto& data : test_cases) {
+        // Create a list column
+        cudf::test::lists_column_wrapper<int32_t> wrapper(data.begin(), data.end());
+        auto column = wrapper.release();
+
+        size_t exp = column->alloc_size();
+        size_t est = rapidsmpf::estimated_memory_usage(column->view(), stream);
+
+        EXPECT_EQ(exp, est);
+    }
+}
+
+/**
+ * @brief Test suite for struct column memory usage estimation
+ */
+TEST_F(BaseEstimatedMemoryUsageTest, StructType) {
+    // Test with different struct data configurations
+    std::vector<std::vector<std::pair<int32_t, std::string>>> test_cases = {
+        {},  // Empty struct column
+        {{std::make_pair(1, "hello")}},  // Single struct
+        {{std::make_pair(1, "hello"), std::make_pair(2, "world")}},  // Two structs
+        {{std::make_pair(0, ""), std::make_pair(100, "very long string"), std::make_pair(42, "short")}},  // Mixed data
+        std::vector<std::pair<int32_t, std::string>>(50, std::make_pair(42, "repeated"))  // Many repeated structs
+    };
+
+    for (const auto& data : test_cases) {
+        // Create struct columns for each field
+        std::vector<int32_t> int_data;
+        std::vector<std::string> string_data;
+
+        for (const auto& item : data) {
+            int_data.push_back(item.first);
+            string_data.push_back(item.second);
+        }
+
+        cudf::test::fixed_width_column_wrapper<int32_t> int_wrapper(
+            int_data.begin(), int_data.end()
+        );
+        cudf::test::strings_column_wrapper string_wrapper(
+            string_data.begin(), string_data.end()
+        );
+
+        std::vector<std::unique_ptr<cudf::column>> children;
+        children.push_back(int_wrapper.release());
+        children.push_back(string_wrapper.release());
+
+        cudf::test::structs_column_wrapper wrapper(std::move(children));
+        auto column = wrapper.release();
+
+        size_t exp = column->alloc_size();
+        size_t est = rapidsmpf::estimated_memory_usage(column->view(), stream);
+
+        EXPECT_EQ(exp, est);
+    }
+}
+/**
+ * @brief Test suite for dictionary column memory usage estimation
+ */
+TEST_F(BaseEstimatedMemoryUsageTest, DictionaryType) {
+    // Test with different dictionary data
+    std::vector<std::vector<std::string>> test_cases = {
+        {},  // Empty column
+        {"hello"},  // Single value
+        {"hello", "world", "test", "hello", "world"},  // Repeated values
+        {"", "a", "very long string", "short", "a", "very long string"
+        },  // Mixed with repetition
+        std::vector<std::string>(100, "repeated")  // Many repeated values
+    };
+
+    for (const auto& data : test_cases) {
+        // Create a dictionary column
+        cudf::test::dictionary_column_wrapper<std::string> wrapper(
+            data.begin(), data.end()
+        );
+        auto column = wrapper.release();
+
+        size_t exp = column->alloc_size();
+        size_t est = rapidsmpf::estimated_memory_usage(column->view(), stream);
+
+        EXPECT_EQ(exp, est);
+    }
+}

--- a/cpp/tests/test_cudf_utils.cpp
+++ b/cpp/tests/test_cudf_utils.cpp
@@ -64,7 +64,8 @@ TEST_F(BaseEstimatedMemoryUsageTest, StringType) {
         {},  // Empty column
         {"hello"},  // Single string
         {"hello", "world", "test"},  // Multiple strings
-        {"", "a", "very long string that should take more memory", "short"
+        {
+            "", "a", "very long string that should take more memory", "short"
         },  // Mixed lengths
         std::vector<std::string>(100, "repeated string")  // Many repeated strings
     };
@@ -115,8 +116,12 @@ TEST_F(BaseEstimatedMemoryUsageTest, StructType) {
         {},  // Empty struct column
         {{std::make_pair(1, "hello")}},  // Single struct
         {{std::make_pair(1, "hello"), std::make_pair(2, "world")}},  // Two structs
-        {{std::make_pair(0, ""), std::make_pair(100, "very long string"), std::make_pair(42, "short")}},  // Mixed data
-        std::vector<std::pair<int32_t, std::string>>(50, std::make_pair(42, "repeated"))  // Many repeated structs
+        {{std::make_pair(0, ""),
+          std::make_pair(100, "very long string"),
+          std::make_pair(42, "short")}},  // Mixed data
+        std::vector<std::pair<int32_t, std::string>>(
+            50, std::make_pair(42, "repeated")
+        )  // Many repeated structs
     };
 
     for (const auto& data : test_cases) {
@@ -149,6 +154,7 @@ TEST_F(BaseEstimatedMemoryUsageTest, StructType) {
         EXPECT_EQ(exp, est);
     }
 }
+
 /**
  * @brief Test suite for dictionary column memory usage estimation
  */
@@ -158,7 +164,8 @@ TEST_F(BaseEstimatedMemoryUsageTest, DictionaryType) {
         {},  // Empty column
         {"hello"},  // Single value
         {"hello", "world", "test", "hello", "world"},  // Repeated values
-        {"", "a", "very long string", "short", "a", "very long string"
+        {
+            "", "a", "very long string", "short", "a", "very long string"
         },  // Mixed with repetition
         std::vector<std::string>(100, "repeated")  // Many repeated values
     };

--- a/cpp/tests/test_partition.cpp
+++ b/cpp/tests/test_partition.cpp
@@ -115,7 +115,7 @@ TEST_F(SpillingTest, SpillUnspillRoundtripPreservesDataAndMetadata) {
     std::vector<rapidsmpf::PackedData> input;
     input.push_back(create_packed_data(metadata, payload, stream, br.get()));
 
-    // Device -> Host
+    // Device -> Device (moves data)
     auto on_gpu = unspill_partitions(
         std::move(input), stream, br.get(), /*allow_overbooking=*/true
     );
@@ -123,7 +123,7 @@ TEST_F(SpillingTest, SpillUnspillRoundtripPreservesDataAndMetadata) {
     EXPECT_EQ(on_gpu[0].data->mem_type(), rapidsmpf::MemoryType::DEVICE);
     EXPECT_EQ(*on_gpu[0].metadata, metadata);
 
-    // Host -> Device
+    // Device -> Host
     auto back_on_host = spill_partitions(std::move(on_gpu), stream, br.get());
     ASSERT_EQ(back_on_host.size(), 1);
     EXPECT_EQ(back_on_host[0].data->mem_type(), rapidsmpf::MemoryType::HOST);

--- a/cpp/tests/test_partition.cpp
+++ b/cpp/tests/test_partition.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cudf/contiguous_split.hpp>
+#include <cudf/utilities/traits.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/debug_utilities.hpp>
@@ -16,6 +18,7 @@
 #include <rapidsmpf/buffer/packed_data.hpp>
 #include <rapidsmpf/buffer/resource.hpp>
 #include <rapidsmpf/integrations/cudf/partition.hpp>
+#include <rapidsmpf/integrations/cudf/utils.hpp>
 #include <rapidsmpf/shuffler/shuffler.hpp>
 #include <rapidsmpf/utils.hpp>
 

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -117,7 +117,9 @@ void test_shuffler(
         hash_fn,
         seed,
         stream,
-        br
+        br,
+        nullptr,  // statistics
+        true  // allow_overbooking because this is an input table
     );
 
     cudf::size_type row_offset = 0;
@@ -146,7 +148,9 @@ void test_shuffler(
                 hash_fn,
                 seed,
                 stream,
-                br
+                br,
+                nullptr,  // statistics
+                true  // allow_overbooking because this is an input table
             );
             // Add the chunks to the shuffle
             insert_fn(std::move(packed_chunks));
@@ -162,7 +166,9 @@ void test_shuffler(
         auto result = rapidsmpf::unpack_and_concat(
             rapidsmpf::unspill_partitions(std::move(packed_chunks), stream, br, true),
             stream,
-            br
+            br,
+            nullptr,  // statistics
+            true  // allow_overbooking because this is an output table
         );
 
         // We should only receive the partitions assigned to this rank.
@@ -723,8 +729,8 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
     );
     cudf::table input_table = random_table_with_index(seed, 1000, 0, 10);
     auto input_chunks = rapidsmpf::partition_and_pack(
-        input_table, {1}, total_num_partitions, hash_fn, seed, stream, &br
-    );
+        input_table, {1}, total_num_partitions, hash_fn, seed, stream, &br, nullptr, true
+    );  // with overbooking
 
     // Insert spills does nothing when device memory is available, we start
     // with 2 device allocations.

--- a/cpp/tests/utils.hpp
+++ b/cpp/tests/utils.hpp
@@ -100,6 +100,8 @@ template <typename T>
 ) {
     auto metadata_ptr =
         std::make_unique<std::vector<uint8_t>>(metadata.begin(), metadata.end());
+
+    auto reservation = br->reserve(rapidsmpf::MemoryType::DEVICE, data.size(), true);
     auto data_ptr =
         std::make_unique<rmm::device_buffer>(data.data(), data.size(), stream);
     return rapidsmpf::PackedData{


### PR DESCRIPTION
Currently when performing shuffle partitioning, splitting, or during data generation, we pass simply pass the device memory resource to cudf utils. Then we loose track of those allocations in the memory resource counters. This causes OOM issues in memory constrained environments (ex: running bench_shuffle with limited memory). 

This PR adds memory reservations prior to calling cudf utils that perform deep copies. 

NOTE: 
I'm suspecting this change might cause some performance degradation, but it should improve stability. 