### PR TITLE
Add Dask integration for a join operation

### DIFF
--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -283,18 +283,18 @@ class DaskCudfJoinIntegration:
         return DaskCudfIntegration()
 
     @classmethod
-    def join_chunk(
+    def join_partition(
         cls,
         ctx: WorkerContext,
         bcast_side: Literal["left", "right", "none"],
         left_op_id: int,
         right_op_id: int,
         part_id: int,
-        n_worker_chunks: int,
+        n_worker_tasks: int,
         options: Any,
     ) -> cudf.DataFrame:
         """
-        Join a chunk of data from the left and right sides of a join.
+        Produce a joined cudf.DataFrame partition.
 
         Parameters
         ----------
@@ -308,8 +308,8 @@ class DaskCudfJoinIntegration:
             The ID of the right shuffle.
         part_id
             The ID of the partition being joined.
-        n_worker_chunks
-            The number of chunks to be produced on this worker.
+        n_worker_tasks
+            The number of join_partition tasks to be called on this worker.
             This information may be used for cleanup.
         options
             Additional options.

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -387,6 +387,7 @@ def dask_cudf_join(
         options are ``{'distributed', 'single', 'auto'}``.
         If 'auto' (the default), 'distributed' will be
         used if a global Dask client is found.
+        Note: Only ``'distributed'`` is supported for now.
     config_options
         RapidsMPF configuration options.
 

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -448,7 +448,6 @@ def dask_cudf_join(
     graph.update(right0.dask)
 
     meta = left0.merge(right0, left_on=left_on, right_on=right_on, how=how)._meta
-    # TODO: Could this be different for bcast!='none'?
     count_out = max(left_partition_count_in, right_partition_count_in)
     return dd.from_graph(
         graph,

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -338,8 +338,8 @@ class DaskCudfJoinIntegration:
         # Extract left side
         left_op_id = left_input if isinstance(left_input, int) else None
         if isinstance(left_op_id, int):
+            left_shuffler = get_shuffler(ctx, left_op_id)
             try:
-                left_shuffler = get_shuffler(ctx, left_op_id)
                 left = cls.shuffler_integration().extract_partition(
                     part_id,
                     left_shuffler,
@@ -357,8 +357,8 @@ class DaskCudfJoinIntegration:
         # Extract right side
         right_op_id = right_input if isinstance(right_input, int) else None
         if isinstance(right_op_id, int):
+            right_shuffler = get_shuffler(ctx, right_op_id)
             try:
-                right_shuffler = get_shuffler(ctx, right_op_id)
                 right = cls.shuffler_integration().extract_partition(
                     part_id,
                     right_shuffler,

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -375,13 +375,13 @@ def dask_cudf_join(
         The type of join to perform.
         Options are ``{'inner', 'left', 'right'}``.
     bcast_side
-        The side of the join being broadcasted (if either).
+        The side of the join to broadcast (if either).
         Options are ``{'left', 'right', 'none'}``.
         Note: Only ``'none'`` is supported for now.
     left_pre_shuffled
-        Whether the left DataFrame is already shuffled.
+        Whether the left collection is already shuffled.
     right_pre_shuffled
-        Whether the right DataFrame is already shuffled.
+        Whether the right collection is already shuffled.
     cluster_kind
         What kind of Dask cluster to use. Available
         options are ``{'distributed', 'single', 'auto'}``.

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -344,7 +344,6 @@ def dask_cudf_join(
     right_on: list[str],
     *,
     how: Literal["inner", "left", "right"] = "inner",
-    bcast_side: Literal["left", "right", "none"] = "none",
     left_pre_shuffled: bool = False,
     right_pre_shuffled: bool = False,
     cluster_kind: Literal["distributed", "single", "auto"] = "auto",
@@ -366,10 +365,6 @@ def dask_cudf_join(
     how
         The type of join to perform.
         Options are ``{'inner', 'left', 'right'}``.
-    bcast_side
-        The side of the join to broadcast (if either).
-        Options are ``{'left', 'right', 'none'}``.
-        Note: Only ``'none'`` is supported for now.
     left_pre_shuffled
         Whether the left collection is already shuffled.
     right_pre_shuffled
@@ -392,10 +387,6 @@ def dask_cudf_join(
     This API is currently intended for demonstration and
     testing purposes only.
     """
-    if bcast_side != "none":  # pragma: no cover
-        # TODO: Support broadcast joins.
-        raise ValueError("Only bcast_side='none' is supported for now.")
-
     if (cluster_kind := _get_cluster_kind(cluster_kind)) == "distributed":
         from rapidsmpf.integrations.dask.join import rapidsmpf_join_graph
     else:  # pragma: no cover
@@ -407,7 +398,7 @@ def dask_cudf_join(
     left_partition_count_in = left0.npartitions
     right_partition_count_in = right0.npartitions
 
-    token = tokenize(left0, right0, left_on, bcast_side, right_on, how)
+    token = tokenize(left0, right0, left_on, right_on, how)
     left_name_in = left0._name
     right_name_in = right0._name
     name_out = f"unified-join-{token}"
@@ -436,7 +427,6 @@ def dask_cudf_join(
             "right_on": right_on,
             "how": how,
         },
-        bcast_side=bcast_side,
         left_pre_shuffled=left_pre_shuffled,
         right_pre_shuffled=right_pre_shuffled,
         config_options=config_options,

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -284,7 +284,7 @@ class DaskCudfJoinIntegration:
     """Dask-cuDF protocol for unified join integration."""
 
     @staticmethod
-    def shuffler_integration() -> ShufflerIntegration[cudf.DataFrame]:
+    def get_shuffler_integration() -> ShufflerIntegration[cudf.DataFrame]:
         """Return the shuffler integration."""
         return DaskCudfIntegration()
 
@@ -340,7 +340,7 @@ class DaskCudfJoinIntegration:
         if isinstance(left_op_id, int):
             left_shuffler = get_shuffler(ctx, left_op_id)
             try:
-                left = cls.shuffler_integration().extract_partition(
+                left = cls.get_shuffler_integration().extract_partition(
                     part_id,
                     left_shuffler,
                     {"column_names": options["left_column_names"]},
@@ -359,7 +359,7 @@ class DaskCudfJoinIntegration:
         if isinstance(right_op_id, int):
             right_shuffler = get_shuffler(ctx, right_op_id)
             try:
-                right = cls.shuffler_integration().extract_partition(
+                right = cls.get_shuffler_integration().extract_partition(
                     part_id,
                     right_shuffler,
                     {"column_names": options["right_column_names"]},

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -288,9 +288,8 @@ class DaskCudfJoinIntegration:
         """Return the shuffler integration."""
         return DaskCudfIntegration()
 
-    @classmethod
+    @staticmethod
     def join_partition(
-        cls,
         left_input: cudf.DataFrame | Callable[[int], cudf.DataFrame],
         right_input: cudf.DataFrame | Callable[[int], cudf.DataFrame],
         bcast_side: Literal["left", "right", "none"],
@@ -303,13 +302,19 @@ class DaskCudfJoinIntegration:
         Parameters
         ----------
         left_input
-            The ID of the left shuffle or the left partition.
+            The left partition or a callable that produces
+            chunks of a broadcasted left partition.
+            The bcast_count argument corresponds to the number
+            of chunks the callable can produce.
         right_input
-            The ID of the right shuffle or the right partition.
+            The right partition or a callable that produces
+            chunks of a broadcasted right partition.
+            The bcast_count argument corresponds to the number
+            of chunks the callable can produce.
         bcast_side
             The side of the join being broadcasted (if either).
         bcast_count
-            The number of partitions to broadcast.
+            The number of broadcasted chunks.
             Ignored unless ``bcast_side`` is "left" or "right".
         options
             Additional join options.

--- a/python/rapidsmpf/rapidsmpf/examples/dask.py
+++ b/python/rapidsmpf/rapidsmpf/examples/dask.py
@@ -295,7 +295,7 @@ class DaskCudfJoinIntegration:
     def join_partition(
         left_input: Callable[[int], cudf.DataFrame],
         right_input: Callable[[int], cudf.DataFrame],
-        bcast_info: BCastJoinInfo,
+        bcast_info: BCastJoinInfo | None,
         options: Any,
     ) -> cudf.DataFrame:
         """
@@ -313,6 +313,7 @@ class DaskCudfJoinIntegration:
             to the number of chunks the callable can produce.
         bcast_info
             The broadcast join information.
+            This should be None for a regular hash join.
         options
             Additional join options.
 
@@ -330,7 +331,7 @@ class DaskCudfJoinIntegration:
             "how": options["how"],
         }
 
-        if bcast_info.bcast_side == "none":
+        if bcast_info is None:
             return left_input(0).merge(right_input(0), **join_kwargs)
         else:  # pragma: no cover
             raise NotImplementedError("Broadcast join not implemented.")

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -384,8 +384,6 @@ class JoinIntegration(Protocol[DataFrameT]):
 
         Parameters
         ----------
-        ctx
-            The worker context.
         bcast_side
             The side of the join being broadcasted. If "none", this is
             a regular hash join.

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -394,8 +394,8 @@ class JoinIntegration(Protocol[DataFrameT]):
 
     @staticmethod
     def join_partition(
-        left_input: DataFrameT | Callable[..., DataFrameT],
-        right_input: DataFrameT | Callable[..., DataFrameT],
+        left_input: Callable[[int], DataFrameT],
+        right_input: Callable[[int], DataFrameT],
         bcast_info: BCastJoinInfo,
         options: Any,
     ) -> DataFrameT:
@@ -405,15 +405,13 @@ class JoinIntegration(Protocol[DataFrameT]):
         Parameters
         ----------
         left_input
-            The left partition or a callable that produces
-            chunks of a broadcasted left partition.
-            The bcast_count argument corresponds to the number
-            of chunks the callable can produce.
+            A callable that produces chunks of the left partition.
+            The ``bcast_info.bcast_count`` parameter corresponds
+            to the number of chunks the callable can produce.
         right_input
-            The right partition or a callable that produces
-            chunks of a broadcasted right partition.
-            The bcast_count argument corresponds to the number
-            of chunks the callable can produce.
+            A callable that produces chunks of the right partition.
+            The ``bcast_info.bcast_count`` parameter corresponds
+            to the number of chunks the callable can produce.
         bcast_info
             The broadcast join information.
         options

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -370,18 +370,18 @@ class JoinIntegration(Protocol[DataFrameT]):
         ...
 
     @classmethod
-    def join_chunk(
+    def join_partition(
         cls,
         ctx: WorkerContext,
         bcast_side: Literal["left", "right", "none"],
         left_op_id: int,
         right_op_id: int,
         part_id: int,
-        n_worker_chunks: int,
+        n_worker_tasks: int,
         options: Any,
     ) -> DataFrameT:
         """
-        Perform a join operation on left and right table chunks.
+        Produce a joined table partition.
 
         Parameters
         ----------
@@ -398,8 +398,8 @@ class JoinIntegration(Protocol[DataFrameT]):
             to an allgather or shuffle operation.
         part_id
             The output partition id.
-        n_worker_chunks
-            The number of worker chunks to be joined on this worker.
+        n_worker_tasks
+            The number of join_partition tasks to be called on this worker.
             This information may be used for cleanup.
         options
             Additional options.
@@ -415,7 +415,7 @@ class JoinIntegration(Protocol[DataFrameT]):
         ...
 
 
-def join_chunk(
+def join_partition(
     get_context: Callable[..., WorkerContext],
     callback: Callable[
         [
@@ -424,7 +424,7 @@ def join_chunk(
             int,  # left_op_id
             int,  # right_op_id
             int,  # part_id
-            int,  # n_worker_chunks
+            int,  # n_worker_tasks
             Any,  # options
         ],
         DataFrameT,
@@ -435,11 +435,11 @@ def join_chunk(
     left_barrier: tuple[int, ...],
     right_barrier: tuple[int, ...],
     part_id: int,
-    n_worker_chunks: int,
+    n_worker_tasks: int,
     options: Any,
 ) -> DataFrameT:
     """
-    Perform a join operation on left and right table chunks.
+    Produce a joined table partition.
 
     Parameters
     ----------
@@ -447,7 +447,7 @@ def join_chunk(
         Callable function to fetch the worker context.
     callback
         Join callback function. This function must be the
-        `join_chunk` attribute of a `JoinIntegration`
+        `join_partition` attribute of a `JoinIntegration`
         protocol.
     bcast_side
         The side of the join being broadcasted. If "none", this is
@@ -464,8 +464,8 @@ def join_chunk(
         Worker-barrier task dependency for the right table.
     part_id
         The output partition id.
-    n_worker_chunks
-        The number of worker chunks to be joined on this worker.
+    n_worker_tasks
+        The number of join_partition tasks to be called on this worker.
         This information may be used for cleanup.
     options
         Additional options.
@@ -478,7 +478,7 @@ def join_chunk(
         left_op_id,
         right_op_id,
         part_id,
-        n_worker_chunks,
+        n_worker_tasks,
         options,
     )
 

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -369,9 +369,8 @@ class JoinIntegration(Protocol[DataFrameT]):
         """Return the shuffler integration."""
         ...
 
-    @classmethod
+    @staticmethod
     def join_partition(
-        cls,
         left_input: DataFrameT | Callable[..., DataFrameT],
         right_input: DataFrameT | Callable[..., DataFrameT],
         bcast_side: Literal["left", "right", "none"],
@@ -384,16 +383,19 @@ class JoinIntegration(Protocol[DataFrameT]):
         Parameters
         ----------
         left_input
-            The left-table operation id or the left partition.
-            The operation may correspond to an allgather or shuffle operation.
+            The left partition or a callable that produces
+            chunks of a broadcasted left partition.
+            The bcast_count argument corresponds to the number
+            of chunks the callable can produce.
         right_input
-            The right-table operation id or the right partition.
-            The operation may correspond to an allgather or shuffle operation.
+            The right partition or a callable that produces
+            chunks of a broadcasted right partition.
+            The bcast_count argument corresponds to the number
+            of chunks the callable can produce.
         bcast_side
-            The side of the join being broadcasted. If "none", this is
-            a regular hash join.
+            The side of the join being broadcasted (if either).
         bcast_count
-            The number of partitions to broadcast.
+            The number of broadcasted chunks.
             Ignored unless ``bcast_side`` is "left" or "right".
         options
             Additional join options.

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -372,7 +372,6 @@ class JoinIntegration(Protocol[DataFrameT]):
     @classmethod
     def join_partition(
         cls,
-        ctx: WorkerContext,
         bcast_side: Literal["left", "right", "none"],
         left_input: int | DataFrameT,
         right_input: int | DataFrameT,
@@ -416,10 +415,8 @@ class JoinIntegration(Protocol[DataFrameT]):
 
 
 def join_partition(
-    get_context: Callable[..., WorkerContext],
     callback: Callable[
         [
-            WorkerContext,  # ctx
             Literal["left", "right", "none"],  # bcast_side
             int | DataFrameT,  # left
             int | DataFrameT,  # right
@@ -443,8 +440,6 @@ def join_partition(
 
     Parameters
     ----------
-    get_context
-        Callable function to fetch the worker context.
     callback
         Join callback function. This function must be the
         `join_partition` attribute of a `JoinIntegration`
@@ -473,7 +468,6 @@ def join_partition(
     options
         Additional options.
     """
-    ctx = get_context()
 
     def _get_input(
         op_id: int | None, barrier: DataFrameT | tuple[int, ...]
@@ -494,7 +488,6 @@ def join_partition(
             return op_id
 
     return callback(
-        ctx,
         bcast_side,
         _get_input(left_op_id, left_barrier),
         _get_input(right_op_id, right_barrier),

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -370,13 +370,11 @@ class BCastJoinInfo:  # pragma: no cover; TODO: Cover in follow-up
     ----------
     bcast_side
         The side of the join being broadcasted.
-        If "none", this is a regular hash join.
     bcast_count
         The number of broadcasted partitions.
-        This value is ignored for regular hash joins.
     need_local_repartition
         Whether to locally repartition on the broadcasted table.
-        This is not necessary for inner or regular hash joins.
+        This is not necessary for inner joins.
     """
 
     bcast_side: Literal["left", "right"]

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -9,7 +9,7 @@ import weakref
 from dataclasses import dataclass, field
 from functools import partial
 from numbers import Number  # noqa: TC003
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, Protocol, TypeVar
 
 import rmm.mr
 from rmm.pylibrmm.stream import DEFAULT_STREAM
@@ -361,6 +361,29 @@ def extract_partition(
                     del ctx.shufflers[shuffle_id]
 
 
+@dataclass
+class BCastJoinInfo:
+    """
+    Broadcast join information.
+
+    Parameters
+    ----------
+    bcast_side
+        The side of the join being broadcasted.
+        If "none", this is a regular hash join.
+    bcast_count
+        The number of broadcasted partitions.
+        This value is ignored for regular hash joins.
+    need_local_repartition
+        Whether to locally repartition on the broadcasted table.
+        This is not necessary for inner or regular hash joins.
+    """
+
+    bcast_side: Literal["left", "right", "none"] = "none"
+    bcast_count: int = 1
+    need_local_repartition: bool = False
+
+
 class JoinIntegration(Protocol[DataFrameT]):
     """Join-integration protocol."""
 
@@ -373,8 +396,7 @@ class JoinIntegration(Protocol[DataFrameT]):
     def join_partition(
         left_input: DataFrameT | Callable[..., DataFrameT],
         right_input: DataFrameT | Callable[..., DataFrameT],
-        bcast_side: Literal["left", "right", "none"],
-        bcast_count: int | None,
+        bcast_info: BCastJoinInfo,
         options: Any,
     ) -> DataFrameT:
         """
@@ -392,11 +414,8 @@ class JoinIntegration(Protocol[DataFrameT]):
             chunks of a broadcasted right partition.
             The bcast_count argument corresponds to the number
             of chunks the callable can produce.
-        bcast_side
-            The side of the join being broadcasted (if either).
-        bcast_count
-            The number of broadcasted chunks.
-            Ignored unless ``bcast_side`` is "left" or "right".
+        bcast_info
+            The broadcast join information.
         options
             Additional join options.
 
@@ -407,15 +426,124 @@ class JoinIntegration(Protocol[DataFrameT]):
         ...
 
 
+class FetchPartition(Generic[DataFrameT]):
+    """
+    Fetch a left or right partition for a join operation.
+
+    Parameters
+    ----------
+    side
+        The side of the join being fetched.
+    output_partition_id
+        The output partition id.
+    get_context
+        Callable function to fetch the worker context.
+    integration
+        The JoinIntegration protocol to use.
+    op_id
+        The operation id.
+    barrier
+        The barrier to fetch the partition from.
+    bcast_info
+        The broadcast join information.
+    n_worker_tasks
+        The number of join_partition tasks to be called on this worker.
+    options
+        Additional options.
+    """
+
+    def __init__(
+        self,
+        side: Literal["left", "right"],
+        output_partition_id: int,
+        get_worker_context: Callable[..., WorkerContext],
+        integration: JoinIntegration[DataFrameT],
+        op_id: int | None,
+        barrier: DataFrameT | tuple[int, ...],
+        bcast_info: BCastJoinInfo,
+        n_worker_tasks: int,
+        options: Any,
+    ):
+        if (
+            bcast_info.bcast_side != "none"
+            or bcast_info.bcast_count != 1
+            or bcast_info.need_local_repartition
+        ):  # pragma: no cover
+            raise NotImplementedError("Broadcast join not yet supported.")
+
+        self.side = side
+        self.get_worker_context = get_worker_context
+        self.integration = integration
+        self.op_id = op_id
+        self.bcast_info = bcast_info
+        self.n_worker_tasks = n_worker_tasks
+        self.options = options
+        self._unbroadcasted_data: dict[int, DataFrameT] = {}
+        if self.side != self.bcast_info.bcast_side:
+            self._prepare_unbroadcasted_data(output_partition_id, barrier)
+
+    def _prepare_unbroadcasted_data(
+        self, output_partition_id: int, barrier: DataFrameT | tuple[int, ...]
+    ) -> None:
+        """
+        Prepare the unbroadcasted data.
+
+        Notes
+        -----
+        If the partition was not broadcasted, we can extract it now.
+        """
+        op_id = self.op_id
+        options = self.options
+        data: DataFrameT
+        if op_id is None:
+            assert not isinstance(barrier, tuple), "Barrier must be a DataFrame."
+            data = barrier
+        else:
+            ctx = self.get_worker_context()
+            shuffler = get_shuffler(ctx, op_id)
+            try:
+                data = self.integration.get_shuffler_integration().extract_partition(
+                    output_partition_id,
+                    shuffler,
+                    options,
+                )
+            finally:
+                if shuffler.finished():
+                    with ctx.lock:
+                        if op_id in ctx.shufflers:
+                            del ctx.shufflers[op_id]
+
+        self._unbroadcasted_data = {0: data}
+
+    def __call__(self, partition_id: int) -> Any:
+        """
+        Return the partition associated with the given id.
+
+        Parameters
+        ----------
+        partition_id
+            The local partition id to fetch.
+
+        Returns
+        -------
+        The partition.
+        """
+        if self.side == self.bcast_info.bcast_side:  # pragma: no cover
+            raise NotImplementedError("Broadcast join not implemented.")
+        else:
+            # Fetch a non-broadcasted partition.
+            # The partition_id is ignored, because we only have a single chunk.
+            return self._unbroadcasted_data[0]
+
+
 def join_partition(
     get_context: Callable[..., WorkerContext],
     integration: JoinIntegration[DataFrameT],
-    bcast_side: Literal["left", "right", "none"],
-    bcast_count: int | None,
+    bcast_info: BCastJoinInfo,
     left_op_id: int | None,
     right_op_id: int | None,
-    left_barrier: DataFrameT | tuple[int, ...],
-    right_barrier: DataFrameT | tuple[int, ...],
+    left_dependency: DataFrameT | tuple[int, ...],
+    right_dependency: DataFrameT | tuple[int, ...],
     part_id: int,
     n_worker_tasks: int,
     left_options: Any,
@@ -431,25 +559,26 @@ def join_partition(
         Callable function to fetch the worker context.
     integration
         The JoinIntegration protocol to use.
-    bcast_side
-        The side of the join being broadcasted. If "none", this is
-        a regular hash join.
-        Note: Only "none" is supported for now.
-    bcast_count
-        The number of partitions to broadcast.
-        Ignored unless ``bcast_side`` is "left" or "right".
+    bcast_info
+        The broadcast join information.
     left_op_id
         The left-table operation id. The operation may correspond
         to an allgather or a shuffle operation. If None, the
-        left_barrier argument must be the left partition.
+        left_dependency argument must be the left partition.
     right_op_id
         The right-table operation id. The operation may correspond
         to an allgather or a shuffle operation. If None, the
-        right_barrier argument must be the right partition.
-    left_barrier
-        Worker-barrier task dependency for the left table or the left partition.
-    right_barrier
-        Worker-barrier task dependency for the right table or the right partition.
+        right_dependency argument must be the right partition.
+    left_dependency
+        Task dependency for the left table. If left_op_id is None,
+        this will correspond to the left partition. Otherwise, this
+        argument is only used to enforce task ordering. The left_op_id
+        argument should be used to fetch the real left partition.
+    right_dependency
+        Task dependency for the right table. If right_op_id is None,
+        this will correspond to the right partition. Otherwise, this
+        argument is only used to enforce task ordering. The right_op_id
+        argument should be used to fetch the real right partition.
     part_id
         The output partition id.
         This information is needed to extract shuffled partitions.
@@ -468,48 +597,35 @@ def join_partition(
     A joined DataFrame partition.
     """
 
-    def _get_input(
-        op_id: int | None,
-        barrier: DataFrameT | tuple[int, ...],
-        options: Any,
-        get_context: Callable[..., WorkerContext],
-        integration: JoinIntegration[DataFrameT],
-        bcast_side: Literal["left", "right", "none"],
-        part_id: int,
-    ) -> DataFrameT | Callable[..., DataFrameT]:
+    def _get_input(side: Literal["left", "right"]) -> FetchPartition:
         """Return the input for one side of the join."""
-        if op_id is None:
-            # There is no operation id for this data.
-            # This means the table didn't need to be
-            # shuffled or broadcasted, and so the data
-            # is being passed in via the `barrier` argument.
-            assert not isinstance(barrier, tuple)
-            return barrier
-        elif bcast_side == "none":
-            # The table was shuffled, so we need to extract the partition.
-            ctx = get_context()
-            shuffler = get_shuffler(ctx, op_id)
-            try:
-                return integration.get_shuffler_integration().extract_partition(
-                    part_id,
-                    shuffler,
-                    options,
-                )
-            finally:
-                if shuffler.finished():
-                    with ctx.lock:
-                        if op_id in ctx.shufflers:
-                            del ctx.shufflers[op_id]
-        else:  # pragma: no cover
-            # The data was broadcasted, so we need to extract the partition.
-            raise NotImplementedError("Broadcast join not implemented.")
+        if side == "left":
+            op_id = left_op_id
+            barrier = left_dependency
+            options = left_options
+        elif side == "right":
+            op_id = right_op_id
+            barrier = right_dependency
+            options = right_options
+        else:
+            raise ValueError(f"Invalid side: {side}")
 
-    get_input_args = (get_context, integration, bcast_side, part_id)
+        return FetchPartition(
+            side,
+            part_id,
+            get_context,
+            integration,
+            op_id,
+            barrier,
+            bcast_info,
+            n_worker_tasks,
+            options,
+        )
+
     return integration.join_partition(
-        _get_input(left_op_id, left_barrier, left_options, *get_input_args),
-        _get_input(right_op_id, right_barrier, right_options, *get_input_args),
-        bcast_side,
-        bcast_count,
+        _get_input("left"),
+        _get_input("right"),
+        bcast_info,
         join_options,
     )
 

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -374,6 +374,7 @@ class JoinIntegration(Protocol[DataFrameT]):
         left_op_id: int,
         right_op_id: int,
         part_id: int,
+        n_worker_chunks: int,
         options: Any,
     ) -> DataFrameT:
         """
@@ -394,6 +395,9 @@ class JoinIntegration(Protocol[DataFrameT]):
             to an allgather or shuffle operation.
         part_id
             The output partition id.
+        n_worker_chunks
+            The number of worker chunks to be joined on this worker.
+            This information may be used for cleanup.
         options
             Additional options.
 
@@ -411,7 +415,15 @@ class JoinIntegration(Protocol[DataFrameT]):
 def join_chunk(
     get_context: Callable[..., WorkerContext],
     callback: Callable[
-        [WorkerContext, Literal["left", "right", "none"], int, int, int, Any],
+        [
+            WorkerContext,  # ctx
+            Literal["left", "right", "none"],  # bcast_side
+            int,  # left_op_id
+            int,  # right_op_id
+            int,  # part_id
+            int,  # n_worker_chunks
+            Any,  # options
+        ],
         DataFrameT,
     ],
     bcast_side: Literal["left", "right", "none"],
@@ -420,6 +432,7 @@ def join_chunk(
     left_barrier: tuple[int, ...],
     right_barrier: tuple[int, ...],
     part_id: int,
+    n_worker_chunks: int,
     options: Any,
 ) -> DataFrameT:
     """
@@ -448,6 +461,9 @@ def join_chunk(
         Worker-barrier task dependency for the right table.
     part_id
         The output partition id.
+    n_worker_chunks
+        The number of worker chunks to be joined on this worker.
+        This information may be used for cleanup.
     options
         Additional options.
     """
@@ -459,6 +475,7 @@ def join_chunk(
         left_op_id,
         right_op_id,
         part_id,
+        n_worker_chunks,
         options,
     )
 

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -364,7 +364,10 @@ def extract_partition(
 class JoinIntegration(Protocol[DataFrameT]):
     """Join-integration protocol."""
 
-    shuffle_integration: ShufflerIntegration[DataFrameT]
+    @staticmethod
+    def shuffler_integration() -> ShufflerIntegration[DataFrameT]:
+        """Return the shuffler integration."""
+        ...
 
     @classmethod
     def join_chunk(

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -365,7 +365,7 @@ class JoinIntegration(Protocol[DataFrameT]):
     """Join-integration protocol."""
 
     @staticmethod
-    def shuffler_integration() -> ShufflerIntegration[DataFrameT]:
+    def get_shuffler_integration() -> ShufflerIntegration[DataFrameT]:
         """Return the shuffler integration."""
         ...
 

--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -426,7 +426,7 @@ class JoinIntegration(Protocol[DataFrameT]):
         ...
 
 
-class FetchPartition(Generic[DataFrameT]):
+class FetchJoinPartition(Generic[DataFrameT]):
     """
     Fetch a left or right partition for a join operation.
 
@@ -597,7 +597,7 @@ def join_partition(
     A joined DataFrame partition.
     """
 
-    def _get_input(side: Literal["left", "right"]) -> FetchPartition:
+    def _get_input(side: Literal["left", "right"]) -> FetchJoinPartition:
         """Return the input for one side of the join."""
         if side == "left":
             op_id = left_op_id
@@ -610,7 +610,7 @@ def join_partition(
         else:
             raise ValueError(f"Invalid side: {side}")
 
-        return FetchPartition(
+        return FetchJoinPartition(
             side,
             part_id,
             get_context,

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Join integration for Dask Distributed clusters."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from rapidsmpf.config import Options
+from rapidsmpf.integrations.core import join_chunk
+from rapidsmpf.integrations.dask.core import (
+    get_dask_client,
+    get_dask_worker_rank,
+    get_worker_context,
+)
+from rapidsmpf.integrations.dask.shuffler import _partial_shuffle_graph
+
+if TYPE_CHECKING:
+    from rapidsmpf.integrations.core import JoinIntegration
+
+
+def rapidsmpf_join_graph(
+    left_name: str,
+    right_name: str,
+    output_name: str,
+    bcast_side: Literal["left", "right", "none"],
+    left_partition_count_in: int,
+    right_partition_count_in: int,
+    integration: JoinIntegration,
+    options: Any,
+    *,
+    config_options: Options = Options(),
+) -> dict[Any, Any]:
+    """Return the task graph for a RapidsMPF broadcast join."""
+    client = get_dask_client(options=config_options)
+    worker_ranks: dict[int, str] = {
+        v: k for k, v in client.run(get_dask_worker_rank).items()
+    }
+    n_workers = len(worker_ranks)
+    restricted_keys: dict[Any, str] = {}
+    graph: dict[Any, Any] = {}
+
+    if bcast_side == "none":
+        # Regular hash join
+        partition_count_out = max(left_partition_count_in, right_partition_count_in)
+        # TODO: What if one or both sides is already shuffled?
+        # Perhaps the user shouldn't use this function in that
+        # case, but we may be able to handle it here.
+
+        # Shuffle left side
+        left_barrier_name = f"rmpf-shuffle-left-{output_name}"
+        left_op_id, left_restricted_keys, left_graph = _partial_shuffle_graph(
+            client,
+            left_name,
+            left_barrier_name,
+            left_partition_count_in,
+            partition_count_out,
+            integration.shuffler_integration(),
+            worker_ranks,
+            {"on": options["left_on"]},
+        )
+        restricted_keys.update(left_restricted_keys)
+        graph.update(left_graph)
+
+        # Shuffle right side
+        right_barrier_name = f"rmpf-shuffle-right-{output_name}"
+        right_op_id, right_restricted_keys, right_graph = _partial_shuffle_graph(
+            client,
+            right_name,
+            right_barrier_name,
+            right_partition_count_in,
+            partition_count_out,
+            integration.shuffler_integration(),
+            worker_ranks,
+            {"on": options["right_on"]},
+        )
+        restricted_keys.update(right_restricted_keys)
+        graph.update(right_graph)
+
+        # Add basic hash-join tasks
+        for part_id in range(partition_count_out):
+            rank = part_id % n_workers
+            n_worker_chunks = partition_count_out // n_workers + int(
+                rank < (partition_count_out % n_workers)
+            )
+            key = (output_name, part_id)
+            graph[key] = (
+                join_chunk,
+                get_worker_context,
+                integration.join_chunk,
+                bcast_side,
+                left_op_id,
+                right_op_id,
+                left_barrier_name,
+                right_barrier_name,
+                part_id,
+                n_worker_chunks,
+                options,
+            )
+            # Assume round-robin partition assignment
+            restricted_keys[key] = worker_ranks[rank]
+
+    elif bcast_side in ["left", "right"]:  # pragma: no cover
+        # TODO: Broadcast join
+        raise NotImplementedError("Broadcast join is not yet implemented.")
+    else:  # pragma: no cover
+        raise ValueError(f"Invalid broadcast side: {bcast_side}")
+
+    # Tell the scheduler to restrict the worker-specific keys
+    client._send_to_scheduler(
+        {
+            "op": "rmpf_add_restricted_tasks",
+            "tasks": restricted_keys,
+        }
+    )
+
+    return graph

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
@@ -11,7 +11,6 @@ from rapidsmpf.integrations.core import join_partition
 from rapidsmpf.integrations.dask.core import (
     get_dask_client,
     get_dask_worker_rank,
-    get_worker_context,
 )
 from rapidsmpf.integrations.dask.shuffler import _partial_shuffle_graph
 
@@ -129,7 +128,6 @@ def rapidsmpf_join_graph(
             key = (output_name, part_id)
             graph[key] = (
                 join_partition,
-                get_worker_context,
                 integration.join_partition,
                 bcast_side,
                 left_op_id,

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
@@ -30,7 +30,7 @@ def rapidsmpf_join_graph(
     right_options: Any,
     join_options: Any,
     *,
-    bcast_side: Literal["left", "right", "none"] = "none",
+    bcast_side: Literal["left", "right", None] = None,
     left_pre_shuffled: bool = False,
     right_pre_shuffled: bool = False,
     config_options: Options = Options(),
@@ -60,8 +60,8 @@ def rapidsmpf_join_graph(
         Additional options for the join.
     bcast_side
         The side of the join being broadcasted.
-        Options are ``{'left', 'right', 'none'}``.
-        Note: Only ``'none'`` is supported for now.
+        Options are ``{'left', 'right', None}``.
+        Note: Only ``None`` is supported for now.
     left_pre_shuffled
         Whether the left table is already shuffled.
     right_pre_shuffled
@@ -88,7 +88,7 @@ def rapidsmpf_join_graph(
     left_op_id: int | None = None
     right_op_id: int | None = None
 
-    if bcast_side == "none":
+    if bcast_side is None:
         # Regular hash join
 
         # Determine the number of partitions in the output table

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
@@ -96,7 +96,7 @@ def rapidsmpf_join_graph(
                 left_barrier_name,
                 left_partition_count_in,
                 partition_count_out,
-                integration.shuffler_integration(),
+                integration.get_shuffler_integration(),
                 worker_ranks,
                 {"on": options["left_on"]},
             )
@@ -112,7 +112,7 @@ def rapidsmpf_join_graph(
                 right_barrier_name,
                 right_partition_count_in,
                 partition_count_out,
-                integration.shuffler_integration(),
+                integration.get_shuffler_integration(),
                 worker_ranks,
                 {"on": options["right_on"]},
             )

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
@@ -13,7 +13,7 @@ from rapidsmpf.integrations.dask.core import (
     get_dask_worker_rank,
     get_worker_context,
 )
-from rapidsmpf.integrations.dask.shuffler import _partial_shuffle_graph
+from rapidsmpf.integrations.dask.shuffler import _shuffle_insertion_graph
 
 if TYPE_CHECKING:
     from rapidsmpf.integrations.core import JoinIntegration
@@ -96,11 +96,15 @@ def rapidsmpf_join_graph(
 
         # Shuffle left side (if necessary)
         if not left_pre_shuffled or left_partition_count_in != partition_count_out:
-            left_barrier_name = f"rmpf-shuffle-left-{output_name}"
-            left_op_id, left_restricted_keys, left_graph = _partial_shuffle_graph(
+            (
+                left_graph,
+                left_barrier_name,
+                left_restricted_keys,
+                left_op_id,
+            ) = _shuffle_insertion_graph(
                 client,
                 left_name,
-                left_barrier_name,
+                f"left-{output_name}",
                 left_partition_count_in,
                 partition_count_out,
                 integration.get_shuffler_integration(),
@@ -112,11 +116,15 @@ def rapidsmpf_join_graph(
 
         # Shuffle right side (if necessary)
         if not right_pre_shuffled or right_partition_count_in != partition_count_out:
-            right_barrier_name = f"rmpf-shuffle-right-{output_name}"
-            right_op_id, right_restricted_keys, right_graph = _partial_shuffle_graph(
+            (
+                right_graph,
+                right_barrier_name,
+                right_restricted_keys,
+                right_op_id,
+            ) = _shuffle_insertion_graph(
                 client,
                 right_name,
-                right_barrier_name,
+                f"right-{output_name}",
                 right_partition_count_in,
                 partition_count_out,
                 integration.get_shuffler_integration(),

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 
 from rapidsmpf.config import Options
-from rapidsmpf.integrations.core import join_chunk
+from rapidsmpf.integrations.core import join_partition
 from rapidsmpf.integrations.dask.core import (
     get_dask_client,
     get_dask_worker_rank,
@@ -80,21 +80,21 @@ def rapidsmpf_join_graph(
         # Add basic hash-join tasks
         for part_id in range(partition_count_out):
             rank = part_id % n_workers
-            n_worker_chunks = partition_count_out // n_workers + int(
+            n_worker_tasks = partition_count_out // n_workers + int(
                 rank < (partition_count_out % n_workers)
             )
             key = (output_name, part_id)
             graph[key] = (
-                join_chunk,
+                join_partition,
                 get_worker_context,
-                integration.join_chunk,
+                integration.join_partition,
                 bcast_side,
                 left_op_id,
                 right_op_id,
                 left_barrier_name,
                 right_barrier_name,
                 part_id,
-                n_worker_chunks,
+                n_worker_tasks,
                 options,
             )
             # Assume round-robin partition assignment

--- a/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/join.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 
 from rapidsmpf.config import Options
-from rapidsmpf.integrations.core import BCastJoinInfo, join_partition
+from rapidsmpf.integrations.core import join_partition
 from rapidsmpf.integrations.dask.core import (
     get_dask_client,
     get_dask_worker_rank,
@@ -135,7 +135,6 @@ def rapidsmpf_join_graph(
             graph.update(right_graph)
 
         # Add basic hash-join tasks
-        bcast_info = BCastJoinInfo(bcast_side="none")  # Not a broadcast join
         for part_id in range(partition_count_out):
             rank = part_id % n_workers
             n_worker_tasks = partition_count_out // n_workers + int(
@@ -146,7 +145,7 @@ def rapidsmpf_join_graph(
                 join_partition,
                 get_worker_context,
                 integration,
-                bcast_info,
+                None,  # Not a broadcast join
                 left_op_id,
                 right_op_id,
                 left_barrier_name or (left_name, part_id),


### PR DESCRIPTION
In order to leverage the recent `AllGather` work within Dask-based execution in multi-GPU Polars, we need a new integration API in RapidsMPF.

Although this new API **could** simply specialize in broadcast joins, it seems reasonable to introduce a general join integration that handles any realistic combination of shuffling/broadcasting the child tables. Even if we are not performing a broadcast join, it may be beneficial to extract left- and right-hand partitions within the same task that is performing the local join. This way, we don't leave un-spillable data on the worker between the shuffle-extraction task(s) and the corresponding join task.

This PR adds a general integration API for join operations. It includes some of the pieces that will be needed for broadcast-based joins. However, it only implements the hash-join code path for now (to limit the size of the diff). Note that this PR does not implement "single-worker" execution either. Both broadcast joins and single-worker execution will be addressed in follow-up work.