### PR TITLE
[MINOR] Fix Spill Manager remove spill function deadlock

### DIFF
--- a/cpp/src/buffer/spill_manager.cpp
+++ b/cpp/src/buffer/spill_manager.cpp
@@ -58,9 +58,9 @@ void SpillManager::remove_spill_function(SpillFunctionID fid) {
     }
     spill_functions_.erase(fid);
 
-    // Pause the spill thread if no spill functions are left.
+    // Pause asynchronously the spill thread if no spill functions are left.
     if (periodic_spill_thread_.has_value() && spill_functions_.empty()) {
-        periodic_spill_thread_->pause();
+        periodic_spill_thread_->pause_nb();
     }
 }
 


### PR DESCRIPTION
Observed a deadlock recently, and there was a legit scenario where Spill manager is being shutdown, while another thread calls `remove_spill_function` and it hangs, because `pause` never completes. 

I think we dont _really_ need to wait for the background thread to pause. Indicating it to pause is sufficient. 