### PR TITLE
[MINOR] Proper shuffler shutdown

### DIFF
--- a/cpp/include/rapidsmpf/shuffler/shuffler.hpp
+++ b/cpp/include/rapidsmpf/shuffler/shuffler.hpp
@@ -330,7 +330,7 @@ class Shuffler {
   private:
     rmm::cuda_stream_view stream_;
     BufferResource* br_;
-    bool active_{true};
+    std::atomic<bool> active_{true};
     detail::PostBox<Rank> outgoing_postbox_;  ///< Postbox for outgoing chunks, that are
                                               ///< ready to be sent to other ranks.
     detail::PostBox<PartID> ready_postbox_;  ///< Postbox for received chunks, that are

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -417,7 +417,7 @@ class Shuffler::Progress {
 
         // Return Done only if the shuffler is inactive (shutdown was called) _and_
         // all containers are empty (all work is done).
-        return (shuffler_.active_
+        return (shuffler_.active_.load(std::memory_order_acquire)
                 || !(
                     fire_and_forget_.empty() && incoming_chunks_.empty()
                     && outgoing_chunks_.empty() && in_transit_chunks_.empty()
@@ -520,10 +520,10 @@ Shuffler::~Shuffler() {
 }
 
 void Shuffler::shutdown() {
-    if (active_) {
+    bool expected = true;
+    if (active_.compare_exchange_strong(expected, false)) {
         auto& log = comm_->logger();
         log.debug("Shuffler.shutdown() - initiate");
-        active_ = false;
         progress_thread_->remove_function(progress_thread_function_id_);
         br_->spill_manager().remove_spill_function(spill_function_id_);
         log.debug("Shuffler.shutdown() - done");

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -1294,7 +1294,7 @@ TEST(ShufflerTest, multiple_shutdowns) {
             shuffler->shutdown();
         }));
     }
-    shuffler.reset();
     std::ranges::for_each(futures, [](auto& future) { future.get(); });
+    shuffler.reset();
     GlobalEnvironment->barrier();
 }


### PR DESCRIPTION
`Shuffler::shutdown()` should be thread-safe and can be called multiple times. This PR ensures that. 