### PR TITLE
Fix missing shuffle stream argument

### DIFF
--- a/cpp/src/streaming/cudf/shuffler.cpp
+++ b/cpp/src/streaming/cudf/shuffler.cpp
@@ -90,7 +90,7 @@ Node shuffler(
         auto packed_chunks = shuffler.extract(finished_partition);
         co_await ch_out->send(
             std::make_unique<PartitionVectorChunk>(
-                sequence_number, std::move(packed_chunks)
+                sequence_number, std::move(packed_chunks), stream
             )
         );
     }


### PR DESCRIPTION
Putting https://github.com/rapidsai/rapidsmpf/pull/464 on hold until we decide on a channel type design.  So fixing the missing stream argument here. 

