### PR TITLE
Fix matching of completed futures to chunks in allgather

### DIFF
--- a/cpp/include/rapidsmpf/allgather/allgather.hpp
+++ b/cpp/include/rapidsmpf/allgather/allgather.hpp
@@ -539,14 +539,14 @@ class AllGather {
     std::vector<std::unique_ptr<detail::Chunk>> to_receive_{};
     /// @brief Fire-and-forget communication futures
     std::vector<std::unique_ptr<Communicator::Future>> fire_and_forget_{};
-    /// @brief Chunks that have been sent with their communication futures
-    std::vector<
-        std::pair<std::unique_ptr<detail::Chunk>, std::unique_ptr<Communicator::Future>>>
-        sent_{};
-    /// @brief Chunks that have been received with their communication futures
-    std::vector<
-        std::pair<std::unique_ptr<detail::Chunk>, std::unique_ptr<Communicator::Future>>>
-        received_{};
+    /// @brief Chunks for which a send future is posted
+    std::vector<std::unique_ptr<detail::Chunk>> sent_posted_{};
+    /// @brief Futures for posted sends. Order matches
+    std::vector<std::unique_ptr<Communicator::Future>> sent_futures_{};
+    /// @brief Chunks for which a receive future is posted
+    std::vector<std::unique_ptr<detail::Chunk>> receive_posted_{};
+    /// @brief Futures for posted receives. Order matches.
+    std::vector<std::unique_ptr<Communicator::Future>> receive_futures_{};
 };
 
 }  // namespace rapidsmpf::allgather

--- a/cpp/include/rapidsmpf/communicator/communicator.hpp
+++ b/cpp/include/rapidsmpf/communicator/communicator.hpp
@@ -464,11 +464,11 @@ class Communicator {
      *
      * @param[inout] future_vector Vector of Future objects. Completed
      * futures are erased from the vector.
-     * @return Completed futures.
+     * @return Pair of completed futures and indices of input vector that were completed.
      */
-    [[nodiscard]] virtual std::vector<std::unique_ptr<Future>> test_some(
-        std::vector<std::unique_ptr<Future>>& future_vector
-    ) = 0;
+    [[nodiscard]] virtual std::
+        pair<std::vector<std::unique_ptr<Future>>, std::vector<std::size_t>>
+        test_some(std::vector<std::unique_ptr<Future>>& future_vector) = 0;
 
     /**
      * @brief Tests for completion of multiple futures in a map.

--- a/cpp/include/rapidsmpf/communicator/mpi.hpp
+++ b/cpp/include/rapidsmpf/communicator/mpi.hpp
@@ -160,9 +160,10 @@ class MPI final : public Communicator {
     /**
      * @copydoc Communicator::test_some
      */
-    std::vector<std::unique_ptr<Communicator::Future>> test_some(
-        std::vector<std::unique_ptr<Communicator::Future>>& future_vector
-    ) override;
+    std::pair<
+        std::vector<std::unique_ptr<Communicator::Future>>,
+        std::vector<std::size_t>>
+    test_some(std::vector<std::unique_ptr<Communicator::Future>>& future_vector) override;
 
     // clang-format off
     /**

--- a/cpp/include/rapidsmpf/communicator/single.hpp
+++ b/cpp/include/rapidsmpf/communicator/single.hpp
@@ -116,9 +116,10 @@ class Single final : public Communicator {
      * @throws std::runtime_error if called (single-process communicators should never
      * send messages).
      */
-    std::vector<std::unique_ptr<Communicator::Future>> test_some(
-        std::vector<std::unique_ptr<Communicator::Future>>& future_vector
-    ) override;
+    std::pair<
+        std::vector<std::unique_ptr<Communicator::Future>>,
+        std::vector<std::size_t>>
+    test_some(std::vector<std::unique_ptr<Communicator::Future>>& future_vector) override;
 
     // clang-format off
     /**

--- a/cpp/include/rapidsmpf/communicator/ucxx.hpp
+++ b/cpp/include/rapidsmpf/communicator/ucxx.hpp
@@ -194,9 +194,10 @@ class UCXX final : public Communicator {
      *
      * @throws ucxx::Error if any completed futures did not complete successfully.
      */
-    std::vector<std::unique_ptr<Communicator::Future>> test_some(
-        std::vector<std::unique_ptr<Communicator::Future>>& future_vector
-    ) override;
+    std::pair<
+        std::vector<std::unique_ptr<Communicator::Future>>,
+        std::vector<std::size_t>>
+    test_some(std::vector<std::unique_ptr<Communicator::Future>>& future_vector) override;
 
     // clang-format off
     /**

--- a/cpp/src/allgather/allgather.cpp
+++ b/cpp/src/allgather/allgather.cpp
@@ -252,55 +252,27 @@ std::size_t PostBox::spill(
 }
 
 static std::vector<std::unique_ptr<Chunk>> test_some(
-    std::vector<std::pair<std::unique_ptr<Chunk>, std::unique_ptr<Communicator::Future>>>&
-        chunks,
+    std::vector<std::unique_ptr<Chunk>>& chunks,
+    std::vector<std::unique_ptr<Communicator::Future>>& futures,
     Communicator* comm
 ) {
+    RAPIDSMPF_EXPECTS(
+        chunks.size() == futures.size(), "Mismatching size for chunks and futures"
+    );
     if (chunks.empty()) {
         return {};
     }
+    auto [complete_futures, indices] = comm->test_some(futures);
     std::vector<std::unique_ptr<Chunk>> result;
-    std::vector<std::unique_ptr<Communicator::Future>> futures;
-    futures.reserve(chunks.size());
-    std::ranges::transform(chunks, std::back_inserter(futures), [](auto&& c) {
-        return std::move(c.second);
-    });
-    // Note: this will always complete a single contiguous block of
-    // futures since we only ever receive from a single source and a
-    // single tag.
-    // If either of those preconditions were to be broken we would
-    // need a different implementation here.
-    auto complete = comm->test_some(futures);
-    result.reserve(complete.size());
+    result.reserve(complete_futures.size());
     std::ranges::transform(
-        complete, chunks, std::back_inserter(result), [&](auto&& fut, auto&& c) {
-            auto chunk = std::move(c.first);
-            RAPIDSMPF_EXPECTS(
-                c.second == nullptr, "Expecting future to have been moved from"
-            );
-            auto data = comm->get_gpu_data(std::move(fut));
-            chunk->attach_data_buffer(std::move(data));
+        indices, complete_futures, std::back_inserter(result), [&](auto i, auto&& fut) {
+            auto chunk = std::move(chunks[i]);
+            chunk->attach_data_buffer(comm->get_gpu_data(std::move(fut)));
             return std::move(chunk);
         }
     );
-    auto cit = chunks.begin() + static_cast<std::int64_t>(complete.size());
-    auto fit = futures.begin();
-    for (; cit != chunks.end() && fit != futures.end(); cit++, fit++) {
-        RAPIDSMPF_EXPECTS(*fit, "Expecting a future here");
-        RAPIDSMPF_EXPECTS(!(*cit).second, "Expecting no future here");
-        std::swap((*cit).second, *fit);
-    }
-    auto osize = chunks.size();
-    std::erase(
-        chunks,
-        std::pair<std::unique_ptr<Chunk>, std::unique_ptr<Communicator::Future>>{
-            nullptr, nullptr
-        }
-    );
-    RAPIDSMPF_EXPECTS(
-        chunks.size() == osize - result.size(),
-        "Didn't remove the expected number of chunks"
-    );
+    std::erase(chunks, nullptr);
     return result;
 }
 }  // namespace detail
@@ -500,8 +472,9 @@ ProgressThread::ProgressState AllGather::event_loop() {
                     chunk->data_size() > 0, "Not expecting zero-sized data chunks"
                 );
                 auto buf = chunk->release_data_buffer();
-                sent_.emplace_back(
-                    std::move(chunk), comm_->send(std::move(buf), dst, gpu_data_tag)
+                sent_posted_.emplace_back(std::move(chunk));
+                sent_futures_.emplace_back(
+                    comm_->send(std::move(buf), dst, gpu_data_tag)
                 );
             }
         }
@@ -536,14 +509,14 @@ ProgressThread::ProgressState AllGather::event_loop() {
                 break;
             }
             auto buf = chunk->release_data_buffer();
-            received_.emplace_back(
-                std::move(chunk), comm_->recv(src, gpu_data_tag, std::move(buf))
-            );
+            receive_posted_.emplace_back(std::move(chunk));
+            receive_futures_.emplace_back(comm_->recv(src, gpu_data_tag, std::move(buf)));
         }
         std::erase(to_receive_, nullptr);
 
         std::ranges::for_each(
-            detail::test_some(received_, comm_.get()), [&](auto&& chunk) {
+            detail::test_some(receive_posted_, receive_futures_, comm_.get()),
+            [&](auto&& chunk) {
                 if (chunk->origin() == dst) {
                     for_extraction_.insert(std::move(chunk));
                 } else {
@@ -551,14 +524,17 @@ ProgressThread::ProgressState AllGather::event_loop() {
                 }
             }
         );
-        for_extraction_.insert(detail::test_some(sent_, comm_.get()));
+        for_extraction_.insert(
+            detail::test_some(sent_posted_, sent_futures_, comm_.get())
+        );
         if (!fire_and_forget_.empty()) {
             std::ignore = comm_->test_some(fire_and_forget_);
         }
     }
     bool const containers_empty =
-        (fire_and_forget_.empty() && sent_.empty() && received_.empty()
-         && to_receive_.empty() && inserted_.empty());
+        (fire_and_forget_.empty() && sent_posted_.empty() && receive_posted_.empty()
+         && sent_futures_.empty() && receive_futures_.empty() && to_receive_.empty()
+         && inserted_.empty());
     bool const is_finished = finished();
     bool const is_done =
         !active_.load(std::memory_order_acquire) || (is_finished && containers_empty);

--- a/cpp/src/communicator/mpi.cpp
+++ b/cpp/src/communicator/mpi.cpp
@@ -215,9 +215,8 @@ std::unique_ptr<std::vector<uint8_t>> MPI::recv_from(Rank src, Tag tag) {
     return msg;
 }
 
-std::vector<std::unique_ptr<Communicator::Future>> MPI::test_some(
-    std::vector<std::unique_ptr<Communicator::Future>>& future_vector
-) {
+std::pair<std::vector<std::unique_ptr<Communicator::Future>>, std::vector<std::size_t>>
+MPI::test_some(std::vector<std::unique_ptr<Communicator::Future>>& future_vector) {
     if (future_vector.empty()) {
         return {};
     }
@@ -250,7 +249,10 @@ std::vector<std::unique_ptr<Communicator::Future>> MPI::test_some(
         [&](std::size_t i) { return std::move(future_vector[i]); }
     );
     std::erase(future_vector, nullptr);
-    return completed;
+    return {
+        std::move(completed),
+        std::vector<std::size_t>(indices.begin(), indices.begin() + num_completed)
+    };
 }
 
 std::vector<std::size_t> MPI::test_some(

--- a/cpp/src/communicator/single.cpp
+++ b/cpp/src/communicator/single.cpp
@@ -35,9 +35,8 @@ std::unique_ptr<std::vector<uint8_t>> Single::recv_from(Rank, Tag) {
     return nullptr;
 }
 
-std::vector<std::unique_ptr<Communicator::Future>> Single::test_some(
-    std::vector<std::unique_ptr<Communicator::Future>>&
-) {
+std::pair<std::vector<std::unique_ptr<Communicator::Future>>, std::vector<std::size_t>>
+Single::test_some(std::vector<std::unique_ptr<Communicator::Future>>&) {
     RAPIDSMPF_FAIL("Unexpected test_some from self", std::runtime_error);
 }
 

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -1171,9 +1171,8 @@ std::unique_ptr<std::vector<uint8_t>> UCXX::recv_from(Rank src, Tag tag) {
     return msg;
 }
 
-std::vector<std::unique_ptr<Communicator::Future>> UCXX::test_some(
-    std::vector<std::unique_ptr<Communicator::Future>>& future_vector
-) {
+std::pair<std::vector<std::unique_ptr<Communicator::Future>>, std::vector<std::size_t>>
+UCXX::test_some(std::vector<std::unique_ptr<Communicator::Future>>& future_vector) {
     if (future_vector.empty()) {
         return {};
     }
@@ -1210,7 +1209,7 @@ std::vector<std::unique_ptr<Communicator::Future>> UCXX::test_some(
         return std::move(future_vector[i]);
     });
     std::erase(future_vector, nullptr);
-    return completed;
+    return {std::move(completed), std::move(indices)};
 }
 
 std::vector<std::size_t> UCXX::test_some(

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -358,7 +358,7 @@ class Shuffler::Progress {
             // when using the UCXX communicator. See comment in
             // ucxx.cpp::test_some.
             for (auto& [dst, futures] : ready_ack_receives_) {
-                auto finished = shuffler_.comm_->test_some(futures);
+                auto [finished, _] = shuffler_.comm_->test_some(futures);
                 for (auto&& future : finished) {
                     auto const msg_data =
                         shuffler_.comm_->get_gpu_data(std::move(future));


### PR DESCRIPTION
The lack of message overtaking in MPI and UCX means that messages are matched in order to their receive buffers. However this need not mean that the set of completed futures when we call test_some is from a contiguous block (even if all messages are from the same rank with the same tag). In the allgather implementation we were incorrectly relying on this (incorrect) invariant.

To fix it, return the indices of completed futures in the input future vector along with the completed futures themselves. This allows us to match up completed futures with their correct chunk to reattach data buffers.

- Closes #469
- Closes #472