### PR TITLE
Remove possibility of race condition when using extract_ready

### DIFF
--- a/cpp/include/rapidsmpf/allgather/allgather.hpp
+++ b/cpp/include/rapidsmpf/allgather/allgather.hpp
@@ -499,6 +499,14 @@ class AllGather {
     void insert(std::unique_ptr<detail::Chunk> chunk);
 
     /**
+     * @brief Handle a finish message.
+     *
+     * @param expected_chunks The expected number of chunks we expect
+     * from the rank this finish message is from.
+     */
+    void mark_finish(std::uint64_t expected_chunks) noexcept;
+
+    /**
      * @brief Wait for the allgather operation to complete.
      *
      * @param timeout Optional maximum duration to wait. Negative values mean no timeout.


### PR DESCRIPTION
The AllGather implementation offers a non-blocking way of extracting any ready messages in an unordered fashion by allowing us to extract whichever chunks have currently been received.

However, the implementation previously admitted a race condition where an extracting thread could incorrectly observe that the allgather operation was finished and thus exit its extraction loop before all chunks have been received.

The culprit is a lack of ordering between the modification of the finish counter and moving the extraction postbox's goalpost. To fix this, ensure that when we receive a finish chunk we first increment the goalpost and then decrement the finish counter and introduce a happens-before relationship between the two.

- Closes #480