### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/rapidsai/rapidsmpf.git
 cd rapidsmpf
 
 # Choose a environment file that match your system.
-mamba env create --name rapidsmpf-dev --file conda/environments/all_cuda-130_arch-$(arch).yaml
+mamba env create --name rapidsmpf-dev --file conda/environments/all_cuda-130_arch-$(uname -m).yaml
 
 # Build
 ./build.sh


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.