### PR TITLE
Run CUPTI C++ example with timeout and stack

### DIFF
--- a/ci/run_cpp_example_smoketests.sh
+++ b/ci/run_cpp_example_smoketests.sh
@@ -4,6 +4,8 @@
 
 set -xeuo pipefail
 
+TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
+
 # Support customizing the ctests' install location
 cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/examples/librapidsmpf/"
 
@@ -16,7 +18,7 @@ export OMPI_MCA_opal_cuda_support=1  # enable CUDA support in OpenMPI
 mpirun --map-by node --bind-to none -np 2 ./example_shuffle
 
 # Ensure that cupti monitor example is runnable and creates the expected csv file
-./example_cupti_monitor
+python "${TIMEOUT_TOOL_PATH}" 30 ./example_cupti_monitor
 if [[ ! -f cupti_monitor_example.csv ]]; then
   echo "Error: cupti_monitor_example.csv was not created!"
   exit 1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -274,11 +274,12 @@ dependencies:
     common:
       - output_types: conda
         packages:
+          - click >=8.1
           - *cmake_ver
+          - cuda-sanitizer-api
+          - psutil  # Used for timeout_with_stack.py
           - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
           - valgrind
-          - cuda-sanitizer-api
-          - click >=8.1
   test_python:
     common:
       - output_types: conda
@@ -286,7 +287,7 @@ dependencies:
           - gdb
       - output_types: [conda, pyproject, requirements]
         packages:
-          - psutil
+          - psutil  # Used for timeout_with_stack.py
           - pytest
           - nvidia-ml-py
     specific:


### PR DESCRIPTION
We have seen an instance of `./example_cupti_monitor` deadlocking in CI. This change limits it to a 30 second run and prints the stack when a deadlock occurs, so it may aid us in debugging if it happens again.