### PR TITLE
Fix test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,12 +35,15 @@ jobs:
       sha: ${{ inputs.sha }}
   conda-cpp-memcheck:
     secrets: inherit
-    needs: checks
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.10
     with:
-      build_type: pull-request
-      script: "ci/test_cpp_memcheck.sh"
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
+      script: ci/test_cpp_memcheck.sh
+      sha: ${{ inputs.sha }}
   conda-python-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.10


### PR DESCRIPTION
The test workflow was modified in #498 to add a custom job, however, the syntax was incorrect and broke the workflow, causing errors such as:

```
Invalid workflow file: .github/workflows/test.yaml
(Line: 38, Col: 12): Job 'conda-cpp-memcheck' depends on unknown job 'checks'.
```

This should fix the broken syntax and match the style of the file.