### PR TITLE
Release the `CuptiMonitor` mutex before joining thread

### DIFF
--- a/cpp/src/cupti.cpp
+++ b/cpp/src/cupti.cpp
@@ -100,8 +100,6 @@ void CuptiMonitor::start_monitoring() {
 }
 
 void CuptiMonitor::stop_monitoring() {
-    std::lock_guard<std::mutex> lock(mutex_);
-
     if (!monitoring_active_.load()) {
         return;
     }


### PR DESCRIPTION
If the sampling thread executes `capture_memory_sample()` and `monitor_active_ == true`, but then simultaneously the application thread calls `stop_monitoring()` and acquires `mutex_` before `sampling_thread_` acquired the mutex a deadlock will occur since `sampling_thread_.join()` can never complete. To prevent this release the `mutex_` before `sampling_thread_.join()` is called.

Fixes https://github.com/rapidsai/rapidsmpf/issues/587