### PR TITLE
Ensure messages are dropped by refcount through channel sends

### DIFF
--- a/python/rapidsmpf/rapidsmpf/streaming/core/channel.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/channel.pyx
@@ -4,6 +4,7 @@
 from libcpp.memory cimport shared_ptr
 from libcpp.utility cimport move
 
+from functools import partial
 from rapidsmpf.streaming.core.context cimport Context, cpp_Context
 from rapidsmpf.streaming.core.message cimport Message, cpp_Message
 from rapidsmpf.streaming.core.utilities cimport cython_invoke_python_function
@@ -133,10 +134,15 @@ cdef extern from * nogil:
         std::shared_ptr<rapidsmpf::streaming::Channel> channel,
         rapidsmpf::streaming::Message &msg_output,
         void (*py_invoker)(void*),
-        void *py_function
+        void *py_function_msg,
+        void *py_function_empty
     ) {
         msg_output = co_await channel->receive();
-        py_invoker(py_function);
+        if (msg_output.empty()) {
+            py_invoker(py_function_empty);
+        } else {
+            py_invoker(py_function_msg);
+        }
     }
     }  // namespace
 
@@ -145,12 +151,17 @@ cdef extern from * nogil:
         std::shared_ptr<rapidsmpf::streaming::Channel> channel,
         rapidsmpf::streaming::Message &msg_output,
         void (*py_invoker)(void*),
-        void *py_function
+        void *py_function_msg,
+        void *py_function_empty
     ) {
         RAPIDSMPF_EXPECTS(
             ctx->executor()->spawn(
                 _channel_recv_task(
-                    std::move(channel), msg_output, py_invoker, py_function
+                    std::move(channel),
+                    msg_output,
+                    py_invoker,
+                    py_function_msg,
+                    py_function_empty
                 )
             ),
             "could not spawn task on thread pool"
@@ -162,8 +173,10 @@ cdef extern from * nogil:
         shared_ptr[cpp_Channel] channel,
         cpp_Message &msg_output,
         void (*py_invoker)(void*),
-        void *py_function
+        void *py_function_msg,
+        void *py_function_empty
     )
+
 
 cdef class Channel:
     """
@@ -200,16 +213,14 @@ cdef class Channel:
         """
         loop = asyncio.get_running_loop()
         ret = loop.create_future()
-
-        def set_result():
-            loop.call_soon_threadsafe(ret.set_result, None)
+        callback = partial(loop.call_soon_threadsafe, partial(ret.set_result, None))
 
         with nogil:
             cpp_channel_drain(
                 ctx._handle,
                 self._handle,
                 cython_invoke_python_function,
-                <void *>set_result
+                <void *>callback
             )
         await ret
 
@@ -230,16 +241,14 @@ cdef class Channel:
         """
         loop = asyncio.get_running_loop()
         ret = loop.create_future()
-
-        def set_result():
-            loop.call_soon_threadsafe(ret.set_result, None)
+        callback = partial(loop.call_soon_threadsafe, partial(ret.set_result, None))
 
         with nogil:
             cpp_channel_shutdown(
                 ctx._handle,
                 self._handle,
                 cython_invoke_python_function,
-                <void *>set_result
+                <void *>callback
             )
         await ret
 
@@ -260,9 +269,7 @@ cdef class Channel:
         """
         loop = asyncio.get_running_loop()
         ret = loop.create_future()
-
-        def set_result():
-            loop.call_soon_threadsafe(ret.set_result, None)
+        callback = partial(loop.call_soon_threadsafe, partial(ret.set_result, None))
 
         with nogil:
             cpp_channel_send(
@@ -270,7 +277,7 @@ cdef class Channel:
                 self._handle,
                 move(msg._handle),
                 cython_invoke_python_function,
-                <void *>set_result
+                <void *>callback
             )
         await ret
 
@@ -291,25 +298,23 @@ cdef class Channel:
         loop = asyncio.get_running_loop()
         ret = loop.create_future()
 
-        cdef cpp_Message msg_output
+        cdef cpp_Message c_msg
+        cdef Message msg = Message.from_handle(move(c_msg))
 
-        def f():
-            if msg_output.empty():
-                return ret.set_result(None)
-
-            ret.set_result(
-                Message.from_handle(move(msg_output))
-            )
-
-        def set_result():
-            loop.call_soon_threadsafe(f)
+        callback_msg = partial(
+            loop.call_soon_threadsafe, partial(ret.set_result, msg)
+        )
+        callback_empty = partial(
+            loop.call_soon_threadsafe, partial(ret.set_result, None)
+        )
 
         with nogil:
             cpp_channel_recv(
                 ctx._handle,
                 self._handle,
-                msg_output,
+                msg._handle,
                 cython_invoke_python_function,
-                <void *>set_result
+                <void *>callback_msg,
+                <void *>callback_empty
             )
         return await ret

--- a/python/rapidsmpf/rapidsmpf/streaming/core/lineariser.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/lineariser.pyx
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
+from functools import partial
 from cython.operator cimport dereference as deref
 from libcpp.memory cimport make_shared, shared_ptr
 
@@ -98,15 +99,13 @@ cdef class Lineariser:
         """
         loop = asyncio.get_running_loop()
         ret = loop.create_future()
-
-        def set_result():
-            loop.call_soon_threadsafe(ret.set_result, None)
+        callback = partial(loop.call_soon_threadsafe, partial(ret.set_result, None))
 
         with nogil:
             cpp_lineariser_drain(
                 self._ctx._handle,
                 self._handle,
                 cython_invoke_python_function,
-                <void *>set_result
+                <void *>callback
             )
         await ret


### PR DESCRIPTION
The previous approach of defining local functions seems like it captures objects in a refcycle that is then only broken by the cyclic collector. This means that if we just sink messages without releasing their payload they might not get collected until the interpreter runs atexit teardown. If the destruction needs to deallocate device memory, the memory resource will already be gone leading to a segfault.

To fix this, use functools.partial to make the closures we pass to the C++ callbacks.