### PR TITLE
Fix rmm.librmm cimport

### DIFF
--- a/python/rapidsmpf/rapidsmpf/rmm_resource_adaptor.pxd
+++ b/python/rapidsmpf/rapidsmpf/rmm_resource_adaptor.pxd
@@ -3,9 +3,9 @@
 
 from cython.operator cimport dereference as deref
 from libc.stdint cimport uint64_t
+from rmm.librmm.memory_resource cimport device_memory_resource
 from rmm.pylibrmm.memory_resource cimport (DeviceMemoryResource,
-                                           UpstreamResourceAdaptor,
-                                           device_memory_resource)
+                                           UpstreamResourceAdaptor)
 
 
 cdef extern from "<rapidsmpf/rmm_resource_adaptor.hpp>" nogil:


### PR DESCRIPTION
`rmm_resource_adapter.pxd` is `cimport`-ing a name from the wrong RMM module. This fixes it.

RMM unintentionally exposed some names in multiple places in the public Cython API, and will be breaking this in https://github.com/rapidsai/rmm/pull/2083.