### PR TITLE
Add `known_first_party` configuration for isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
     hooks:
       - id: isort
         name: isort (cython)
-        args: ["--config-root=python/", "--resolve-all-configs"]
+        args: ["--resolve-all-configs"]
         files: python/.*
         types_or: [cython]
   - repo: https://github.com/codespell-project/codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,12 @@ ignore-words-list = "inout,unparseable,falsy,couldn,Couldn,thirdparty"
 builtin = "clear"
 quiet-level = 3
 
+[tool.isort]
+# Define known first party modules explicitly to avoid directory name dependency.
+# Without this the isort/cython checks may fail if the repository clone is not
+# named `rapidsmpf`.
+known_first_party = ["rapidsmpf", "librapidsmpf"]
+
 [tool.mypy]
 exclude = ["_deps/*"]
 ignore_missing_imports = true


### PR DESCRIPTION
This is necessary to ensure isort doesn't break style if the clone of the repository has a different name than `rapidsmpf`.

To reproduce the original issue:

```
git clone https://github.com/rapidsai/rapidsmpf rapidsmpf-clone  # The directory name must be something other than rapidsmpf
cd rapidsmpf-clone
git checkout 9b36b33  # Current branch-25.10 commit, where this is known to fail
pre-commit run isort -a
```

That will make style changes to Cython files that are already in the expected format.