### PR TITLE
Enable timeout with stacks for ctests

### DIFF
--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -4,6 +4,8 @@
 
 set -xeuo pipefail
 
+TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
+
 # Support customizing the ctests' install location
 cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/librapidsmpf/"
 
@@ -21,10 +23,13 @@ timeout_secs=$((5*60)) # 5m timeout
 # Run tests using mpirun with multiple nranks. Test cases and nranks are defined in the cpp/tests/CMakeLists.txt
 
 # mpi_tests cases
-ctest --verbose --no-tests=error --output-on-failure --timeout $timeout_secs -R "mpi_tests_*" "${EXTRA_ARGS[@]}"
+python "${TIMEOUT_TOOL_PATH}" "${timeout_secs}" \
+   ctest --verbose --no-tests=error --output-on-failure -R "mpi_tests_*" "${EXTRA_ARGS[@]}"
 
 # ucxx_tests cases
-ctest --verbose --no-tests=error --output-on-failure --timeout $timeout_secs -R "ucxx_tests_*" "${EXTRA_ARGS[@]}"
+python "${TIMEOUT_TOOL_PATH}" "${timeout_secs}" \
+    ctest --verbose --no-tests=error --output-on-failure -R "ucxx_tests_*" "${EXTRA_ARGS[@]}"
 
 # single_tests case
-ctest --verbose --no-tests=error --output-on-failure --timeout $timeout_secs -R "single_tests" "${EXTRA_ARGS[@]}"
+python "${TIMEOUT_TOOL_PATH}" "${timeout_secs}" \
+    ctest --verbose --no-tests=error --output-on-failure  -R "single_tests" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
The timeout with stacks tool is only available for Python tests at the moment, but today some deadlocks started (see #539) to show up in CI, thus enabling it for ctests is probably gonna be useful.

Testing locally shows this approach works, however, it dumps stack and then kills each process individually, because of that if tests are still running in some of the workers (or if killing one of the workers "unblocks" others) it may look like the tests are continuing while they're being killed (i.e., there's a stack trace, then more tests running, then another stack, ...), so it's important to analyze output carefully to understand what really is going on and make no assumptions in case some of those worker processes happen to continue after others have been killed.