### PR TITLE
[MINOR] Enable overbooking by default in cudf utils 

### DIFF
--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -33,7 +33,7 @@ namespace rapidsmpf {
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
- * @param allow_overbooking If true, allow overbooking (false by default)
+ * @param allow_overbooking If true, allow overbooking (true by default)
  *
  * @return A vector of each partition and a table that owns the device memory.
  *
@@ -67,7 +67,8 @@ partition_and_split(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
- * @param allow_overbooking If true, allow overbooking (false by default)
+ * @param allow_overbooking If true, allow overbooking (true by default)
+ * // TODO: disable this by default https://github.com/rapidsmpf/rapidsmpf/issues/449
  *
  * @return A map of partition IDs and their packed tables.
  *
@@ -99,7 +100,8 @@ partition_and_split(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
- * @param allow_overbooking If true, allow overbooking (false by default)
+ * @param allow_overbooking If true, allow overbooking (true by default)
+ * // TODO: disable this by default https://github.com/rapidsmpf/rapidsmpf/issues/449
  *
  * @return A map of partition IDs and their packed tables.
  *
@@ -128,7 +130,9 @@ partition_and_split(
  * @param stream CUDA stream used for device memory operations and kernel launches.
  * @param br Buffer resource for memory allocations.
  * @param statistics The statistics instance to use (disabled by default).
- * @param allow_overbooking If true, allow overbooking (false by default)
+ * @param allow_overbooking If true, allow overbooking (true by default)
+ * // TODO: disable this by default https://github.com/rapidsmpf/rapidsmpf/issues/449
+ *
  * @return The unpacked and concatenated result.
  *
  * @throw std::overflow_error if the buffer resource cannot reserve enough memory

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -52,7 +52,7 @@ partition_and_split(
     rmm::cuda_stream_view stream,
     BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled(),
-    bool allow_overbooking = false
+    bool allow_overbooking = true
 );
 
 
@@ -86,7 +86,7 @@ partition_and_split(
     rmm::cuda_stream_view stream,
     BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled(),
-    bool allow_overbooking = false
+    bool allow_overbooking = true
 );
 
 
@@ -115,7 +115,7 @@ partition_and_split(
     rmm::cuda_stream_view stream,
     BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled(),
-    bool allow_overbooking = false
+    bool allow_overbooking = true
 );
 
 
@@ -144,7 +144,7 @@ partition_and_split(
     rmm::cuda_stream_view stream,
     BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled(),
-    bool allow_overbooking = false
+    bool allow_overbooking = true
 );
 
 /**

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -79,7 +79,9 @@ MemoryReservation BufferResource::reserve_and_spill(
         auto spilled = spill_manager_.spill(ob);
         RAPIDSMPF_EXPECTS(
             allow_overbooking || spilled >= ob,
-            "failed to spill enough memory",
+            "failed to spill enough memory (reserved: " + format_nbytes(size)
+                + ", overbooking: " + format_nbytes(ob)
+                + ", spilled: " + format_nbytes(spilled) + ")",
             std::overflow_error
         );
     }

--- a/cpp/src/integrations/cudf/utils.cpp
+++ b/cpp/src/integrations/cudf/utils.cpp
@@ -78,7 +78,7 @@ struct cudf_column_data_size_fn {
     }
 
     static size_t bitmask_size(cudf::column_view const& col) {
-        return col.has_nulls() ? cudf::bitmask_allocation_size_bytes(col.size()) : 0;
+        return col.nullable() ? cudf::bitmask_allocation_size_bytes(col.size()) : 0;
     }
 };
 


### PR DESCRIPTION
A temporary measure to preserve behavior prior to #438. But this needs to be reverted in #449