### PR TITLE
Use a large stack size when running lineariser test

### DIFF
--- a/cpp/tests/streaming/test_lineariser.cpp
+++ b/cpp/tests/streaming/test_lineariser.cpp
@@ -34,7 +34,7 @@ class StreamingLineariser : public BaseStreamingFixture {
         pthread_attr_init(&old_attr);
         pthread_getattr_default_np(&old_attr);
 
-        // Install 100 MiB default stack for *new* threads created after this point
+        // Set a 64 MiB default stack size for new threads created after this point.
         pthread_attr_t attr;
         pthread_attr_init(&attr);
         constexpr std::size_t big = 1 << 26;


### PR DESCRIPTION
Even with https://github.com/rapidsai/rapidsmpf/pull/622, I sometimes get a stack overflow. This PR increases the stack size for the lineariser test.

