### PR TITLE
Add `distributed-ucxx` to `dependencies.yaml`

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -21,6 +21,7 @@ dependencies:
 - cython>=3.0.3
 - dask-cuda==25.10.*,>=0.0.0a0
 - dask-cudf==25.10.*,>=0.0.0a0
+- distributed-ucxx==0.46.*,>=0.0.0a0
 - doxygen=1.9.1
 - gcc_linux-aarch64=14.*
 - gdb

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -21,6 +21,7 @@ dependencies:
 - cython>=3.0.3
 - dask-cuda==25.10.*,>=0.0.0a0
 - dask-cudf==25.10.*,>=0.0.0a0
+- distributed-ucxx==0.46.*,>=0.0.0a0
 - doxygen=1.9.1
 - gcc_linux-64=14.*
 - gdb

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -449,6 +449,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - dask-cuda==25.10.*,>=0.0.0a0
+          - distributed-ucxx==0.46.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -45,6 +45,7 @@ test = [
     "cupy-cuda12x>=12.0.0",
     "dask-cuda==25.10.*,>=0.0.0a0",
     "dask-cudf==25.10.*,>=0.0.0a0",
+    "distributed-ucxx==0.46.*,>=0.0.0a0",
     "libcudf==25.10.*,>=0.0.0a0",
     "librmm==25.10.*,>=0.0.0a0",
     "numpy >=1.23,<3.0a0",


### PR DESCRIPTION
Adds `distributed-ucxx` to the `depends_on_dask_cuda` section of `dependencies.yaml`, since rapidsmpf technically requires `distributed-ucxx` (or `ucxx` + `ucx-py`) to function on a dask-cuda cluster.

This change *should* make it a bit easier to build multi-gpu Polars with rapidsmpf.