### PR TITLE
Avoid setting memory resource in `rmpf_worker_setup`

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -452,7 +452,6 @@ def rmpf_worker_setup(
             else None
         ),
     )
-    rmm.mr.set_current_device_resource(mr)
 
     # Print statistics at worker shutdown.
     if options.get_or_default(f"{option_prefix}statistics", default_value=False):


### PR DESCRIPTION
This updates `rmpf_worker_setup` to avoid setting the (global) default device memory resource. rapidsmpf *shouldn't* need it set, and setting it can interfere with applications using RMM and rapidsmpf.