### PR TITLE
Fix hang in boostrap_dask_cluster with new clients

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/dask/core.py
@@ -283,13 +283,13 @@ def bootstrap_dask_cluster(
         ]
         wait(ucxx_setup_futures)
 
-        # finally, prepare the rapidsmpf resources on top of the ucxx comms
+        # Finally, prepare the RapidsMPF resources on top of the UCXX comms
         client.run(
             dask_worker_setup,
             options=options,
         )
 
-        # only run the above steps once
+        # Only run the above steps once
         _initialized_clusters.add(info["id"])
 
 

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import multiprocessing
 from typing import TYPE_CHECKING, Literal
 
 import dask
@@ -509,13 +510,32 @@ def test_dask_cudf_join(
 
 
 @gen_test(timeout=30)
+@pytest.mark.filterwarnings("ignore")
 async def test_bootstrap_multiple_clients(
     loop: pytest.FixtureDef,  # noqa: F811
 ) -> None:
     # https://github.com/rapidsai/rapidsmpf/issues/458
+
+    def connect_from_subprocess(
+        scheduler_address: str, q: multiprocessing.Queue
+    ) -> None:
+        client = Client(scheduler_address)
+        bootstrap_dask_cluster(client)
+        q.put(obj=True)
+
     with LocalCUDACluster(loop=loop) as cluster:
         with Client(cluster) as client_1:
             bootstrap_dask_cluster(client_1)
 
         with Client(cluster) as client_2:
             bootstrap_dask_cluster(client_2)
+
+        q: multiprocessing.Queue[bool] = multiprocessing.Queue()
+        p = multiprocessing.Process(
+            target=connect_from_subprocess, args=(cluster.scheduler_address, q)
+        )
+        p.start()
+        result = q.get(timeout=10)
+        p.join()
+
+    assert result is True

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -506,3 +506,16 @@ def test_dask_cudf_join(
                 right0, left_on=left_on, right_on=right_on, how=how
             ).compute()
             dd.assert_eq(joined, expected, check_index=False)
+
+
+@gen_test(timeout=30)
+async def test_bootstrap_multiple_clients(
+    loop: pytest.FixtureDef,  # noqa: F811
+) -> None:
+    # https://github.com/rapidsai/rapidsmpf/issues/458
+    with LocalCUDACluster(loop=loop) as cluster:
+        with Client(cluster) as client_1:
+            bootstrap_dask_cluster(client_1)
+
+        with Client(cluster) as client_2:
+            bootstrap_dask_cluster(client_2)


### PR DESCRIPTION
The resources created by rapidsmpf are all global to the scheduler / worker processes.

Dask supports multiple Clients sharing the same cluster.

Previously, we used the Client ID to track whether we've bootstrapped a Dask Cluster. If the user provided a new Client for the same cluster, we'd attempt to re-bootstrap it and things would hang.

To fix this, we use the scheduler ID instead of the client ID to check if we've boostrapped the cluster.

Closes https://github.com/rapidsai/rapidsmpf/issues/458