### PR TITLE
Coroutine utility function: `coro_results()`

### DIFF
--- a/cpp/include/rapidsmpf/streaming/core/coro_utils.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/coro_utils.hpp
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+#include <ranges>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <coro/coro.hpp>
+
+namespace rapidsmpf::streaming {
+
+/**
+ * @brief Collect the results of multiple finished coroutines.
+ *
+ * This helper consumes a range of coroutine result objects (e.g., from
+ * `coro::when_all` or `coro::when_any`) and extracts their return values by
+ * invoking `.return_value()` on each element.
+ *
+ * - If the tasks produce a non-void type `T`, all values are collected into a
+ *   `std::vector<T>` and returned.
+ * - If the tasks return `void`, the function simply invokes `.return_value()`
+ *   on each element to surface any unhandled exceptions and then returns `void`.
+ *
+ * @tparam Range A range type whose elements support a `.return_value()` member
+ * function. Typically the result of functions and coroutines like `coro::when_all`
+ * and `coro::wait_all`
+ *
+ * @param task_results A range of completed coroutine results.
+ * @return `std::vector<T>` if the underlying tasks return a value of type `T` or
+ * `void` if the underlying tasks return `void`.
+ *
+ * @note All result types must be the same. If your coroutines produce heterogeneous
+ * result types, this helper cannot be used; you must instead extract each result
+ * manually by calling `.return_value()` on each element.
+ *
+ * @note The return values of libcoro's gather functions such as `coro::when_all`
+ * and `coro::wait_all` must always be retrieved by calling `.return_value()` (either
+ * directly or via this helper). Failing to do so leaves exceptions unobserved, which
+ * can cause the streaming pipeline to deadlock or hang indefinitely while waiting for
+ * error propagation.
+ */
+template <std::ranges::range Range>
+auto coro_results(Range&& task_results) {
+    using first_ref_t = std::ranges::range_value_t<Range>;
+    using raw_ret_t = decltype(std::declval<first_ref_t>().return_value());
+    using val_t = std::remove_cvref_t<raw_ret_t>;
+
+    if constexpr (std::is_void_v<val_t>) {
+        // Just surface exceptions; return void.
+        for (auto&& r : task_results) {
+            r.return_value();
+        }
+    } else {
+        std::vector<val_t> ret;
+        if constexpr (std::ranges::sized_range<Range>) {
+            ret.reserve(task_results.size());
+        }
+        for (auto&& r : task_results) {
+            ret.emplace_back(r.return_value());
+        }
+        return ret;
+    }
+}
+
+}  // namespace rapidsmpf::streaming

--- a/cpp/src/streaming/core/node.cpp
+++ b/cpp/src/streaming/core/node.cpp
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rapidsmpf/streaming/core/coro_utils.hpp>
 #include <rapidsmpf/streaming/core/node.hpp>
 
 namespace rapidsmpf::streaming {
 
 void run_streaming_pipeline(std::vector<Node> nodes) {
-    auto results = coro::sync_wait(coro::when_all(std::move(nodes)));
-    for (auto& result : results) {
-        // The node result itself is always `void` but we access it here to re-throw
-        // possible unhandled exceptions.
-        result.return_value();
-    }
+    coro_results(coro::sync_wait(coro::when_all(std::move(nodes))));
 }
 
 }  // namespace rapidsmpf::streaming

--- a/cpp/tests/streaming/test_leaf_node.cpp
+++ b/cpp/tests/streaming/test_leaf_node.cpp
@@ -16,6 +16,7 @@
 #include <rapidsmpf/communicator/single.hpp>
 #include <rapidsmpf/streaming/core/channel.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
+#include <rapidsmpf/streaming/core/coro_utils.hpp>
 #include <rapidsmpf/streaming/core/leaf_node.hpp>
 #include <rapidsmpf/streaming/core/node.hpp>
 #include <rapidsmpf/streaming/cudf/table_chunk.hpp>
@@ -78,10 +79,7 @@ Node shutdown(
     std::shared_ptr<Context> ctx, std::shared_ptr<Channel> ch, std::vector<Node>&& tasks
 ) {
     ShutdownAtExit c{ch};
-    auto results = co_await coro::when_all(std::move(tasks));
-    for (auto& r : results) {
-        r.return_value();
-    }
+    coro_results(co_await coro::when_all(std::move(tasks)));
     co_await ch->drain(ctx->executor());
 }
 


### PR DESCRIPTION
```c++
/**
 * @brief Collect the results of multiple finished coroutines.
 *
 * This helper consumes a range of coroutine result objects (e.g., from
 * `coro::when_all` or `coro::when_any`) and extracts their return values by
 * invoking `.return_value()` on each element.
 *
 * - If the tasks produce a non-void type `T`, all values are collected into a
 *   `std::vector<T>` and returned.
 * - If the tasks return `void`, the function simply invokes `.return_value()`
 *   on each element to surface any unhandled exceptions and then returns `void`.
 *
 * @tparam Range A range type whose elements support a `.return_value()` member
 * function. Typically the result of functions and coroutines like `coro::when_all`
 * and `coro::wait_all`
 *
 * @param task_results A range of completed coroutine results.
 * @return `std::vector<T>` if the underlying tasks return a value of type `T` or
 * `void` if the underlying tasks return `void`.
 *
 * @note All result types must be the same. If your coroutines produce heterogeneous
 * result types, this helper cannot be used; you must instead extract each result
 * manually by calling `.return_value()` on each element.
 *
 * @note The return values of libcoro's gather functions such as `coro::when_all`
 * and `coro::wait_all` must always be retrieved by calling `.return_value()` (either
 * directly or via this helper). Failing to do so leaves exceptions unobserved, which
 * can cause the streaming pipeline to deadlock or hang indefinitely while waiting for
 * error propagation.
 */
template <std::ranges::range Range>
auto coro_results(Range&& task_results);
```