### PR TITLE
Make CI scripts more consistent and trap exit error codes

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -32,8 +32,15 @@ rapids-print-env
 RAPIDS_DOCS_DIR="$(mktemp -d)"
 export RAPIDS_DOCS_DIR
 
+# Trap ERR so that `EXITCODE` is printed when a command fails and the script
+# exits with error status
 EXITCODE=0
-trap "EXITCODE=1" ERR
+# shellcheck disable=SC2317
+set_exit_code() {
+    EXITCODE=$?
+    rapids-logger "Test failed with error ${EXITCODE}"
+}
+trap set_exit_code ERR
 set +e
 
 rapids-logger "Build CPP docs"
@@ -56,4 +63,5 @@ popd
 
 RAPIDS_VERSION_NUMBER="${RAPIDS_VERSION_MAJOR_MINOR}" rapids-upload-docs
 
+rapids-logger "Test script exiting with latest error code: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/run_cpp_benchmark_smoketests.sh
+++ b/ci/run_cpp_benchmark_smoketests.sh
@@ -4,6 +4,8 @@
 
 set -xeuo pipefail
 
+TIMEOUT_TOOL_PATH="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/timeout_with_stack.py
+
 # Support customizing the ctests' install location
 cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/benchmarks/librapidsmpf/"
 
@@ -13,12 +15,15 @@ export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 export OMPI_MCA_opal_cuda_support=1  # enable CUDA support in OpenMPI
 
 # Ensure that benchmarks are runnable
-mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m cuda
-mpirun --map-by node --bind-to none -np 3 ./bench_comm -m cuda
+python "${TIMEOUT_TOOL_PATH}" 30 \
+    mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m cuda
+python "${TIMEOUT_TOOL_PATH}" 30 \
+    mpirun --map-by node --bind-to none -np 3 ./bench_comm -m cuda
 ./bench_streaming_shuffle -m cuda
 
 # Ensure that shuffle benchmark with CUPTI monitor is runnable and creates the expected csv files
-mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m cuda -M cupti_shuffle
+python "${TIMEOUT_TOOL_PATH}" 30 \
+    mpirun --map-by node --bind-to none -np 3 ./bench_shuffle -m cuda -M cupti_shuffle
 for i in {0..2}; do
   if [[ ! -f cupti_shuffle${i}.csv ]]; then
     echo "Error: cupti_shuffle${i}.csv was not created!"
@@ -27,7 +32,8 @@ for i in {0..2}; do
 done
 
 # Ensure that comm benchmark with CUPTI monitor is runnable and creates the expected csv files
-mpirun --map-by node --bind-to none -np 3 ./bench_comm -m cuda -M cupti_comm
+python "${TIMEOUT_TOOL_PATH}" 30 \
+    mpirun --map-by node --bind-to none -np 3 ./bench_comm -m cuda -M cupti_comm
 for i in {0..2}; do
   if [[ ! -f cupti_comm${i}.csv ]]; then
     echo "Error: cupti_comm${i}.csv was not created!"

--- a/ci/run_cpp_example_smoketests.sh
+++ b/ci/run_cpp_example_smoketests.sh
@@ -15,7 +15,8 @@ export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 export OMPI_MCA_opal_cuda_support=1  # enable CUDA support in OpenMPI
 
 # Ensure that shuffle example is runnable
-mpirun --map-by node --bind-to none -np 2 ./example_shuffle
+python "${TIMEOUT_TOOL_PATH}" 30 \
+    mpirun --map-by node --bind-to none -np 2 ./example_shuffle
 
 # Ensure that cupti monitor example is runnable and creates the expected csv file
 python "${TIMEOUT_TOOL_PATH}" 30 ./example_cupti_monitor

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -37,11 +37,22 @@ nvidia-smi
 # Support invoking test_python.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
+# Trap ERR so that `EXITCODE` is printed when a command fails and the script
+# exits with error status
+EXITCODE=0
+# shellcheck disable=SC2317
+set_exit_code() {
+    EXITCODE=$?
+    rapids-logger "Test failed with error ${EXITCODE}"
+}
+trap set_exit_code ERR
+set +e
+
 rapids-logger "Pytest RapidsMPF (MPI+UCXX)"
-./ci/run_pytests.sh && EXITCODE=$? || EXITCODE=$?;
+./ci/run_pytests.sh
 
 rapids-logger "Pytest RapidsMPF (UCXX polling mode)"
-RAPIDSMPF_UCXX_PROGRESS_MODE=polling ./ci/run_pytests.sh --disable-mpi && EXITCODE=$? || EXITCODE=$?;
+RAPIDSMPF_UCXX_PROGRESS_MODE=polling ./ci/run_pytests.sh --disable-mpi
 
-rapids-logger "Test script exiting with value: $EXITCODE"
+rapids-logger "Test script exiting with latest error code: $EXITCODE"
 exit "${EXITCODE}"


### PR DESCRIPTION
Make CI scripts more consistent by doing the following changes:

- Use timeout with stack on all test processes, serving two purposes:
  - Ensure all test processes that execute will timeout if a deadlock occurs and thus never rely on the default 6h CI job timeout
  - If C++ examples and benchmarks deadlock and timeout, their stacks will be printed as other tests do
- Always use trap to catch errors from test processes
- Improve trap script to print individual logs for each process that failed running