### PR TITLE
BaseChunk: common base for streaming chunks 

### DIFF
--- a/cpp/include/rapidsmpf/streaming/core/base_chunk.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/base_chunk.hpp
@@ -29,7 +29,7 @@ class BaseChunk {
     constexpr BaseChunk(
         std::uint64_t sequence_number, rmm::cuda_stream_view stream
     ) noexcept
-        : _sequence_number{sequence_number}, _stream{stream} {}
+        : sequence_number_{sequence_number}, stream_{stream} {}
 
     /**
      * @brief Virtual destructor.
@@ -56,7 +56,7 @@ class BaseChunk {
      * @return The sequence number.
      */
     [[nodiscard]] constexpr std::uint64_t sequence_number() const noexcept {
-        return _sequence_number;
+        return sequence_number_;
     }
 
     /**
@@ -65,12 +65,12 @@ class BaseChunk {
      * @return The associated rmm::cuda_stream_view.
      */
     [[nodiscard]] rmm::cuda_stream_view stream() const noexcept {
-        return _stream;
+        return stream_;
     }
 
   private:
-    std::uint64_t _sequence_number;
-    rmm::cuda_stream_view _stream;
+    std::uint64_t sequence_number_;
+    rmm::cuda_stream_view stream_;
 };
 
 }  // namespace rapidsmpf::streaming

--- a/cpp/include/rapidsmpf/streaming/core/base_chunk.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/base_chunk.hpp
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <rmm/cuda_stream_view.hpp>
+
+namespace rapidsmpf::streaming {
+
+/**
+ * @brief Common base for streaming chunks.
+ *
+ * Holds the per-chunk sequence number (for ordering) and the CUDA stream
+ * on which the chunk's resources were created.
+ *
+ */
+class BaseChunk {
+  public:
+    /**
+     * @brief Construct a base chunk.
+     *
+     * @param sequence_number Ordering identifier for the chunk.
+     * @param stream CUDA stream associated with the chunk's resources.
+     */
+    constexpr BaseChunk(
+        std::uint64_t sequence_number, rmm::cuda_stream_view stream
+    ) noexcept
+        : _sequence_number{sequence_number}, _stream{stream} {}
+
+    /**
+     * @brief Virtual destructor.
+     */
+    virtual ~BaseChunk() = default;
+
+    /**
+     * @brief move constructor
+     */
+    BaseChunk(BaseChunk&&) noexcept = default;
+
+    /**
+     * @brief move assignment operator
+     * @return this chunk.
+     */
+    BaseChunk& operator=(BaseChunk&&) noexcept = default;
+
+    BaseChunk(BaseChunk const&) = delete;
+    BaseChunk& operator=(BaseChunk const&) = delete;
+
+    /**
+     * @brief Sequence number used to preserve chunk ordering.
+     *
+     * @return The sequence number.
+     */
+    [[nodiscard]] constexpr std::uint64_t sequence_number() const noexcept {
+        return _sequence_number;
+    }
+
+    /**
+     * @brief The CUDA stream on which this chunk was created.
+     *
+     * @return The associated rmm::cuda_stream_view.
+     */
+    [[nodiscard]] rmm::cuda_stream_view stream() const noexcept {
+        return _stream;
+    }
+
+  private:
+    std::uint64_t _sequence_number;
+    rmm::cuda_stream_view _stream;
+};
+
+}  // namespace rapidsmpf::streaming

--- a/cpp/include/rapidsmpf/streaming/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/streaming/cudf/partition.hpp
@@ -26,7 +26,7 @@ namespace rapidsmpf::streaming {
  * @brief Chunk of packed partitions identified by partition ID.
  *
  * Represents a single unit of work in a streaming pipeline where each entry
- * maps a `shuffler::PartID` to its packed (serialized) data payload.
+ * maps a `shuffler::PartID` to its packed (serialized) data.
  *
  * The sequence number from BaseChunk is used to preserve cross-chunk ordering.
  */
@@ -41,10 +41,10 @@ class PartitionMapChunk : public BaseChunk {
      */
     PartitionMapChunk(
         std::uint64_t sequence_number,
-        rmm::cuda_stream_view stream,
-        std::unordered_map<shuffler::PartID, PackedData>&& data
+        std::unordered_map<shuffler::PartID, PackedData>&& data,
+        rmm::cuda_stream_view stream
     )
-        : BaseChunk(sequence_number, stream), _data(std::move(data)) {}
+        : BaseChunk(sequence_number, stream), data_(std::move(data)) {}
 
     ~PartitionMapChunk() override = default;
 
@@ -67,11 +67,11 @@ class PartitionMapChunk : public BaseChunk {
      * @return Mutable reference to the partition → packed-data map.
      */
     [[nodiscard]] auto& data() noexcept {
-        return _data;
+        return data_;
     }
 
   private:
-    std::unordered_map<shuffler::PartID, PackedData> _data;
+    std::unordered_map<shuffler::PartID, PackedData> data_;
 };
 
 /**
@@ -91,10 +91,10 @@ class PartitionVectorChunk : public BaseChunk {
      */
     PartitionVectorChunk(
         std::uint64_t sequence_number,
-        rmm::cuda_stream_view stream,
-        std::vector<PackedData>&& data
+        std::vector<PackedData>&& data,
+        rmm::cuda_stream_view stream
     )
-        : BaseChunk(sequence_number, stream), _data(std::move(data)) {}
+        : BaseChunk(sequence_number, stream), data_(std::move(data)) {}
 
     ~PartitionVectorChunk() override = default;
 
@@ -117,11 +117,11 @@ class PartitionVectorChunk : public BaseChunk {
      * @return Packed data for each partition stored in a vector.
      */
     [[nodiscard]] auto& data() noexcept {
-        return _data;
+        return data_;
     }
 
   private:
-    std::vector<PackedData> _data;
+    std::vector<PackedData> data_;
 };
 
 namespace node {

--- a/cpp/include/rapidsmpf/streaming/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/streaming/cudf/partition.hpp
@@ -66,7 +66,7 @@ class PartitionMapChunk : public BaseChunk {
      *
      * @return Mutable reference to the partition → packed-data map.
      */
-    [[nodiscard]] auto& data() noexcept {
+    [[nodiscard]] constexpr auto& data() noexcept {
         return data_;
     }
 

--- a/cpp/include/rapidsmpf/streaming/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/streaming/cudf/partition.hpp
@@ -46,6 +46,21 @@ class PartitionMapChunk : public BaseChunk {
     )
         : BaseChunk(sequence_number, stream), _data(std::move(data)) {}
 
+    ~PartitionMapChunk() override = default;
+
+    /**
+     * @brief move constructor
+     */
+    PartitionMapChunk(PartitionMapChunk&&) noexcept = default;
+
+    /**
+     * @brief move assignment operator
+     * @return this chunk.
+     */
+    PartitionMapChunk& operator=(PartitionMapChunk&&) noexcept = default;
+    PartitionMapChunk(PartitionMapChunk const&) = delete;
+    PartitionMapChunk& operator=(PartitionMapChunk const&) = delete;
+
     /**
      * @brief Access the packed data for each partition.
      *
@@ -81,6 +96,21 @@ class PartitionVectorChunk : public BaseChunk {
     )
         : BaseChunk(sequence_number, stream), _data(std::move(data)) {}
 
+    ~PartitionVectorChunk() override = default;
+
+    /**
+     * @brief move constructor
+     */
+    PartitionVectorChunk(PartitionVectorChunk&&) noexcept = default;
+
+    /**
+     * @brief move assignment operator
+     * @return this chunk.
+     */
+    PartitionVectorChunk& operator=(PartitionVectorChunk&&) noexcept = default;
+    PartitionVectorChunk(PartitionVectorChunk const&) = delete;
+    PartitionVectorChunk& operator=(PartitionVectorChunk const&) = delete;
+
     /**
      * @brief Access the packed data.
      *
@@ -95,7 +125,6 @@ class PartitionVectorChunk : public BaseChunk {
 };
 
 namespace node {
-
 
 /**
  * @brief Asynchronously partitions input tables into multiple packed (serialized) tables.
@@ -156,7 +185,6 @@ Node unpack_and_concat(
     SharedChannel<PartitionMapChunk> ch_in,
     SharedChannel<TableChunk> ch_out
 );
-
 
 /**
  * @brief Asynchronously unpacks and concatenates vectors of packed partitions.

--- a/cpp/src/streaming/cudf/partition.cpp
+++ b/cpp/src/streaming/cudf/partition.cpp
@@ -101,15 +101,18 @@ Node unpack_and_concat(
         }
         std::unique_ptr<cudf::table> ret = rapidsmpf::unpack_and_concat(
             rapidsmpf::unspill_partitions(
-                std::move(partition_vec->data), partition_vec->stream, ctx->br(), false
+                std::move(partition_vec->data()),
+                partition_vec->stream(),
+                ctx->br(),
+                false
             ),
-            partition_vec->stream,
+            partition_vec->stream(),
             ctx->br(),
             ctx->statistics()
         );
         co_await ch_out->send(
             std::make_unique<TableChunk>(
-                partition_vec->sequence_number, std::move(ret), partition_vec->stream
+                partition_vec->sequence_number(), std::move(ret), partition_vec->stream()
             )
         );
     }

--- a/cpp/src/streaming/cudf/partition.cpp
+++ b/cpp/src/streaming/cudf/partition.cpp
@@ -35,7 +35,6 @@ Node partition_and_pack(
 
         PartitionMapChunk partition_map{
             tbl.sequence_number(),
-            tbl.stream(),
             rapidsmpf::partition_and_pack(
                 tbl.table_view(),
                 std::move(columns_to_hash),
@@ -45,7 +44,8 @@ Node partition_and_pack(
                 table->stream(),
                 ctx->br(),
                 ctx->statistics()
-            )
+            ),
+            tbl.stream()
         };
 
         co_await ch_out->send(

--- a/cpp/src/streaming/cudf/shuffler.cpp
+++ b/cpp/src/streaming/cudf/shuffler.cpp
@@ -90,7 +90,7 @@ Node shuffler(
         auto packed_chunks = shuffler.extract(finished_partition);
         co_await ch_out->send(
             std::make_unique<PartitionVectorChunk>(
-                sequence_number, stream, std::move(packed_chunks)
+                sequence_number, std::move(packed_chunks), stream
             )
         );
     }

--- a/cpp/src/streaming/cudf/shuffler.cpp
+++ b/cpp/src/streaming/cudf/shuffler.cpp
@@ -90,7 +90,7 @@ Node shuffler(
         auto packed_chunks = shuffler.extract(finished_partition);
         co_await ch_out->send(
             std::make_unique<PartitionVectorChunk>(
-                sequence_number, std::move(packed_chunks)
+                sequence_number, stream, std::move(packed_chunks)
             )
         );
     }

--- a/cpp/src/streaming/cudf/shuffler.cpp
+++ b/cpp/src/streaming/cudf/shuffler.cpp
@@ -72,12 +72,12 @@ Node shuffler(
             break;
         }
         // Make sure that the input chunk's stream is in sync with shuffler's stream.
-        sync_streams(stream, partition_map->stream, event);
+        sync_streams(stream, partition_map->stream(), event);
 
-        shuffler.insert(std::move(partition_map->data));
+        shuffler.insert(std::move(partition_map->data()));
 
         // Use the highest input sequence number as the output sequence number.
-        sequence_number = std::max(sequence_number, partition_map->sequence_number);
+        sequence_number = std::max(sequence_number, partition_map->sequence_number());
     }
 
     // Tell the shuffler that we have no more input data.


### PR DESCRIPTION
Introduce a common base for streaming chunks and fixes a bug in the shuffler where the stream argument wasn't set.

This also simplifies the Python bindings a lot.