### PR TITLE
Replace path to user's home with wildcard

### DIFF
--- a/cpp/compute-sanitizer-suppressions.xml
+++ b/cpp/compute-sanitizer-suppressions.xml
@@ -251,7 +251,7 @@
       </frame>
       <frame>
         <func>std::invoke_result&lt;rapidsmpf::buffer_copy</func>
-        <path>/home/mkristensen/repos/rapidsmpf/cpp/include/rapidsmpf/buffer/buffer.hpp</path>
+        <path>*/buffer/buffer.hpp</path>
         <module>.*/librapidsmpf.so</module>
       </frame>
       <frame>


### PR DESCRIPTION
The change introduced in https://github.com/rapidsai/rapidsmpf/pull/544 added a full path to the user's directory, this was probably unintentional and a wildcard should suffice as alternative.