### PR TITLE
Add an arbitrary payload chunk

### DIFF
--- a/cpp/include/rapidsmpf/streaming/cudf/owning_wrapper.hpp
+++ b/cpp/include/rapidsmpf/streaming/cudf/owning_wrapper.hpp
@@ -55,6 +55,15 @@ class OwningWrapper {
     explicit OwningWrapper(void* obj, deleter_type deleter)
         : obj_{owning_type(obj, deleter)} {}
 
+    /**
+     * @brief Release ownership of the underlying pointer
+     *
+     * @return Pointer to object.
+     */
+    void* release() noexcept {
+        return obj_.release();
+    }
+
   private:
     using owning_type = std::unique_ptr<void, deleter_type>;
     owning_type obj_{nullptr, [](void*) {}};

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/CMakeLists.txt
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake-format: on
 # =================================================================================
 
-set(cython_modules partition.pyx)
+set(cython_modules arbitrary.pyx partition.pyx utils.pyx)
 
 rapids_cython_create_modules(
   CXX

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/arbitrary.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/arbitrary.pxd
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from libcpp.memory cimport unique_ptr
+
+
+cdef extern from "<rapidsmpf/streaming/cudf/owning_wrapper.hpp>" nogil:
+    cdef cppclass cpp_OwningWrapper "rapidsmpf::streaming::OwningWrapper":
+        cpp_OwningWrapper(void *, void(*)(void*)) noexcept
+        void* release() noexcept
+
+
+cdef class ArbitraryChunk:
+    cdef unique_ptr[cpp_OwningWrapper] _handle
+
+    @staticmethod
+    cdef ArbitraryChunk from_handle(unique_ptr[cpp_OwningWrapper] handle)
+    cdef const cpp_OwningWrapper* handle_ptr(self)
+    cdef unique_ptr[cpp_OwningWrapper] release_handle(self)

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/arbitrary.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/arbitrary.pyi
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Generic, Self, TypeVar
+
+from rapidsmpf.streaming.core.message import Message, Payload
+
+T = TypeVar("T")
+
+class ArbitraryChunk(Generic[T]):
+    def __init__(self, obj: T) -> None: ...
+    def release(self) -> T: ...
+    @classmethod
+    def from_message(cls: type[Self], message: Message[Self]) -> Self: ...
+    def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...
+
+if TYPE_CHECKING:
+    # Check that ArbitraryChunk implements Payload.
+    t1: ArbitraryChunk
+    t2: Payload = t1

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/arbitrary.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/arbitrary.pyx
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from cpython.object cimport PyObject
+from cpython.ref cimport Py_DECREF, Py_INCREF
+from cython.operator cimport dereference as deref
+from libc.stdint cimport uint64_t
+from libcpp.memory cimport make_unique, unique_ptr
+from libcpp.utility cimport move
+
+from rapidsmpf.streaming.chunks.utils cimport py_deleter
+from rapidsmpf.streaming.core.message cimport Message, cpp_Message
+
+
+cdef extern from * nogil:
+    """
+    namespace {
+    rapidsmpf::streaming::Message cpp_to_message(
+        std::uint64_t sequence_number,
+        std::unique_ptr<rapidsmpf::streaming::OwningWrapper> obj
+    ) {
+        return rapidsmpf::streaming::Message(sequence_number, std::move(obj));
+    }
+    }
+    """
+    cpp_Message cpp_to_message"cpp_to_message"(
+        uint64_t, unique_ptr[cpp_OwningWrapper]
+    ) except +
+
+
+cdef class ArbitraryChunk:
+    """
+    A chunk containing an arbitrary Python object as a payload.
+
+    Parameters
+    ----------
+    obj
+        The payload object.
+
+    Notes
+    -----
+    To extract the object from the chunk, use :meth:`release`. The object
+    is stored in a unique pointer with a custom deleter, so it is safe to
+    drop the chunk in C++: deallocation will acquire the gil and decref the
+    stored object.
+    """
+    def __init__(self, object obj):
+        Py_INCREF(obj)
+        self._handle = make_unique[cpp_OwningWrapper](
+            <void *><PyObject *>obj, py_deleter
+        )
+
+    @classmethod
+    def __class_getitem__(cls, args):
+        return cls
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()
+
+    @staticmethod
+    cdef ArbitraryChunk from_handle(unique_ptr[cpp_OwningWrapper] handle):
+        """
+        Construct an ArbitraryChunk from an existing C++ handle.
+
+        Parameters
+        ----------
+        handle
+            A unique pointer to a C++ OwningWrapper.
+
+        Returns
+        -------
+        A new ArbitraryChunk wrapping the given handle.
+        """
+
+        cdef ArbitraryChunk ret = ArbitraryChunk.__new__(ArbitraryChunk)
+        ret._handle = move(handle)
+        return ret
+
+    def release(self):
+        cdef unique_ptr[cpp_OwningWrapper] obj = self.release_handle()
+        cdef object pyobj = <object><PyObject *>(deref(obj).release())
+        # Cast to object increfs, so we must decref here
+        Py_DECREF(pyobj)
+        return pyobj
+
+    @staticmethod
+    def from_message(Message message not None):
+        """
+        Construct an ArbitraryChunk by consuming a Message.
+
+        Parameters
+        ----------
+        message
+            Message containing an ArbitraryChunk. The message is released
+            and is empty after this call.
+
+        Returns
+        -------
+        A new ArbitraryChunk extracted from the given message.
+        """
+        return ArbitraryChunk.from_handle(
+            make_unique[cpp_OwningWrapper](
+                message._handle.release[cpp_OwningWrapper]()
+            )
+        )
+
+    def into_message(self, uint64_t sequence_number, Message message not None):
+        """
+        Move this ArbitraryChunk into a Message.
+
+        This method is not typically called directly. Instead, it is invoked by
+        `Message.__init__()` when creating a new Message with this ArbitraryChunk
+        as its payload.
+
+        Parameters
+        ----------
+        sequence_number
+            Ordering identifier for the message.
+        message
+            Message object that will take ownership of this ArbitraryChunk.
+
+        Raises
+        ------
+        ValueError
+            If the provided message is not empty.
+
+        Warnings
+        --------
+        The ArbitraryChunk is released and must not be used after this call.
+        """
+        if not message.empty():
+            raise ValueError("cannot move into a non-empty message")
+        message._handle = cpp_to_message(
+            sequence_number, move(self.release_handle())
+        )
+
+    cdef const cpp_OwningWrapper* handle_ptr(self):
+        """
+        Return a pointer to the underlying C++ OwningWrapper.
+
+        Returns
+        -------
+        Raw pointer to the underlying C++ object.
+
+        Raises
+        ------
+        ValueError
+            If the ArbitraryChunk is uninitialized.
+        """
+        if not self._handle:
+            raise ValueError("is uninitialized, has it been released?")
+        return self._handle.get()
+
+    cdef unique_ptr[cpp_OwningWrapper] release_handle(self):
+        """
+        Release ownership of the underlying C++ OwningWrapper.
+
+        After this call, the current object is in a moved-from state and
+        must not be accessed.
+
+        Returns
+        -------
+        Unique pointer to the underlying C++ object.
+
+        Raises
+        ------
+        ValueError
+            If the OwningWrapperChunk is uninitialized.
+        """
+        if not self._handle:
+            raise ValueError("is uninitialized, has it been released?")
+        return move(self._handle)

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/utils.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/utils.pxd
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+cdef void py_deleter(void *p) noexcept nogil

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/utils.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/utils.pyx
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from cpython.object cimport PyObject
+from cpython.ref cimport Py_XDECREF
+
+
+cdef void py_deleter(void *p) noexcept nogil:
+    with gil:
+        Py_XDECREF(<PyObject*>p)

--- a/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from cpython.object cimport PyObject
-from cpython.ref cimport Py_XDECREF
 from cython.operator cimport dereference as deref
 from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t
@@ -12,6 +11,7 @@ from pylibcudf.column cimport Column
 from pylibcudf.libcudf.table.table_view cimport table_view as cpp_table_view
 from pylibcudf.table cimport Table
 
+from rapidsmpf.streaming.chunks.utils cimport py_deleter
 from rapidsmpf.streaming.core.message cimport Message, cpp_Message
 
 
@@ -61,12 +61,6 @@ cdef extern from *:
         cpp_release_table_chunk_from_message(cpp_Message) except +
 
     unique_ptr[cpp_TableChunk] cpp_from_table_view_with_owner(...) except +
-
-
-cdef void py_deleter(void *p) noexcept nogil:
-    if p != NULL:
-        with gil:
-            Py_XDECREF(<PyObject*>p)
 
 
 cdef class TableChunk:

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_arbitrary_chunk.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_arbitrary_chunk.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import weakref
+from typing import TYPE_CHECKING
+
+from rapidsmpf.streaming.chunks.arbitrary import ArbitraryChunk
+from rapidsmpf.streaming.core.channel import Channel
+from rapidsmpf.streaming.core.leaf_node import pull_from_channel, push_to_channel
+from rapidsmpf.streaming.core.message import Message
+from rapidsmpf.streaming.core.node import define_py_node, run_streaming_pipeline
+
+if TYPE_CHECKING:
+    from concurrent.futures import ThreadPoolExecutor
+    from typing import Any
+
+    from rapidsmpf.streaming.core.context import Context
+    from rapidsmpf.streaming.core.node import CppNode, PyNode
+
+
+class Object:
+    def __init__(self, value: Any):
+        self.value = value
+
+
+def test_roundtrip_chunk(context: Context) -> None:
+    expect = Object(10)
+
+    got = ArbitraryChunk(expect).release()
+
+    assert got is expect
+
+
+def test_roundtrip_message() -> None:
+    expect = Object(10)
+
+    got = ArbitraryChunk.from_message(Message(1, ArbitraryChunk(expect))).release()
+
+    assert got is expect
+
+
+def test_gc_in_chunk() -> None:
+    obj = Object(10)
+
+    finalizer = weakref.finalize(obj, lambda: None)
+
+    assert finalizer.alive
+
+    chunk = ArbitraryChunk(obj)
+    del obj
+    assert finalizer.alive
+    del chunk
+    assert not finalizer.alive
+
+
+def test_gc_in_message() -> None:
+    obj = Object(10)
+
+    finalizer = weakref.finalize(obj, lambda: None)
+
+    assert finalizer.alive
+
+    chunk = ArbitraryChunk(obj)
+    del obj
+    assert finalizer.alive
+    message = Message(1, chunk)
+    del chunk
+    assert finalizer.alive
+    del message
+    assert not finalizer.alive
+
+
+def test_gc_after_message_release() -> None:
+    obj = Object(10)
+
+    finalizer = weakref.finalize(obj, lambda: None)
+
+    assert finalizer.alive
+
+    chunk = ArbitraryChunk(obj)
+    del obj
+    assert finalizer.alive
+    message = Message(1, chunk)
+    del chunk
+    assert finalizer.alive
+    chunk = ArbitraryChunk.from_message(message)
+    del message
+    assert finalizer.alive
+    del chunk
+    assert not finalizer.alive
+
+
+def test_gc_after_chunk_release() -> None:
+    obj = Object(10)
+    addr = id(obj)
+    finalizer = weakref.finalize(obj, lambda: None)
+
+    assert finalizer.alive
+
+    chunk = ArbitraryChunk(obj)
+    del obj
+    assert finalizer.alive
+    message = Message(1, chunk)
+    del chunk
+    assert finalizer.alive
+    chunk = ArbitraryChunk.from_message(message)
+    del message
+    assert finalizer.alive
+    obj = chunk.release()
+    del chunk
+    assert finalizer.alive
+    assert id(obj) == addr
+    assert obj.value == 10
+    del obj
+    assert not finalizer.alive
+
+
+def test_with_channel(context: Context, py_executor: ThreadPoolExecutor) -> None:
+    ch_in = Channel[ArbitraryChunk[int]]()
+    ch_out = Channel[ArbitraryChunk[int]]()
+
+    inputs = [Message(seq, ArbitraryChunk(seq)) for seq in range(10)]
+
+    @define_py_node()
+    async def increment(
+        ctx: Context,
+        ch_in: Channel[ArbitraryChunk[int]],
+        ch_out: Channel[ArbitraryChunk[int]],
+    ) -> None:
+        while (msg := await ch_in.recv(ctx)) is not None:
+            value = ArbitraryChunk.from_message(msg).release()
+            assert value == msg.sequence_number
+
+            await ch_out.send(
+                ctx, Message(msg.sequence_number, ArbitraryChunk(value + 1))
+            )
+        await ch_out.drain(ctx)
+
+    nodes: list[CppNode | PyNode] = [
+        push_to_channel(context, ch_in, inputs),
+        increment(context, ch_in, ch_out),
+    ]
+    node, deferred_messages = pull_from_channel(context, ch_out)
+    nodes.append(node)
+
+    run_streaming_pipeline(nodes=nodes, py_executor=py_executor)
+
+    results = deferred_messages.release()
+    for seq, msg in enumerate(results):
+        value = ArbitraryChunk.from_message(msg).release()
+        assert isinstance(value, int)
+        assert value == msg.sequence_number + 1
+        assert seq == msg.sequence_number


### PR DESCRIPTION
Useful for sending type-erased PyObjects through channels.

This is an alternative to #584 (cc @rjzamora). It's slightly simpler because we just use the `OwningWrapper` directly, rather having a `TypeErasedChunk` C++ class.