### PR TITLE
Fix linker flags in new streaming benchmarks CMakeLists

### DIFF
--- a/cpp/benchmarks/streaming/CMakeLists.txt
+++ b/cpp/benchmarks/streaming/CMakeLists.txt
@@ -11,6 +11,7 @@ set_target_properties(
              CXX_STANDARD_REQUIRED ON
              CUDA_STANDARD 20
              CUDA_STANDARD_REQUIRED ON
+             LINK_FLAGS "-Wl,--allow-shlib-undefined"
 )
 target_compile_options(
   bench_streaming_shuffle PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"


### PR DESCRIPTION
https://github.com/rapidsai/rapidsmpf/pull/429 added linker flags to allow linking to pass in devcontainers, unfortunately the new streaming engine ended up being merged just after that without the same changes, which are now included in this PR.