### PR TITLE
Python API for gathering statistics

### DIFF
--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -13,7 +13,10 @@ from rapidsmpf.communicator import COMMUNICATORS
 from rapidsmpf.config import Options
 from rapidsmpf.examples.dask import DaskCudfIntegration, dask_cudf_shuffle
 from rapidsmpf.integrations.dask.core import get_worker_context
-from rapidsmpf.integrations.dask.shuffler import rapidsmpf_shuffle_graph
+from rapidsmpf.integrations.dask.shuffler import (
+    gather_shuffle_statistics,
+    rapidsmpf_shuffle_graph,
+)
 from rapidsmpf.shuffler import Shuffler
 
 dask_cuda = pytest.importorskip("dask_cuda")
@@ -356,3 +359,37 @@ def test_many_shuffles_single() -> None:
         else:
             shuffler.shutdown()
             del context.shufflers[shuffle_id]
+
+
+def test_gather_shuffle_statistics() -> None:
+    with LocalCUDACluster(n_workers=1) as cluster, Client(cluster) as client:
+        config_options = Options({"dask_statistics": "true"})
+
+        df = dask.datasets.timeseries().reset_index(drop=True).to_backend("cudf")
+        shuffled = dask_cudf_shuffle(df, on=["name"], config_options=config_options)
+        shuffled.compute()
+
+        stats = gather_shuffle_statistics(client)
+        expected_stats = {
+            "event-loop-check-future-finish",
+            "event-loop-init-gpu-data-send",
+            "event-loop-metadata-recv",
+            "event-loop-metadata-send",
+            "event-loop-post-incoming-chunk-recv",
+            "event-loop-total",
+            "shuffle-payload-recv",
+            "shuffle-payload-send",
+            "spill-bytes-host-to-device",
+            "spill-time-host-to-device",
+        }
+
+        assert set(stats) == expected_stats
+        for stat in expected_stats:
+            assert stats[stat]["count"] > 0
+            assert "value" in stats[stat]
+
+        assert stats["shuffle-payload-send"]["value"] > 0
+        assert (
+            stats["shuffle-payload-send"]["value"]
+            == stats["shuffle-payload-recv"]["value"]
+        )


### PR DESCRIPTION
This adds a python API for gathering statistics.

```python
import pprint
import dask.distributed
from dask_cuda import LocalCUDACluster

from rapidsmpf.config import Options
from rapidsmpf.examples.dask import dask_cudf_shuffle
from rapidsmpf.integrations.dask.shuffler import gather_shuffle_statistics


def main():
    config_options = Options({"dask_statistics": "true"})

    # RapidsMPF is compatible with `dask_cuda` workers.
    # Use an rmm pool for optimal performance.
    cluster =  LocalCUDACluster(rmm_pool_size=0.8)
    client = dask.distributed.Client(cluster)

    df = dask.datasets.timeseries().reset_index(drop=True).to_backend("cudf")
    shuffled = dask_cudf_shuffle(df, on=["name"], config_options=config_options)

    # collect the results in memory.
    shuffled.compute()

    stats = gather_shuffle_statistics(client)
    pprint.pprint(stats)


if __name__ == "__main__":
    main()

```

which prints:

```
{'event-loop-check-future-finish': {'count': 414255,
                                    'value': 0.21929259299999673},
 'event-loop-init-gpu-data-send': {'count': 414255, 'value': 1.084213984999997},
 'event-loop-metadata-recv': {'count': 414255, 'value': 18.802375738000066},
 'event-loop-metadata-send': {'count': 414255, 'value': 5.232919412000041},
 'event-loop-post-incoming-chunk-recv': {'count': 414255,
                                         'value': 12.169733180998538},
 'event-loop-total': {'count': 828510, 'value': 76.28069178999999},
 'shuffle-payload-recv': {'count': 569, 'value': 86509952.0},
 'shuffle-payload-send': {'count': 569, 'value': 86509952.0},
 'spill-bytes-host-to-device': {'count': 30, 'value': 0.0},
 'spill-time-host-to-device': {'count': 30, 'value': 0.000358106}}
```

Closes #422 