### PR TITLE
Added documentation for statistics

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -102,3 +102,19 @@ libraries.
 ```{eval-rst}
 .. automodule:: rapidsmpf.config
    :members:
+```
+
+(api-statistics)=
+## Statistics
+
+```{eval-rst}
+.. automodule:: rapidsmpf.statistics
+   :members:
+```
+
+## RMM Resource Adaptor
+
+```{eval-rst}
+.. automodule:: rapidsmpf.rmm_resource_adaptor
+   :members:
+```

--- a/docs/source/background.md
+++ b/docs/source/background.md
@@ -1,1 +1,24 @@
 # Background
+
+## Shuffle Statistics
+
+Shuffles can be configured to collect statistics, which can help you understand the performance of the system.
+This table gives an overview of the different statistics collected.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `spill-bytes-device-to-host` | int | The size in bytes of data moved from device to host when spilling data. |
+| `spill-time-device-to-host` | float | The duration of the device to host spill. The unit is platform dependent. |
+| `spill-bytes-host-to-device` | int | The size in bytes of data moved from host to device when unspilling data. |
+| `spill-time-host-to-device` | float | The duration of the host to device spill. The unit is platform dependent. |
+| `spill-bytes-recv-to-host` | int | The size in bytes of data received into host memory on one node from some other node. |
+| `shuffle-payload-send` | int | The size in bytes of data transferred from a node (including locally, from a node to itself). |
+| `shuffle-payload-recv` | int | The size in bytes of data transferred to a node (including locally, from a node to itself). |
+| `event-loop-total` | float | The duration of a Shuffler's event loop iteration. The unit is platform dependent. |
+| `event-loop-metadata-send` | float | The duration of sending metadata from one node to another. The unit is platform dependent. |
+| `event-loop-metadata-recv` | float | The duration of receiving any outstanding metadata messages from other nodes. The unit is platform dependent. |
+| `event-loop-post-incoming-chunk-recv` | float | The duration of posting receives for any incoming chunks from other nodes. The unit is platform dependent. |
+| `event-loop-init-gpu-data-send` | float | The duration of receiving ready-for-data messages and initiating data send operations. The duration of the actual data transfer is not captured by this statistic. The unit is platform dependent. |
+| `event-loop-check-future-finish` | float | The duration spent checking if any data has finished being sent. The unit is platform dependent. |
+
+Statistics are available in both C++ and [Python](#api-statistics).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,6 +86,11 @@ nitpick_ignore_regex = [
     ("py:obj", "rapidsmpf.communicator.communicator.LOG_LEVEL.*"),
     ("py:obj", "rapidsmpf.buffer.buffer.MemoryType.*"),
     ("py:obj", "(denominator|imag|numerator|real)"),
+    ('py:obj', 'rapidsmpf.rmm_resource_adaptor.AllocType.*'),
     ('py:class', 'rmm.pylibrmm.stream.Stream'),
     ('py:class', 'rmm.pylibrmm.memory_resource.DeviceMemoryResource'),
+    # We're subclassing this from RMM, and sphinx can't find these methods.
+    ("py:obj", "rapidsmpf.rmm_resource_adaptor.RmmResourceAdaptor.allocate"),
+    ("py:obj", "rapidsmpf.rmm_resource_adaptor.RmmResourceAdaptor.deallocate"),
+    ("py:obj", "rapidsmpf.rmm_resource_adaptor.RmmResourceAdaptor.get_upstream"),
 ]

--- a/python/rapidsmpf/rapidsmpf/rmm_resource_adaptor.pyx
+++ b/python/rapidsmpf/rapidsmpf/rmm_resource_adaptor.pyx
@@ -11,11 +11,12 @@ from rmm.pylibrmm.memory_resource cimport (DeviceMemoryResource,
 ctypedef cpp_RmmResourceAdaptor* cpp_RmmResourceAdaptor_ptr
 
 cdef class ScopedMemoryRecord:
+    """Scoped memory record for tracking memory usage statistics."""
     @staticmethod
     cdef ScopedMemoryRecord from_handle(cpp_ScopedMemoryRecord handle):
         """Create a new scoped memory record from a C++ handle
 
-        This is copying `handle`, which is a POD struct.
+        This is copying ``handle``, which is a POD struct.
 
         Parameters
         ----------
@@ -140,6 +141,7 @@ cdef class ScopedMemoryRecord:
 
 
 cdef class RmmResourceAdaptor(UpstreamResourceAdaptor):
+    """A RMM memory resource adaptor tailored to RapidsMPF."""
     def __cinit__(
         self,
         DeviceMemoryResource upstream_mr,
@@ -160,7 +162,7 @@ cdef class RmmResourceAdaptor(UpstreamResourceAdaptor):
 
         fallback_mr
             If specified, a fallback device memory resource used when allocation from
-            the primary resource throws `rmm::out_of_memory`.
+            the primary resource throws ``rmm::out_of_memory``.
         """
         self.fallback_mr = fallback_mr
 

--- a/python/rapidsmpf/rapidsmpf/statistics.pyx
+++ b/python/rapidsmpf/rapidsmpf/statistics.pyx
@@ -197,21 +197,22 @@ cdef class Statistics:
         Returns a context manager that tracks memory allocations and
         deallocations made through the associated memory resource while
         the context is active. The profiling data is aggregated under
-        the provided `name` and made available via `get_memory_records()`.
+        the provided ``name`` and made available via
+        :meth:`Statistics.get_memory_records()`.
 
         The statistics include:
-        - Total and peak memory allocated within the scope (`scoped`)
-        - Global peak memory usage during the scope (`global_peak`)
-        - Number of times the named scope was entered (`num_calls`)
+        - Total and peak memory allocated within the scope (``scoped``)
+        - Global peak memory usage during the scope (``global_peak``)
+        - Number of times the named scope was entered (``num_calls``)
 
-        If memory profiling is disabled or the memory resource is `None`,
+        If memory profiling is disabled or the memory resource is ``None``,
         this is a no-op.
 
         Parameters
         ----------
         name
             A unique identifier for the profiling scope. Used as a key
-            when accessing profiling data via `get_memory_records()`.
+            when accessing profiling data via :meth:`Statistics.get_memory_records`.
 
         Returns
         -------
@@ -280,7 +281,7 @@ cdef class MemoryRecorder:
     A context manager for recording memory allocation statistics within a code block.
 
     This class is not intended to be used directly by end users. Instead, use
-    `Statistics.memory_profiling(name)`, which creates and manages an instance
+    :meth:`Statistics.memory_profiling`, which creates and manages an instance
     of this class.
 
     Parameters


### PR DESCRIPTION
This adds some documentation for the statistics we collect, along Python API docs for ``rapidsmpf.statistics`` and objects referenced from there.