### PR TITLE
update dependencies: nvidia-ml-py (>=12)

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - myst-parser
 - ninja
 - numpydoc
-- nvidia-ml-py
+- nvidia-ml-py>=12
 - openmpi >=5.0
 - pre-commit
 - psutil

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - myst-parser
 - ninja
 - numpydoc
-- nvidia-ml-py
+- nvidia-ml-py>=12
 - openmpi >=5.0
 - pre-commit
 - psutil

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - myst-parser
 - ninja
 - numpydoc
-- nvidia-ml-py
+- nvidia-ml-py>=12
 - openmpi >=5.0
 - pre-commit
 - psutil

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - myst-parser
 - ninja
 - numpydoc
-- nvidia-ml-py
+- nvidia-ml-py>=12
 - openmpi >=5.0
 - pre-commit
 - psutil

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -289,7 +289,7 @@ dependencies:
         packages:
           - psutil  # Used for timeout_with_stack.py
           - pytest
-          - nvidia-ml-py
+          - nvidia-ml-py>=12
     specific:
       - output_types: conda
         matrices:

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -43,7 +43,7 @@ test = [
     "cudf==25.10.*,>=0.0.0a0",
     "dask-cuda==25.10.*,>=0.0.0a0",
     "dask-cudf==25.10.*,>=0.0.0a0",
-    "nvidia-ml-py",
+    "nvidia-ml-py>=12",
     "psutil",
     "pytest",
     "ucxx==0.46.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/214, updating pins to match the rest of RAPIDS:

* nvidia-ml-py: `>=12`

## Notes for Reviewers

### Benefits of these changes

`nvidia-ml-py` is currently not directly pinned in this project, but it's constrained to `>=12` anyway by depending on `cudf`, so this change should have 0 effect on this project's current state.

Making the pin explicit makes it a bit easier to do all-of-RAPIDS updates in the future if needed.