### PR TITLE
`AllGather` unregisters spill function in destructor

### DIFF
--- a/cpp/include/rapidsmpf/allgather/allgather.hpp
+++ b/cpp/include/rapidsmpf/allgather/allgather.hpp
@@ -544,7 +544,7 @@ class AllGather {
     detail::PostBox inserted_{};  ///< Postbox for chunks inserted by user/event loop
     detail::PostBox for_extraction_{};  ///< Postbox for chunks ready for user extraction
     ProgressThread::FunctionID function_id_{};  ///< Function ID in progress thread
-    SpillManager::SpillFunctionID spill_id_{};  ///< Function ID for spilling
+    SpillManager::SpillFunctionID spill_function_id_{};  ///< Function ID for spilling
     /// @brief Chunks being received from left neighbor
     std::vector<std::unique_ptr<detail::Chunk>> to_receive_{};
     /// @brief Fire-and-forget communication futures

--- a/cpp/src/allgather/allgather.cpp
+++ b/cpp/src/allgather/allgather.cpp
@@ -382,6 +382,7 @@ AllGather::~AllGather() {
     if (active_.load(std::memory_order_acquire)) {
         active_.store(false, std::memory_order_release);
         progress_thread_->remove_function(function_id_);
+        br_->spill_manager().remove_spill_function(spill_function_id_);
     }
 }
 
@@ -401,7 +402,7 @@ AllGather::AllGather(
       finish_counter_{comm_->nranks()},
       op_id_{op_id} {
     function_id_ = progress_thread_->add_function([this]() { return event_loop(); });
-    spill_id_ = br_->spill_manager().add_spill_function(
+    spill_function_id_ = br_->spill_manager().add_spill_function(
         [this](std::size_t amount) -> std::size_t { return spill(amount); },
         /* priority = */ 0
     );


### PR DESCRIPTION
On creation, `AllGather` registers a spill function, which it never unregisters. Fixed.
