### PR TITLE
Buffer's stream

### DIFF
--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -261,7 +261,7 @@ rapidsmpf::Duration do_run(
             output_partitions.emplace_back(
                 rapidsmpf::unpack_and_concat(
                     rapidsmpf::unspill_partitions(
-                        std::move(packed_chunks), stream, br, true, statistics
+                        std::move(packed_chunks), br, true, statistics
                     ),
                     stream,
                     br,

--- a/cpp/examples/example_shuffle.cpp
+++ b/cpp/examples/example_shuffle.cpp
@@ -118,9 +118,7 @@ int main(int argc, char** argv) {
         // convenience function.
         local_outputs.push_back(
             rapidsmpf::unpack_and_concat(
-                rapidsmpf::unspill_partitions(
-                    std::move(packed_chunks), stream, &br, true
-                ),
+                rapidsmpf::unspill_partitions(std::move(packed_chunks), &br, true),
                 stream,
                 &br
             )

--- a/cpp/include/rapidsmpf/allgather/allgather.hpp
+++ b/cpp/include/rapidsmpf/allgather/allgather.hpp
@@ -326,9 +326,10 @@ class PostBox {
     /**
      * @brief Spill device data from the post box.
      *
+     * The spilling is stream ordered by the spilled buffers' CUDA streams.
+     *
      * @param br The buffer resource for host and device allocations.
      * @param log Logger instance.
-     * @param stream Stream on which device data should be spilled.
      * @param amount Requested amount of data to spill in bytes.
      * @return Actual amount of data spilled in bytes.
      *
@@ -336,10 +337,7 @@ class PostBox {
      * spilled, as well as the amount of "overspill".
      */
     [[nodiscard]] std::size_t spill(
-        BufferResource* br,
-        Communicator::Logger& log,
-        rmm::cuda_stream_view stream,
-        std::size_t amount
+        BufferResource* br, Communicator::Logger& log, std::size_t amount
     );
 
   private:

--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -145,15 +145,6 @@ class Buffer {
     }
 
     /**
-     * @brief Get the event for the buffer.
-     *
-     * @return The event.
-     */
-    [[nodiscard]] std::shared_ptr<CudaEvent> get_event() const {
-        return event_;
-    }
-
-    /**
      * @brief Check if the device memory operation has completed.
      *
      * @return true if the device memory operation has completed or no device

--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -191,16 +191,12 @@ class Buffer {
      *
      * @param device_buffer A unique pointer to a device buffer.
      * @param stream CUDA stream used for the device buffer allocation.
-     * @param event The shared event to use for the buffer.
      *
      * @throws std::invalid_argument if `device_buffer` is null.
-     * @throws std::invalid_argument if `stream` or `br->mr` isn't the same used by
-     * `device_buffer`.
+     * @throws std::invalid_argument if `stream` isn't the same used by `device_buffer`.
      */
     Buffer(
-        std::unique_ptr<rmm::device_buffer> device_buffer,
-        rmm::cuda_stream_view stream,
-        std::shared_ptr<CudaEvent> event = nullptr
+        std::unique_ptr<rmm::device_buffer> device_buffer, rmm::cuda_stream_view stream
     );
 
     /**

--- a/cpp/include/rapidsmpf/buffer/buffer.hpp
+++ b/cpp/include/rapidsmpf/buffer/buffer.hpp
@@ -126,7 +126,10 @@ class Buffer {
     /**
      * @brief Get the associated CUDA stream.
      *
-     * @return The CUDA stream.
+     * All operations must either use this stream or synchronize with it
+     * before accessing the underlying data (both host and device memory).
+     *
+     * @return The associated CUDA stream.
      */
     [[nodiscard]] constexpr rmm::cuda_stream_view stream() const noexcept {
         return stream_;
@@ -251,7 +254,6 @@ class Buffer {
     StorageT storage_;
     /// @brief CUDA event used to track copy operations
     std::shared_ptr<CudaEvent> event_;
-
     rmm::cuda_stream_view stream_;
 };
 

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -317,13 +317,10 @@ class BufferResource {
      *
      * @param data A unique pointer to the device buffer.
      * @param stream CUDA stream used for the data allocation, copy, and/or move.
-     * @param event The event to use for the buffer.
      * @return A unique pointer to the resulting Buffer.
      */
     std::unique_ptr<Buffer> move(
-        std::unique_ptr<rmm::device_buffer> data,
-        rmm::cuda_stream_view stream,
-        std::shared_ptr<CudaEvent> event = nullptr
+        std::unique_ptr<rmm::device_buffer> data, rmm::cuda_stream_view stream
     );
 
     /**

--- a/cpp/include/rapidsmpf/buffer/resource.hpp
+++ b/cpp/include/rapidsmpf/buffer/resource.hpp
@@ -305,9 +305,12 @@ class BufferResource {
      * @brief Move host vector data into a Buffer.
      *
      * @param data A unique pointer to the vector containing host data.
+     * @param stream CUDA stream used for the data allocation, copy, and/or move.
      * @return A unique pointer to the resulting Buffer.
      */
-    std::unique_ptr<Buffer> move(std::unique_ptr<std::vector<uint8_t>> data);
+    std::unique_ptr<Buffer> move(
+        std::unique_ptr<std::vector<uint8_t>> data, rmm::cuda_stream_view stream
+    );
 
     /**
      * @brief Move device buffer data into a Buffer.
@@ -326,10 +329,10 @@ class BufferResource {
     /**
      * @brief Move a Buffer to the specified memory type by the reservation.
      *
-     * If and only if moving between different memory types will this perform a copy.
+     * If and only if moving between different memory types will this perform a copy
+     * using the buffer's CUDA stream.
      *
      * @param buffer The buffer to move.
-     * @param stream CUDA stream used for the buffer allocation, copy, and/or move.
      * @param reservation The reservation to use for memory allocations.
      * @return A unique pointer to the moved Buffer.
      *
@@ -337,18 +340,16 @@ class BufferResource {
      * @throws std::overflow_error if the memory requirement exceeds the reservation.
      */
     std::unique_ptr<Buffer> move(
-        std::unique_ptr<Buffer> buffer,
-        rmm::cuda_stream_view stream,
-        MemoryReservation& reservation
+        std::unique_ptr<Buffer> buffer, MemoryReservation& reservation
     );
 
     /**
      * @brief Move a Buffer to a device buffer.
      *
-     * If and only if moving between different memory types will this perform a copy.
+     * If and only if moving between different memory types will this perform a copy using
+     * the buffer's CUDA stream.
      *
      * @param buffer The buffer to move.
-     * @param stream CUDA stream used for the buffer allocation, copy, and/or move.
      * @param reservation The reservation to use for memory allocations.
      * @return A unique pointer to the resulting device buffer.
      *
@@ -357,18 +358,16 @@ class BufferResource {
      * @throws std::overflow_error if the memory requirement exceeds the reservation.
      */
     std::unique_ptr<rmm::device_buffer> move_to_device_buffer(
-        std::unique_ptr<Buffer> buffer,
-        rmm::cuda_stream_view stream,
-        MemoryReservation& reservation
+        std::unique_ptr<Buffer> buffer, MemoryReservation& reservation
     );
 
     /**
      * @brief Move a Buffer to a host vector.
      *
-     * If and only if moving between different memory types will this perform a copy.
+     * If and only if moving between different memory types will this perform a copy
+     * using the buffer's CUDA stream.
      *
      * @param buffer The buffer to move.
-     * @param stream CUDA stream used for the buffer allocation, copy, and/or move.
      * @param reservation The reservation to use for memory allocations.
      * @return A unique pointer to the resulting host vector.
      *
@@ -377,9 +376,7 @@ class BufferResource {
      * @throws std::overflow_error if the memory requirement exceeds the reservation.
      */
     std::unique_ptr<std::vector<uint8_t>> move_to_host_vector(
-        std::unique_ptr<Buffer> buffer,
-        rmm::cuda_stream_view stream,
-        MemoryReservation& reservation
+        std::unique_ptr<Buffer> buffer, MemoryReservation& reservation
     );
 
     /**

--- a/cpp/include/rapidsmpf/cuda_stream.hpp
+++ b/cpp/include/rapidsmpf/cuda_stream.hpp
@@ -55,7 +55,7 @@ void cuda_stream_join(
         event = event_.get();
     }
 
-    // Let all downstreams should wait on all upstreams.
+    // Let all downstreams wait on all upstreams.
     for (rmm::cuda_stream_view const& upstream : upstreams) {
         event->record(upstream);
         for (rmm::cuda_stream_view const& downstream : downstreams) {

--- a/cpp/include/rapidsmpf/cuda_stream.hpp
+++ b/cpp/include/rapidsmpf/cuda_stream.hpp
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <memory>
+
+#include <rapidsmpf/cuda_event.hpp>
+
+namespace rapidsmpf {
+
+
+/**
+ * @brief Make downstream CUDA streams wait on upstream CUDA streams.
+ *
+ * This call is asynchronous with respect to the host thread; no host-side
+ * blocking occurs.
+ *
+ * @tparam Range1 Iterable whose elements are rmm::cuda_stream_view.
+ * @tparam Range2 Iterable whose elements are rmm::cuda_stream_view.
+ *
+ * @param downstreams Streams that must not run ahead.
+ * @param upstreams Streams whose already-enqueued work must complete first.
+ * @param event Optional CUDA event used for synchronization. A unique event per
+ * call is not required; the same event may be reused. If `nullptr`, a temporary
+ * event is created internally. The reason to provide an event is to avoid the
+ * small overhead of constructing a temporary one.
+ *
+ * @note If all upstream and downstream streams are identical, this function is a no-op.
+ */
+template <typename Range1, typename Range2>
+void cuda_stream_join(
+    Range1 const& downstreams, Range2 const& upstreams, CudaEvent* event = nullptr
+) {
+    // Quick exit if all streams are identical.
+    if ([&] {
+            for (rmm::cuda_stream_view const& upstream : upstreams) {
+                for (rmm::cuda_stream_view const& downstream : downstreams) {
+                    if (upstream.value() != downstream.value()) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }())
+    {
+        return;
+    }
+
+    // Create a temporary cuda event if none was provided.
+    std::unique_ptr<CudaEvent> event_;
+    if (event == nullptr) {
+        event_ = std::make_unique<CudaEvent>();
+        event = event_.get();
+    }
+
+    // Let all downstreams should wait on all upstreams.
+    for (rmm::cuda_stream_view const& upstream : upstreams) {
+        event->record(upstream);
+        for (rmm::cuda_stream_view const& downstream : downstreams) {
+            if (upstream.value() != downstream.value()) {
+                event->stream_wait(downstream);
+            }
+        }
+    }
+}
+
+}  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
+++ b/cpp/include/rapidsmpf/integrations/cudf/partition.hpp
@@ -122,22 +122,25 @@ partition_and_split(
 
 
 /**
- * @brief Unpack (deserialize) input tables and concatenate them.
+ * @brief Unpack (deserialize) input partitions and concatenate them into a single table.
  *
- * Ignores empty partitions.
+ * Empty partitions are ignored.
  *
- * @param partitions The packed input tables.
- * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param br Buffer resource for memory allocations.
- * @param statistics The statistics instance to use (disabled by default).
- * @param allow_overbooking If true, allow overbooking (true by default)
- * // TODO: disable this by default https://github.com/rapidsmpf/rapidsmpf/issues/449
+ * The unpacking of each partition is stream-ordered on that partition's own CUDA stream.
+ * The returned table is stream-ordered on the provided @p stream and synchronized with
+ * the unpacking.
  *
- * @return The unpacked and concatenated result.
+ * @param partitions Packed input tables (partitions).
+ * @param stream CUDA stream on which concatenation occurs and on which the resulting
+ * table is ordered.
+ * @param br Buffer resource used for memory allocations.
+ * @param statistics Statistics instance to use (disabled by default).
+ * @param allow_overbooking If true, allow overbooking (true by default).
+ * @return The concatenated table resulting from unpacking the input partitions.
  *
- * @throws std::overflow_error if the buffer resource cannot reserve enough memory
- * to concatenate all partitions.
- * @throws std::logic_error if the partitions are not in device memory.
+ * @throws std::overflow_error If the buffer resource cannot reserve enough memory to
+ * concatenate all partitions.
+ * @throws std::logic_error If the partitions are not in device memory.
  *
  * @see partition_and_pack
  * @see cudf::unpack
@@ -155,8 +158,8 @@ partition_and_split(
  * @brief Spill partitions from device memory to host memory.
  *
  * Moves the buffer of each `PackedData` from device memory to host memory using
- * the provided buffer resource. Partitions that are already in host memory are
- * passed through unchanged.
+ * the provided buffer resource and the buffer's CUDA stream. Partitions that are
+ * already in host memory are passed through unchanged.
  *
  * For device-resident partitions, a host memory reservation is made before moving
  * the buffer. If the reservation fails due to insufficient host memory, an exception
@@ -173,7 +176,6 @@ partition_and_split(
  */
 std::vector<PackedData> spill_partitions(
     std::vector<PackedData>&& partitions,
-    rmm::cuda_stream_view stream,
     BufferResource* br,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()
 );
@@ -184,14 +186,13 @@ std::vector<PackedData> spill_partitions(
  *
  * Each partition is inspected to determine whether its buffer resides in device memory.
  * Buffers already in device memory are left untouched. Host-resident buffers are moved
- * to device memory using the provided buffer resource and CUDA stream.
+ * to device memory using the provided buffer resource and the buffer's CUDA stream.
  *
  * If insufficient device memory is available, the buffer resource's spill manager is
  * invoked to free memory. If overbooking occurs and spilling fails to reclaim enough
  * memory, behavior depends on the `allow_overbooking` flag.
  *
  * @param partitions The partitions to unspill, potentially containing host-resident data.
- * @param stream CUDA stream used for memory operations and kernel launches.
  * @param br Buffer resource responsible for memory reservation and spills.
  * @param allow_overbooking If false, ensures enough memory is freed to satisfy the
  * reservation; otherwise, allows overbooking even if spilling was insufficient.
@@ -204,7 +205,6 @@ std::vector<PackedData> spill_partitions(
  */
 std::vector<PackedData> unspill_partitions(
     std::vector<PackedData>&& partitions,
-    rmm::cuda_stream_view stream,
     BufferResource* br,
     bool allow_overbooking,
     std::shared_ptr<Statistics> statistics = Statistics::disabled()

--- a/cpp/include/rapidsmpf/streaming/cudf/table_chunk.hpp
+++ b/cpp/include/rapidsmpf/streaming/cudf/table_chunk.hpp
@@ -82,15 +82,12 @@ class TableChunk {
     /**
      * @brief Construct a TableChunk from a packed data blob.
      *
+     * The packed data's CUDA stream will be associated the new table chunk.
+     *
      * @param sequence_number Ordering identifier for the chunk.
      * @param packed_data Serialized host/device data with metadata.
-     * @param stream The CUDA stream on which the packed_data was created.
      */
-    TableChunk(
-        std::uint64_t sequence_number,
-        std::unique_ptr<PackedData> packed_data,
-        rmm::cuda_stream_view stream
-    );
+    TableChunk(std::uint64_t sequence_number, std::unique_ptr<PackedData> packed_data);
 
     ~TableChunk() = default;
 
@@ -149,18 +146,16 @@ class TableChunk {
     /**
      * @brief Moves this chunk into a new one with its cudf table made available.
      *
-     * As part of the move, a copy or unpack may be performed if required.
+     * As part of the move, a copy or unpack may be performed if required using
+     * the associated CUDA stream.
      *
      * @param reservation Memory reservation for allocations if needed.
-     * @param stream CUDA stream to use for operations.
      * @return A new TableChunk with data available on device.
      *
      * @note After this call, the current object is in a moved-from state;
      *       only reassignment, movement, or destruction are valid.
      */
-    [[nodiscard]] TableChunk make_available(
-        MemoryReservation& reservation, rmm::cuda_stream_view stream
-    );
+    [[nodiscard]] TableChunk make_available(MemoryReservation& reservation);
 
     /**
      * @brief Returns a view of the underlying table.
@@ -176,18 +171,16 @@ class TableChunk {
     /**
      * @brief Move this table chunk into host memory.
      *
-     * Converts the device-resident table into a `PackedData` stored in host memory.
+     * Converts the device-resident table into a `PackedData` stored in host memory using
+     * the associated CUDA stream.
      *
-     * @param stream CUDA stream to use for the copy.
      * @param br Buffer resource used for allocations.
      * @return A new TableChunk containing packed host data.
      *
      * @note After this call, this object is in a has-been-moved-state and anything other
      * than reassignment, movement, and destruction is UB.
      */
-    [[nodiscard]] TableChunk spill_to_host(
-        rmm::cuda_stream_view stream, BufferResource* br
-    );
+    [[nodiscard]] TableChunk spill_to_host(BufferResource* br);
 
   private:
     std::uint64_t sequence_number_;

--- a/cpp/src/buffer/buffer.cpp
+++ b/cpp/src/buffer/buffer.cpp
@@ -35,7 +35,8 @@ Buffer::Buffer(
       storage_{std::move(device_buffer)},
       // Use the provided event if it exists, otherwise create a new event to track the
       // async copy only if the buffer is not empty
-      event_{size > 0 ? CudaEvent::make_shared_record(stream) : nullptr} {
+      event_{size > 0 ? CudaEvent::make_shared_record(stream) : nullptr},
+      stream_{stream} {
     RAPIDSMPF_EXPECTS(
         std::get<DeviceStorageT>(storage_) != nullptr, "the device buffer cannot be NULL"
     );

--- a/cpp/src/buffer/buffer.cpp
+++ b/cpp/src/buffer/buffer.cpp
@@ -29,19 +29,13 @@ Buffer::Buffer(
 }
 
 Buffer::Buffer(
-    std::unique_ptr<rmm::device_buffer> device_buffer,
-    rmm::cuda_stream_view stream,
-    std::shared_ptr<CudaEvent> event
+    std::unique_ptr<rmm::device_buffer> device_buffer, rmm::cuda_stream_view stream
 )
     : size{device_buffer ? device_buffer->size() : 0},
       storage_{std::move(device_buffer)},
       // Use the provided event if it exists, otherwise create a new event to track the
       // async copy only if the buffer is not empty
-      event_{
-          event      ? event
-          : size > 0 ? CudaEvent::make_shared_record(stream)
-                     : nullptr
-      } {
+      event_{size > 0 ? CudaEvent::make_shared_record(stream) : nullptr} {
     RAPIDSMPF_EXPECTS(
         std::get<DeviceStorageT>(storage_) != nullptr, "the device buffer cannot be NULL"
     );

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 
 #include <rapidsmpf/buffer/resource.hpp>
+#include <rapidsmpf/cuda_stream.hpp>
 #include <rapidsmpf/error.hpp>
 
 namespace rapidsmpf {
@@ -133,7 +134,7 @@ std::unique_ptr<Buffer> BufferResource::allocate(
         // TODO: use pinned memory, maybe use rmm::mr::pinned_memory_resource and
         // std::pmr::vector?
         ret = std::unique_ptr<Buffer>(
-            new Buffer(std::make_unique<std::vector<uint8_t>>(size))
+            new Buffer(std::make_unique<std::vector<uint8_t>>(size), stream)
         );
         break;
     case MemoryType::DEVICE:
@@ -154,8 +155,10 @@ std::unique_ptr<Buffer> BufferResource::allocate(
     return allocate(reservation.size(), stream, reservation);
 }
 
-std::unique_ptr<Buffer> BufferResource::move(std::unique_ptr<std::vector<uint8_t>> data) {
-    return std::unique_ptr<Buffer>(new Buffer(std::move(data)));
+std::unique_ptr<Buffer> BufferResource::move(
+    std::unique_ptr<std::vector<uint8_t>> data, rmm::cuda_stream_view stream
+) {
+    return std::unique_ptr<Buffer>(new Buffer(std::move(data), stream));
 }
 
 std::unique_ptr<Buffer> BufferResource::move(
@@ -163,46 +166,52 @@ std::unique_ptr<Buffer> BufferResource::move(
     rmm::cuda_stream_view stream,
     std::shared_ptr<CudaEvent> event
 ) {
+    auto upstream = data->stream();
+    if (upstream.value() != stream.value()) {
+        cuda_stream_join(std::array{stream}, std::array{upstream});
+        data->set_stream(stream);
+    }
     return std::unique_ptr<Buffer>(new Buffer(std::move(data), stream, std::move(event)));
 }
 
 std::unique_ptr<Buffer> BufferResource::move(
-    std::unique_ptr<Buffer> buffer,
-    rmm::cuda_stream_view stream,
-    MemoryReservation& reservation
+    std::unique_ptr<Buffer> buffer, MemoryReservation& reservation
 ) {
     if (reservation.mem_type_ != buffer->mem_type()) {
-        auto ret = allocate(buffer->size, stream, reservation);
-        buffer_copy(*ret, *buffer, buffer->size, 0, 0, stream, true);
+        auto ret = allocate(buffer->size, buffer->stream(), reservation);
+        buffer_copy(*ret, *buffer, buffer->size);
         return ret;
     }
     return buffer;
 }
 
 std::unique_ptr<rmm::device_buffer> BufferResource::move_to_device_buffer(
-    std::unique_ptr<Buffer> buffer,
-    rmm::cuda_stream_view stream,
-    MemoryReservation& reservation
+    std::unique_ptr<Buffer> buffer, MemoryReservation& reservation
 ) {
     RAPIDSMPF_EXPECTS(
         reservation.mem_type_ == MemoryType::DEVICE,
         "the memory type of MemoryReservation doesn't match",
         std::invalid_argument
     );
-    return move(std::move(buffer), stream, reservation)->release_device();
+    auto upstream = buffer->stream();
+    auto ret = move(std::move(buffer), reservation)->release_device();
+    RAPIDSMPF_EXPECTS(
+        ret->stream().value() == upstream.value(),
+        "something went wrong, the Buffer's stream and the device_buffer's stream "
+        "doesn't match"
+    );
+    return ret;
 }
 
 std::unique_ptr<std::vector<uint8_t>> BufferResource::move_to_host_vector(
-    std::unique_ptr<Buffer> buffer,
-    rmm::cuda_stream_view stream,
-    MemoryReservation& reservation
+    std::unique_ptr<Buffer> buffer, MemoryReservation& reservation
 ) {
     RAPIDSMPF_EXPECTS(
         reservation.mem_type_ == MemoryType::HOST,
         "the memory type of MemoryReservation doesn't match",
         std::invalid_argument
     );
-    return move(std::move(buffer), stream, reservation)->release_host();
+    return move(std::move(buffer), reservation)->release_host();
 }
 
 SpillManager& BufferResource::spill_manager() {

--- a/cpp/src/buffer/resource.cpp
+++ b/cpp/src/buffer/resource.cpp
@@ -162,16 +162,14 @@ std::unique_ptr<Buffer> BufferResource::move(
 }
 
 std::unique_ptr<Buffer> BufferResource::move(
-    std::unique_ptr<rmm::device_buffer> data,
-    rmm::cuda_stream_view stream,
-    std::shared_ptr<CudaEvent> event
+    std::unique_ptr<rmm::device_buffer> data, rmm::cuda_stream_view stream
 ) {
     auto upstream = data->stream();
     if (upstream.value() != stream.value()) {
         cuda_stream_join(std::array{stream}, std::array{upstream});
         data->set_stream(stream);
     }
-    return std::unique_ptr<Buffer>(new Buffer(std::move(data), stream, std::move(event)));
+    return std::unique_ptr<Buffer>(new Buffer(std::move(data), stream));
 }
 
 std::unique_ptr<Buffer> BufferResource::move(

--- a/cpp/src/integrations/cudf/partition.cpp
+++ b/cpp/src/integrations/cudf/partition.cpp
@@ -10,17 +10,18 @@
 #include <cudf/copying.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
+#include <rapidsmpf/buffer/buffer.hpp>
 #include <rapidsmpf/buffer/packed_data.hpp>
 #include <rapidsmpf/buffer/resource.hpp>
+#include <rapidsmpf/cuda_stream.hpp>
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/integrations/cudf/partition.hpp>
 #include <rapidsmpf/integrations/cudf/utils.hpp>
 #include <rapidsmpf/nvtx.hpp>
 #include <rapidsmpf/utils.hpp>
-
-#include "rapidsmpf/buffer/buffer.hpp"
 
 namespace rapidsmpf {
 
@@ -179,8 +180,10 @@ std::unique_ptr<cudf::table> unpack_and_concat(
 
     std::vector<cudf::table_view> unpacked;
     std::vector<cudf::packed_columns> references;
+    std::vector<rmm::cuda_stream_view> packed_data_streams;
     unpacked.reserve(partitions.size());
     references.reserve(partitions.size());
+    packed_data_streams.reserve(partitions.size());
 
     // Reserve device memory for the unspill AND the cudf::unpack() calls.
     with_memory_reservation(
@@ -190,11 +193,12 @@ std::unique_ptr<cudf::table> unpack_and_concat(
         [&](auto& reservation) {
             for (auto& packed_data : partitions) {
                 if (!packed_data.empty()) {
+                    packed_data_streams.push_back(packed_data.data->stream());
                     unpacked.push_back(
                         cudf::unpack(references.emplace_back(
                             std::move(packed_data.metadata),
                             br->move_to_device_buffer(
-                                std::move(packed_data.data), stream, reservation
+                                std::move(packed_data.data), reservation
                             )
                         ))
                     );
@@ -202,7 +206,7 @@ std::unique_ptr<cudf::table> unpack_and_concat(
             }
         }
     );
-
+    cuda_stream_join(std::array{stream}, packed_data_streams);
     // Reserve memory for the concatenation.
     return with_memory_reservation(
         br->reserve_and_spill(MemoryType::DEVICE, total_size, allow_overbooking),
@@ -212,7 +216,6 @@ std::unique_ptr<cudf::table> unpack_and_concat(
 
 std::vector<PackedData> spill_partitions(
     std::vector<PackedData>&& partitions,
-    rmm::cuda_stream_view stream,
     BufferResource* br,
     std::shared_ptr<Statistics> statistics
 ) {
@@ -231,8 +234,9 @@ std::vector<PackedData> spill_partitions(
             std::vector<PackedData> ret;
             ret.reserve(partitions.size());
             for (auto& [metadata, data] : partitions) {
+                auto stream = data->stream();
                 ret.emplace_back(
-                    std::move(metadata), br->move(std::move(data), stream, reservation)
+                    std::move(metadata), br->move(std::move(data), reservation)
                 );
             }
             statistics->add_duration_stat(
@@ -246,7 +250,6 @@ std::vector<PackedData> spill_partitions(
 
 std::vector<PackedData> unspill_partitions(
     std::vector<PackedData>&& partitions,
-    rmm::cuda_stream_view stream,
     BufferResource* br,
     bool allow_overbooking,
     std::shared_ptr<Statistics> statistics
@@ -267,8 +270,9 @@ std::vector<PackedData> unspill_partitions(
             std::vector<PackedData> ret;
             ret.reserve(partitions.size());
             for (auto& [metadata, data] : partitions) {
+                auto stream = data->stream();
                 ret.emplace_back(
-                    std::move(metadata), br->move(std::move(data), stream, reservation)
+                    std::move(metadata), br->move(std::move(data), reservation)
                 );
             }
 

--- a/cpp/src/shuffler/chunk.cpp
+++ b/cpp/src/shuffler/chunk.cpp
@@ -83,9 +83,7 @@ Chunk Chunk::get_data(
                 *data_,
                 data_slice_size,
                 0,  // dst_offset
-                data_slice_offset,  // src_offset
-                stream,
-                true
+                data_slice_offset  // src_offset
             );
         }
 
@@ -304,8 +302,9 @@ Chunk Chunk::concat(
     // Create concatenated data buffer if needed
     std::unique_ptr<Buffer> concat_data;
     if (total_data_size > 0) {
-        auto reserve = br->reserve_or_fail(total_data_size, preferred_mem_type);
-        concat_data = br->allocate(total_data_size, stream, reserve);
+        concat_data = br->allocate(
+            stream, br->reserve_or_fail(total_data_size, preferred_mem_type)
+        );
     } else {  // no data, allocate an empty host buffer
         concat_data = br->allocate(stream, br->reserve_or_fail(0, MemoryType::HOST));
     }
@@ -368,9 +367,7 @@ Chunk Chunk::concat(
                 *chunk.data_,
                 chunk.data_->size,
                 std::ptrdiff_t(curr_data_offset),  // dst_offset
-                0,  // src_offset
-                stream,
-                false
+                0  // src_offset
             );
             // Update offsets for each message in the chunk
             for (size_t i = 0; i < chunk_messages; ++i) {

--- a/cpp/src/streaming/cudf/partition.cpp
+++ b/cpp/src/streaming/cudf/partition.cpp
@@ -33,7 +33,7 @@ Node partition_and_pack(
         auto reservation = ctx->br()->reserve_and_spill(
             MemoryType::DEVICE, table.make_available_cost(), false
         );
-        auto tbl = table.make_available(reservation, table.stream());
+        auto tbl = table.make_available(reservation);
 
         PartitionMapChunk partition_map{
             .sequence_number = tbl.sequence_number(),
@@ -87,7 +87,7 @@ Node unpack_and_concat(
             stream = partition_vec.stream;
         }
         std::unique_ptr<cudf::table> ret = rapidsmpf::unpack_and_concat(
-            rapidsmpf::unspill_partitions(std::move(data), stream, ctx->br(), false),
+            rapidsmpf::unspill_partitions(std::move(data), ctx->br(), false),
             stream,
             ctx->br(),
             ctx->statistics()

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(
             test_chunk.cpp
             test_communicator.cpp
             test_config.cpp
+            test_cuda_stream.cpp
             test_cudf_utils.cpp
             test_cupti_monitor.cpp
             test_partition.cpp

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(
             test_pausable_thread_loop.cpp
             test_progress_thread.cpp
             test_rmm_resource_adaptor.cpp
+            test_shuffler_many_streams.cpp
             test_shuffler.cpp
             test_spill_manager.cpp
             test_statistics.cpp

--- a/cpp/tests/test_allgather.cpp
+++ b/cpp/tests/test_allgather.cpp
@@ -71,9 +71,7 @@ void validate_packed_data(
     auto copied_vec = br.allocate(
         stream, br.reserve_or_fail(n_elements * sizeof(int), rapidsmpf::MemoryType::HOST)
     );
-    rapidsmpf::buffer_copy(
-        *copied_vec, *packed_data.data, n_elements * sizeof(int), 0, 0, stream, true
-    );
+    rapidsmpf::buffer_copy(*copied_vec, *packed_data.data, n_elements * sizeof(int));
     RAPIDSMPF_CUDA_TRY(cudaStreamSynchronize(stream));
     EXPECT_EQ(metadata, *const_cast<rapidsmpf::Buffer const&>(*copied_vec).host());
 }

--- a/cpp/tests/test_allgather.cpp
+++ b/cpp/tests/test_allgather.cpp
@@ -4,9 +4,7 @@
  */
 
 #include <algorithm>
-#include <cstdint>
 #include <iterator>
-#include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -15,6 +13,7 @@
 #include <cudf_test/table_utilities.hpp>
 
 #include <rapidsmpf/allgather/allgather.hpp>
+#include <rapidsmpf/buffer/buffer.hpp>
 #include <rapidsmpf/buffer/packed_data.hpp>
 #include <rapidsmpf/buffer/resource.hpp>
 #include <rapidsmpf/communicator/communicator.hpp>
@@ -23,58 +22,11 @@
 #include <rapidsmpf/statistics.hpp>
 
 #include "environment.hpp"
-#include "rapidsmpf/buffer/buffer.hpp"
 #include "utils.hpp"
 
 using namespace rapidsmpf::allgather;
 
 extern Environment* GlobalEnvironment;
-
-// Generate a packed data object with the given number of elements and offset.
-// Both metadata and gpu_data contains the same data.
-rapidsmpf::PackedData generate_packed_data(
-    int n_elements,
-    int offset,
-    rmm::cuda_stream_view stream,
-    rapidsmpf::BufferResource& br
-) {
-    auto values = iota_vector<int>(n_elements, offset);
-
-    auto metadata = std::make_unique<std::vector<uint8_t>>(n_elements * sizeof(int));
-    std::memcpy(metadata->data(), values.data(), n_elements * sizeof(int));
-
-    auto data = std::make_unique<rmm::device_buffer>(
-        values.data(), n_elements * sizeof(int), stream, br.device_mr()
-    );
-
-    return {std::move(metadata), br.move(std::move(data), stream)};
-}
-
-// Validate the packed data object by checking the metadata and gpu_data.
-void validate_packed_data(
-    rapidsmpf::PackedData&& packed_data,
-    int n_elements,
-    int offset,
-    rmm::cuda_stream_view stream,
-    rapidsmpf::BufferResource& br
-) {
-    auto const& metadata = *packed_data.metadata;
-    EXPECT_EQ(n_elements * sizeof(int), metadata.size());
-
-    for (int i = 0; i < n_elements; i++) {
-        int val;
-        std::memcpy(&val, metadata.data() + i * sizeof(int), sizeof(int));
-        EXPECT_EQ(offset + i, val);
-    }
-
-    EXPECT_EQ(n_elements * sizeof(int), packed_data.data->size);
-    auto copied_vec = br.allocate(
-        stream, br.reserve_or_fail(n_elements * sizeof(int), rapidsmpf::MemoryType::HOST)
-    );
-    rapidsmpf::buffer_copy(*copied_vec, *packed_data.data, n_elements * sizeof(int));
-    RAPIDSMPF_CUDA_TRY(cudaStreamSynchronize(stream));
-    EXPECT_EQ(metadata, *const_cast<rapidsmpf::Buffer const&>(*copied_vec).host());
-}
 
 class BaseAllGatherTest : public ::testing::Test {
   protected:

--- a/cpp/tests/test_communicator.cpp
+++ b/cpp/tests/test_communicator.cpp
@@ -70,7 +70,7 @@ TEST_P(BasicCommunicatorTest, SendToSelf) {
     auto send_data_h = iota_vector<std::uint8_t>(nelems);
     auto [reservation, ob] = br->reserve(memory_type(), 2 * send_data_h.size(), true);
     auto send_buf = br->move(
-        br->move(std::make_unique<std::vector<uint8_t>>(send_data_h)), stream, reservation
+        br->move(std::make_unique<std::vector<uint8_t>>(send_data_h), stream), reservation
     );
     stream.synchronize();
     rapidsmpf::Tag tag{0, 0};
@@ -83,8 +83,7 @@ TEST_P(BasicCommunicatorTest, SendToSelf) {
     auto recv_buf = comm->wait(std::move(recv_fut));
     auto [host_reservation, host_ob] =
         br->reserve(rapidsmpf::MemoryType::HOST, send_data_h.size(), true);
-    auto recv_data_h =
-        br->move_to_host_vector(std::move(recv_buf), stream, host_reservation);
+    auto recv_data_h = br->move_to_host_vector(std::move(recv_buf), host_reservation);
     stream.synchronize();
     EXPECT_EQ(send_data_h, *recv_data_h);
 }

--- a/cpp/tests/test_cuda_stream.cpp
+++ b/cpp/tests/test_cuda_stream.cpp
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+
+#include <rapidsmpf/cuda_event.hpp>
+#include <rapidsmpf/cuda_stream.hpp>
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/utils.hpp>
+
+
+using namespace rapidsmpf;
+
+TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
+    // 3 upstreams write disjoint slices repeatedly (slow), then 3 downstreams
+    // overwrite those slices once (fast). With priority streams, missing the join
+    // is even more likely to produce the wrong final contents.
+    constexpr int num_slices = 3;
+    constexpr int upstream_repeats = 1000;
+
+    const std::array<unsigned char, num_slices> upstream_values{0x11, 0x22, 0x33};
+    const auto downstream_value = [](int i) {
+        return static_cast<unsigned char>(0xE0 + i);
+    };
+
+    // Streams and their views (created with explicit priorities).
+    std::array<cudaStream_t, num_slices> upstream_raw{};
+    std::array<cudaStream_t, num_slices> downstream_raw{};
+    std::array<rmm::cuda_stream_view, num_slices> upstreams{};
+    std::array<rmm::cuda_stream_view, num_slices> downstreams{};
+
+    int least_priority = 0;  // numerically larger (often 0) => lower priority
+    int greatest_priority = 0;  // numerically smaller (often negative) => higher priority
+    RAPIDSMPF_CUDA_TRY(
+        cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority)
+    );
+
+    for (int i = 0; i < num_slices; ++i) {
+        RAPIDSMPF_CUDA_TRY(cudaStreamCreateWithPriority(
+            &upstream_raw[i], cudaStreamNonBlocking, least_priority
+        ));  // low priority
+        RAPIDSMPF_CUDA_TRY(cudaStreamCreateWithPriority(
+            &downstream_raw[i], cudaStreamNonBlocking, greatest_priority
+        ));  // high priority
+        upstreams[i] = rmm::cuda_stream_view{upstream_raw[i]};
+        downstreams[i] = rmm::cuda_stream_view{downstream_raw[i]};
+    }
+
+    // One large device buffer, initialize to 0x00 and sync once for known base state.
+    constexpr size_t total_bytes = 1 << 25;
+    rmm::device_buffer buf(total_bytes, upstreams[0]);
+    RAPIDSMPF_CUDA_TRY(cudaMemset(buf.data(), 0x00, buf.size()));
+    RAPIDSMPF_CUDA_TRY(cudaDeviceSynchronize());
+
+    constexpr size_t slice_bytes = total_bytes / num_slices;
+    ASSERT_GT(slice_bytes, 0u);
+    auto* dptr = static_cast<unsigned char*>(buf.data());
+
+    // Upstreams: each writes its slice repeatedly to stretch execution time.
+    for (int i = 0; i < num_slices; ++i) {
+        unsigned char* slice_dev_ptr = dptr + size_t(i) * slice_bytes;
+        for (int r = 0; r < upstream_repeats; ++r) {
+            RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(
+                slice_dev_ptr, upstream_values[i], slice_bytes, upstreams[i]
+            ));
+        }
+    }
+
+    // Join: all downstreams wait on all upstreams.
+    cuda_stream_join(downstreams, upstreams);
+
+    // Downstreams: single, quick overwrite per slice (should win if join is correct).
+    for (int i = 0; i < num_slices; ++i) {
+        unsigned char* slice_dev_ptr = dptr + size_t(i) * slice_bytes;
+        RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(
+            slice_dev_ptr, downstream_value(i), slice_bytes, downstreams[i]
+        ));
+    }
+
+    // Complete all work.
+    RAPIDSMPF_CUDA_TRY(cudaDeviceSynchronize());
+
+    // Verify: each slice must equal its downstream value (0xE0 + i).
+    for (int i = 0; i < num_slices; ++i) {
+        std::vector<unsigned char> host(slice_bytes);
+        unsigned char const* slice_dev_ptr = dptr + size_t(i) * slice_bytes;
+
+        RAPIDSMPF_CUDA_TRY(
+            cudaMemcpy(host.data(), slice_dev_ptr, slice_bytes, cudaMemcpyDeviceToHost)
+        );
+
+        unsigned char expect = downstream_value(i);
+
+        // Quick sentinels to keep test snappy on large slices:
+        ASSERT_EQ(host.front(), expect) << "slice " << i << " first byte mismatch";
+        ASSERT_EQ(host[slice_bytes / 2], expect)
+            << "slice " << i << " middle byte mismatch";
+        ASSERT_EQ(host.back(), expect) << "slice " << i << " last byte mismatch";
+    }
+
+    // Cleanup streams
+    for (int i = 0; i < num_slices; ++i) {
+        if (upstream_raw[i])
+            RAPIDSMPF_CUDA_TRY(cudaStreamDestroy(upstream_raw[i]));
+        if (downstream_raw[i])
+            RAPIDSMPF_CUDA_TRY(cudaStreamDestroy(downstream_raw[i]));
+    }
+}

--- a/cpp/tests/test_cuda_stream.cpp
+++ b/cpp/tests/test_cuda_stream.cpp
@@ -107,9 +107,11 @@ TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
 
     // Cleanup streams
     for (int i = 0; i < num_slices; ++i) {
-        if (upstream_raw[i])
+        if (upstream_raw[i]) {
             RAPIDSMPF_CUDA_TRY(cudaStreamDestroy(upstream_raw[i]));
-        if (downstream_raw[i])
+        }
+        if (downstream_raw[i]) {
             RAPIDSMPF_CUDA_TRY(cudaStreamDestroy(downstream_raw[i]));
+        }
     }
 }

--- a/cpp/tests/test_partition.cpp
+++ b/cpp/tests/test_partition.cpp
@@ -116,21 +116,20 @@ TEST_F(SpillingTest, SpillUnspillRoundtripPreservesDataAndMetadata) {
     input.push_back(create_packed_data(metadata, payload, stream, br.get()));
 
     // Device -> Device (moves data)
-    auto on_gpu = unspill_partitions(
-        std::move(input), stream, br.get(), /*allow_overbooking=*/true
-    );
+    auto on_gpu =
+        unspill_partitions(std::move(input), br.get(), /*allow_overbooking=*/true);
     ASSERT_EQ(on_gpu.size(), 1);
     EXPECT_EQ(on_gpu[0].data->mem_type(), rapidsmpf::MemoryType::DEVICE);
     EXPECT_EQ(*on_gpu[0].metadata, metadata);
 
     // Device -> Host
-    auto back_on_host = spill_partitions(std::move(on_gpu), stream, br.get());
+    auto back_on_host = spill_partitions(std::move(on_gpu), br.get());
     ASSERT_EQ(back_on_host.size(), 1);
     EXPECT_EQ(back_on_host[0].data->mem_type(), rapidsmpf::MemoryType::HOST);
     EXPECT_EQ(*back_on_host[0].metadata, metadata);
 
     // Check that contents match original
     auto res = br->reserve_or_fail(back_on_host[0].data->size, MemoryType::HOST);
-    auto actual = br->move_to_host_vector(std::move(back_on_host[0].data), stream, res);
+    auto actual = br->move_to_host_vector(std::move(back_on_host[0].data), res);
     EXPECT_EQ(*actual, payload);
 }

--- a/cpp/tests/test_shuffler_many_streams.cpp
+++ b/cpp/tests/test_shuffler_many_streams.cpp
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <random>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cudf/utilities/memory_resource.hpp>
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+
+#include <rapidsmpf/cuda_stream.hpp>
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/integrations/cudf/partition.hpp>
+#include <rapidsmpf/shuffler/shuffler.hpp>
+
+#include "environment.hpp"
+#include "utils.hpp"
+
+extern Environment* GlobalEnvironment;
+
+using namespace rapidsmpf;
+
+/**
+ * @brief Generate a random CUDA stream priority.
+ *
+ * @param seed Seed for the random number generator.
+ * @return A valid CUDA stream priority in the device range.
+ */
+int gen_stream_priority(unsigned int seed = 42) {
+    int least_priority = 0;  // numerically larger (often 0) => lower priority
+    int greatest_priority = 0;  // numerically smaller (often negative) => higher priority
+    RAPIDSMPF_CUDA_TRY(
+        cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority)
+    );
+
+    int num_priorities = least_priority - greatest_priority + 1;
+    std::mt19937 gen{seed};
+    std::uniform_int_distribution<int> dist(0, num_priorities - 1);
+    return greatest_priority + dist(gen);
+}
+
+// To expose unexpected deadlocks, we use a 30s timeout. In a normal run, the
+// shuffle shouldn't get near 30s.
+constexpr std::chrono::seconds wait_timeout(30);
+
+TEST(ShufflerManyStreams, Test) {
+    constexpr size_t chunksize = 1 << 20;
+    constexpr int num_partitions = 100;
+    auto br = std::make_unique<BufferResource>(cudf::get_current_device_resource_ref());
+
+    // Create a CUDA stream for the shuffler and for each partition.
+    cudaStream_t shuffler_stream;
+    RAPIDSMPF_CUDA_TRY(cudaStreamCreateWithPriority(
+        &shuffler_stream, cudaStreamNonBlocking, gen_stream_priority()
+    ));
+    std::array<cudaStream_t, num_partitions> partition_streams{};
+    for (shuffler::PartID pid = 0; pid < num_partitions; ++pid) {
+        RAPIDSMPF_CUDA_TRY(cudaStreamCreateWithPriority(
+            &partition_streams[pid], cudaStreamNonBlocking, gen_stream_priority()
+        ));
+    }
+
+    // Create the shuffler on `shuffler_stream`.
+    rapidsmpf::shuffler::Shuffler shuffler(
+        GlobalEnvironment->comm_,
+        GlobalEnvironment->progress_thread_,
+        0,  // op_id
+        num_partitions,
+        shuffler_stream,
+        br.get()
+    );
+
+    // Create each partition on its own CUDA stream.
+    std::unordered_map<shuffler::PartID, PackedData> partitions;
+    for (shuffler::PartID pid = 0; pid < num_partitions; ++pid) {
+        partitions.insert(
+            {pid, generate_packed_data(chunksize, pid, partition_streams[pid], *br)}
+        );
+    }
+
+    // Insert all partitions.
+    shuffler.insert(std::move(partitions));
+    shuffler.insert_finished(iota_vector<rapidsmpf::shuffler::PartID>(num_partitions));
+
+    // Extract and validate the partitions as they finishes.
+    while (!shuffler.finished()) {
+        auto pid = shuffler.wait_any(wait_timeout);
+        std::vector<PackedData> partition_chunks = shuffler.extract(pid);
+        for (PackedData& chunk : partition_chunks) {
+            auto stream = chunk.data->stream();
+            EXPECT_NO_FATAL_FAILURE(
+                validate_packed_data(std::move(chunk), chunksize, pid, stream, *br)
+            );
+        }
+    }
+
+    // Cleanup streams
+    for (auto& stream : partition_streams) {
+        RAPIDSMPF_CUDA_TRY(cudaStreamDestroy(stream));
+    }
+    RAPIDSMPF_CUDA_TRY(cudaStreamDestroy(shuffler_stream));
+}

--- a/cpp/tests/utils.hpp
+++ b/cpp/tests/utils.hpp
@@ -5,10 +5,13 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <numeric>
 #include <random>
 #include <span>
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include <cudf/sorting.hpp>
 #include <cudf/table/table.hpp>
@@ -107,4 +110,67 @@ template <typename T>
     return rapidsmpf::PackedData{
         std::move(metadata_ptr), br->move(std::move(data_ptr), stream)
     };
+}
+
+/**
+ * @brief Generate a packed data object with the given number of elements and offset.
+ *
+ * Both metadata and GPU data contain the same integer sequence.
+ *
+ * @param n_elements Number of elements in the sequence.
+ * @param offset Starting value of the sequence.
+ * @param stream CUDA stream for device allocation.
+ * @param br Buffer resource used for allocations.
+ * @return A packed data object containing metadata and GPU data.
+ */
+[[nodiscard]] inline rapidsmpf::PackedData generate_packed_data(
+    int n_elements,
+    int offset,
+    rmm::cuda_stream_view stream,
+    rapidsmpf::BufferResource& br
+) {
+    auto values = iota_vector<int>(n_elements, offset);
+
+    auto metadata = std::make_unique<std::vector<uint8_t>>(n_elements * sizeof(int));
+    std::memcpy(metadata->data(), values.data(), n_elements * sizeof(int));
+
+    auto data = std::make_unique<rmm::device_buffer>(
+        values.data(), n_elements * sizeof(int), stream, br.device_mr()
+    );
+
+    return {std::move(metadata), br.move(std::move(data), stream)};
+}
+
+/**
+ * @brief Validate a packed data object by checking metadata and GPU data contents.
+ *
+ * @param packed_data Packed data object to validate.
+ * @param n_elements Expected number of elements.
+ * @param offset Expected starting value of the sequence.
+ * @param stream CUDA stream used for device-host transfers.
+ * @param br Buffer resource used for host allocation.
+ */
+inline void validate_packed_data(
+    rapidsmpf::PackedData&& packed_data,
+    int n_elements,
+    int offset,
+    rmm::cuda_stream_view stream,
+    rapidsmpf::BufferResource& br
+) {
+    auto const& metadata = *packed_data.metadata;
+    EXPECT_EQ(n_elements * sizeof(int), metadata.size());
+
+    for (int i = 0; i < n_elements; i++) {
+        int val;
+        std::memcpy(&val, metadata.data() + i * sizeof(int), sizeof(int));
+        EXPECT_EQ(offset + i, val);
+    }
+
+    EXPECT_EQ(n_elements * sizeof(int), packed_data.data->size);
+    auto copied_vec = br.allocate(
+        stream, br.reserve_or_fail(n_elements * sizeof(int), rapidsmpf::MemoryType::HOST)
+    );
+    rapidsmpf::buffer_copy(*copied_vec, *packed_data.data, n_elements * sizeof(int));
+    RAPIDSMPF_CUDA_TRY(cudaStreamSynchronize(stream));
+    EXPECT_EQ(metadata, *const_cast<rapidsmpf::Buffer const&>(*copied_vec).host());
 }

--- a/python/rapidsmpf/rapidsmpf/allgather/allgather.pxd
+++ b/python/rapidsmpf/rapidsmpf/allgather/allgather.pxd
@@ -35,7 +35,7 @@ cdef extern from "<rapidsmpf/allgather/allgather.hpp>" nogil:
         ) except +
         void insert(cpp_PackedData packed_data) except +
         void insert_finished() except +
-        bool finished() nogil except +
+        bool finished() except + nogil
         vector[cpp_PackedData] wait_and_extract(
             Ordered ordered,
             milliseconds_t timeout

--- a/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
@@ -214,7 +214,6 @@ def bulk_mpi_shuffle(
             table = unpack_and_concat(
                 unspill_partitions(
                     shuffler.extract(partition_id),
-                    stream=DEFAULT_STREAM,
                     br=br,
                     allow_overbooking=True,
                     statistics=statistics,

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -140,7 +140,6 @@ class DaskCudfIntegration:
         table = unpack_and_concat(
             unspill_partitions(
                 shuffler.extract(partition_id),
-                stream=DEFAULT_STREAM,
                 br=ctx.br,
                 allow_overbooking=True,
                 statistics=ctx.statistics,

--- a/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
@@ -236,7 +236,6 @@ class BulkRayShufflerActor(BaseShufflingActor):
             partition = unpack_and_concat(
                 unspill_partitions(
                     packed_chunks,
-                    stream=DEFAULT_STREAM,
                     br=self.br,
                     allow_overbooking=True,
                     statistics=self.stats,

--- a/python/rapidsmpf/rapidsmpf/examples/ray/ray_shuffle_example.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/ray_shuffle_example.py
@@ -142,9 +142,7 @@ class ShufflingActor(BaseShufflingActor):
             partition_id = shuffler.wait_any()
             packed_chunks = shuffler.extract(partition_id)
             partition = unpack_and_concat(
-                unspill_partitions(
-                    packed_chunks, stream=stream, br=br, allow_overbooking=True
-                ),
+                unspill_partitions(packed_chunks, br=br, allow_overbooking=True),
                 br=br,
                 stream=stream,
             )

--- a/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
+++ b/python/rapidsmpf/rapidsmpf/integrations/cudf/partition.pyi
@@ -32,14 +32,12 @@ def unpack_and_concat(
 def spill_partitions(
     partitions: Iterable[PackedData],
     *,
-    stream: Stream,
     br: BufferResource,
     statistics: Statistics | None = None,
 ) -> list[PackedData]: ...
 def unspill_partitions(
     partitions: Iterable[PackedData],
     *,
-    stream: Stream,
     br: BufferResource,
     allow_overbooking: bool,
     statistics: Statistics | None = None,

--- a/python/rapidsmpf/rapidsmpf/tests/test_partition.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_partition.py
@@ -117,10 +117,8 @@ def test_spill_unspill_roundtrip(
     )
 
     # Spill roundtrip
-    spilled = spill_partitions(partitions.values(), stream=DEFAULT_STREAM, br=br)
-    unspilled = unspill_partitions(
-        spilled, stream=DEFAULT_STREAM, br=br, allow_overbooking=False
-    )
+    spilled = spill_partitions(partitions.values(), br=br)
+    unspilled = unspill_partitions(spilled, br=br, allow_overbooking=False)
 
     got = pylibcudf_to_cudf_dataframe(
         unpack_and_concat(

--- a/python/rapidsmpf/rapidsmpf/tests/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_shuffler.py
@@ -89,9 +89,7 @@ def test_shuffler_single_nonempty_partition(
             my_partitions.remove(partition_id)
         packed_chunks = shuffler.extract(partition_id)
         partition = unpack_and_concat(
-            unspill_partitions(
-                packed_chunks, stream=DEFAULT_STREAM, br=br, allow_overbooking=True
-            ),
+            unspill_partitions(packed_chunks, br=br, allow_overbooking=True),
             br=br,
             stream=DEFAULT_STREAM,
         )
@@ -196,9 +194,7 @@ def test_shuffler_uniform(
         partition_id = shuffler.wait_any()
         packed_chunks = shuffler.extract(partition_id)
         partition = unpack_and_concat(
-            unspill_partitions(
-                packed_chunks, stream=DEFAULT_STREAM, br=br, allow_overbooking=True
-            ),
+            unspill_partitions(packed_chunks, br=br, allow_overbooking=True),
             br=br,
             stream=DEFAULT_STREAM,
         )


### PR DESCRIPTION
A `Buffer` now carries its own CUDA stream, which should be used consistently across RapidsMPF.

This change is part of the #493 work and already eliminates many explicit `stream` parameters from the public API. We still need to remove a few more, as well as the _event-buffer-attachment_ stuff, before #493 can be fully closed.
