### PR TITLE
Attempt to address deadlocks in streaming shuffle tests

### DIFF
--- a/cpp/src/streaming/cudf/shuffler.cpp
+++ b/cpp/src/streaming/cudf/shuffler.cpp
@@ -120,9 +120,9 @@ coro::task<std::vector<PackedData>> ShufflerAsync::extract_async(shuffler::PartI
     );
     extracted_pids_.emplace(pid);
     auto all_extracted = all_extracted_unsafe();
-    lock.unlock();  // no longer need the lock
 
     auto chunks = shuffler_.extract(pid);
+    lock.unlock();  // no longer need the lock
 
     // if all partitions have been extracted, notify all waiting tasks.
     if (all_extracted) {
@@ -152,9 +152,8 @@ ShufflerAsync::extract_any_async() {
     auto pid = ready_pids_.extract(ready_pids_.begin()).value();
     extracted_pids_.emplace(pid);
     auto all_extracted = all_extracted_unsafe();
-    lock.unlock();
-
     auto chunks = shuffler_.extract(pid);
+    lock.unlock();
 
     // if all partitions have been extracted, notify all waiting tasks.
     if (all_extracted) {

--- a/cpp/tests/streaming/test_shuffler.cpp
+++ b/cpp/tests/streaming/test_shuffler.cpp
@@ -149,9 +149,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(StreamingShuffler, basic_shuffler) {
     EXPECT_NO_FATAL_FAILURE(run_test([&](auto ch_in, auto ch_out) -> Node {
-        return node::shuffler(
-            ctx, std::move(ch_in), std::move(ch_out), op_id, num_partitions
-        );
+        return node::shuffler(ctx, ch_in, ch_out, op_id, num_partitions);
     }));
 }
 
@@ -288,25 +286,19 @@ Node shuffler_nb(
 
 TEST_P(StreamingShuffler, callbacks_1_consumer) {
     EXPECT_NO_FATAL_FAILURE(run_test([&](auto ch_in, auto ch_out) -> Node {
-        return shuffler_nb(
-            ctx, std::move(ch_in), std::move(ch_out), op_id, num_partitions, 1
-        );
+        return shuffler_nb(ctx, ch_in, ch_out, op_id, num_partitions, 1);
     }));
 }
 
 TEST_P(StreamingShuffler, callbacks_2_consumer) {
     EXPECT_NO_FATAL_FAILURE(run_test([&](auto ch_in, auto ch_out) -> Node {
-        return shuffler_nb(
-            ctx, std::move(ch_in), std::move(ch_out), op_id, num_partitions, 2
-        );
+        return shuffler_nb(ctx, ch_in, ch_out, op_id, num_partitions, 2);
     }));
 }
 
 TEST_P(StreamingShuffler, callbacks_4_consumer) {
     EXPECT_NO_FATAL_FAILURE(run_test([&](auto ch_in, auto ch_out) -> Node {
-        return shuffler_nb(
-            ctx, std::move(ch_in), std::move(ch_out), op_id, num_partitions, 4
-        );
+        return shuffler_nb(ctx, ch_in, ch_out, op_id, num_partitions, 4);
     }));
 }
 

--- a/cpp/tests/streaming/test_shuffler.cpp
+++ b/cpp/tests/streaming/test_shuffler.cpp
@@ -279,7 +279,10 @@ Node shuffler_nb(
         shutdown_task(std::move(shuffler_ctx), ctx.get(), std::move(ch_out), latch)
     );
 
-    co_await coro::when_all(std::move(nodes));
+    auto results = co_await coro::when_all(std::move(nodes));
+    for (auto& result : results) {
+        result.return_value();
+    }
 }
 
 }  // namespace

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -278,6 +278,7 @@ dependencies:
           - *cmake_ver
           - cuda-sanitizer-api
           - psutil  # Used for timeout_with_stack.py
+          - gdb
           - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
           - valgrind
   test_python:


### PR DESCRIPTION
Locally if I run:

```sh
while mpiexec --tag-output -n 4 ./ucxx_tests --gtest_filter='*ShufflerAsync*:StreamingShuffler/*:BaseStreamingFixture*'; do 
  /bin/true; 
done
```

On branch-25.12, I observe a deadlock in the multi-consumer test after around 5-10mins. Some ranks appear to be in the teardown barrier for a test while one other rank is still completing a shuffle (and has not destroyed the shuffler despite reporting it finished).

After these changes, I have run for over 20mins without observing a deadlock. This is clearly only necessary, and not sufficient, for correctness but it appears to be _better_.

There are a combination of changes which:

- tidy up the placement of barriers in the tests so that things are consistent.
- assert the invariant that after `extract_any_async` returns `nullopt` that the shuffle reports `finished()`
- fix the implementation of `extract_any_async` to ensure that invariant.
- rethrow exceptions from an awaited `coro::when_all`
- use a normal mutex in the "hand" implementation of the async shuffle for updating the output results with many consumers. I think this is a more natural thing.
- require gdb in the C++ test environment so that we can actually produce stack traces.