### PR TITLE
Revise ``Spillable`` and ``SpillableCollection`` behavior

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -16,7 +16,7 @@ from rmm.pylibrmm.stream import DEFAULT_STREAM
 
 from rapidsmpf.buffer.buffer import MemoryType
 from rapidsmpf.buffer.resource import BufferResource, LimitAvailableMemory
-from rapidsmpf.buffer.spill_collection import SpillCollection
+from rapidsmpf.buffer.spill_collection import SpillCollection, Spillable
 from rapidsmpf.config import (
     Optional,
     OptionalBytes,
@@ -301,7 +301,8 @@ def insert_partition(
         Other keys needed by ``callback``.
     """
     callback(
-        df,
+        # Check if input partitions are Spillable.
+        df.unspill() if isinstance(df, Spillable) else df,
         partition_id,
         partition_count,
         get_shuffler(get_context(), shuffle_id),

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -16,7 +16,7 @@ from rmm.pylibrmm.stream import DEFAULT_STREAM
 
 from rapidsmpf.buffer.buffer import MemoryType
 from rapidsmpf.buffer.resource import BufferResource, LimitAvailableMemory
-from rapidsmpf.buffer.spill_collection import SpillCollection, Spillable
+from rapidsmpf.buffer.spill_collection import SpillCollection
 from rapidsmpf.config import (
     Optional,
     OptionalBytes,
@@ -301,8 +301,7 @@ def insert_partition(
         Other keys needed by ``callback``.
     """
     callback(
-        # Check if input partitions are Spillable.
-        df.unspill() if isinstance(df, Spillable) else df,
+        df,
         partition_id,
         partition_count,
         get_shuffler(get_context(), shuffle_id),

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/spilling.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/spilling.py
@@ -143,16 +143,17 @@ class SpillableWrapper(Generic[WrappedType]):
         """
         if amount > 0:
             on_device = self._on_device
-            if on_device is not None and self._on_host is None:
+            if on_device is not None:
                 ret = self.approx_spillable_amount()
-                self._on_host = dask_dumps(
-                    on_device,
-                    context={
-                        "stream": stream,
-                        "device_mr": device_mr,
-                        "staging_device_buffer": staging_device_buffer,
-                    },
-                )
+                if self._on_host is None:
+                    self._on_host = dask_dumps(
+                        on_device,
+                        context={
+                            "stream": stream,
+                            "device_mr": device_mr,
+                            "staging_device_buffer": staging_device_buffer,
+                        },
+                    )
                 self._on_device = None
                 return ret
         return 0

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/spilling.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/spilling.py
@@ -75,17 +75,14 @@ class SpillableWrapper(Generic[WrappedType]):
     ):
         self._on_device = on_device
         self._on_host = on_host
-        if on_device is not None:
-            # If running on a Worker, add this wrapper to the worker's spill collection,
-            # which makes it available for spilling on demand.
-            try:
-                spill_collection: SpillCollection = (
-                    get_worker_context().spill_collection
-                )
-            except ValueError:
-                pass
-            else:
-                spill_collection.add_spillable(self)
+        # If running on a Worker, add this wrapper to the worker's spill collection,
+        # which makes it available for spilling on demand.
+        try:
+            spill_collection: SpillCollection = get_worker_context().spill_collection
+        except ValueError:
+            pass
+        else:
+            spill_collection.add_spillable(self)
 
     def mem_type(self) -> MemoryType:
         """

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask_spilling.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask_spilling.py
@@ -57,6 +57,11 @@ def test_spillable_wrapper(stream: Stream, device_mr: DeviceMemoryResource) -> N
     # A SpillableWrapper never deletes spilled data.
     assert wrapper._on_host is not None
 
+    # Check that we can spill again.
+    wrapper.spill(amount=1, stream=stream, device_mr=device_mr)
+    assert wrapper.mem_type() == MemoryType.HOST
+    assert wrapper.approx_spillable_amount() == 0
+
 
 @pytest.mark.parametrize(
     "memtype",

--- a/python/rapidsmpf/rapidsmpf/tests/test_spill_collection.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_spill_collection.py
@@ -35,6 +35,10 @@ class MySpillableObject:
         self._mem_type = MemoryType.HOST
         return self._nbytes
 
+    def unspill(self) -> MySpillableObject:
+        self._mem_type = MemoryType.DEVICE
+        return self
+
 
 def test_spill_collection(stream: Stream, device_mr: DeviceMemoryResource) -> None:
     collection = SpillCollection()
@@ -55,3 +59,10 @@ def test_spill_collection(stream: Stream, device_mr: DeviceMemoryResource) -> No
     assert collection.spill(100, stream=stream, device_mr=device_mr) == 0
     assert obj2.mem_type() == MemoryType.HOST
     assert obj3.mem_type() == MemoryType.HOST
+
+    # Check that we can unspill and re-spill an object.
+    obj1 = obj1.unspill()
+    assert obj1.mem_type() == MemoryType.DEVICE
+    assert collection.spill(100, stream=stream, device_mr=device_mr) == 100
+    assert collection.spill(100, stream=stream, device_mr=device_mr) == 0
+    assert obj1.mem_type() == MemoryType.HOST


### PR DESCRIPTION
Experimental spilling changes. **NOTE**: I'm definitely still **unsure** about these changes.

**Background**: While thinking about ways to improve memory stability in multi-gpu Polars, I eventually persuaded myself that the existing `SpillableCollection`/`SpillableWrapper` functionality in `rapidsmpf` **should** (probably) be more effective than we've observed so far.

Some pain points:

- Right now, cudf-polars can only leverage rapidsmpf spilling in an "all or nothing" way. Rather than wrapping every callable object in the task graph, it would probably be more effective if cudf-polars tasks were always designed to pull `Spillable` inputs into device memory if/when necessary. This way, we could be more targeted with our spilling and we could avoid the fragile (and somewhat expensive) graph processing step. Although this would **mostly** be a cudf-polars change, it does require ~`rapidsmpf.integrations.core.insert_partition` to automatically handle `Spillable` input. It also requires~ `Spillable`/`SpillableWrapper` behavior to be a bit more robust than it is right now (see next point).
- While experimenting with rapidsmpf spilling, I realized that `Spillable` objects **cannot** be spilled more than once by a `SpillCollection`. In other words, if broadcasted data is wrapped in `Spillable` and then passed into 10+ other dependent tasks, the broadcasted data can only be spilled/unspilled once.
  - **NOTE**: This is the primary problem I am pursuing in this PR. In order for us to handle spilling for broadcast joins with multi-partition "small" tables, we probably need to be able to repetitively spill/un-spill parts of the small table.
  
 cc @madsbk - I'm very interested in your thoughts on this :)