### PR TITLE
`Context`: use shared pointer for buffer resource

### DIFF
--- a/cpp/benchmarks/streaming/bench_streaming_shuffle.cpp
+++ b/cpp/benchmarks/streaming/bench_streaming_shuffle.cpp
@@ -304,7 +304,8 @@ int main(int argc, char** argv) {
     }
 
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref();
-    rapidsmpf::BufferResource br(mr, std::move(memory_available));
+    auto br =
+        std::make_shared<rapidsmpf::BufferResource>(mr, std::move(memory_available));
 
     auto& log = comm->logger();
     rmm::cuda_stream_view stream = cudf::get_default_stream();
@@ -332,7 +333,7 @@ int main(int argc, char** argv) {
     // We start with disabled statistics.
     auto stats = std::make_shared<rapidsmpf::Statistics>(/* enable = */ false);
 
-    auto ctx = std::make_shared<rapidsmpf::streaming::Context>(options, comm, &br, stats);
+    auto ctx = std::make_shared<rapidsmpf::streaming::Context>(options, comm, br, stats);
 
     std::vector<double> elapsed_vec;
     std::uint64_t const total_num_runs = args.num_warmups + args.num_runs;

--- a/cpp/include/rapidsmpf/streaming/core/context.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/context.hpp
@@ -40,7 +40,7 @@ class Context {
         std::shared_ptr<Communicator> comm,
         std::shared_ptr<ProgressThread> progress_thread,
         std::unique_ptr<coro::thread_pool> executor,
-        BufferResource* br,
+        std::shared_ptr<BufferResource> br,
         std::shared_ptr<Statistics> statistics
     );
 
@@ -57,7 +57,7 @@ class Context {
     Context(
         config::Options options,
         std::shared_ptr<Communicator> comm,
-        BufferResource* br,
+        std::shared_ptr<BufferResource> br,
         std::shared_ptr<Statistics> statistics = Statistics::disabled()
     );
 
@@ -115,7 +115,7 @@ class Context {
     std::shared_ptr<Communicator> comm_;
     std::shared_ptr<ProgressThread> progress_thread_;
     std::unique_ptr<coro::thread_pool> executor_;
-    BufferResource* br_;
+    std::shared_ptr<BufferResource> br_;
     std::shared_ptr<Statistics> statistics_;
 };
 

--- a/cpp/src/streaming/core/context.cpp
+++ b/cpp/src/streaming/core/context.cpp
@@ -15,7 +15,7 @@ Context::Context(
     std::shared_ptr<Communicator> comm,
     std::shared_ptr<ProgressThread> progress_thread,
     std::unique_ptr<coro::thread_pool> executor,
-    BufferResource* br,
+    std::shared_ptr<BufferResource> br,
     std::shared_ptr<Statistics> statistics
 )
     : options_{std::move(options)},
@@ -34,7 +34,7 @@ Context::Context(
 Context::Context(
     config::Options options,
     std::shared_ptr<Communicator> comm,
-    BufferResource* br,
+    std::shared_ptr<BufferResource> br,
     std::shared_ptr<Statistics> statistics
 )
     : Context(
@@ -80,7 +80,7 @@ std::unique_ptr<coro::thread_pool>& Context::executor() noexcept {
 }
 
 BufferResource* Context::br() const noexcept {
-    return br_;
+    return br_.get();
 }
 
 std::shared_ptr<Statistics> Context::statistics() const noexcept {

--- a/cpp/tests/streaming/base_streaming_fixture.hpp
+++ b/cpp/tests/streaming/base_streaming_fixture.hpp
@@ -39,14 +39,14 @@ class BaseStreamingFixture : public ::testing::Test {
         rapidsmpf::config::Options options(std::move(env_vars));
 
         stream = cudf::get_default_stream();
-        br = std::make_unique<rapidsmpf::BufferResource>(mr_cuda);
+        br = std::make_shared<rapidsmpf::BufferResource>(mr_cuda);
         ctx = std::make_shared<rapidsmpf::streaming::Context>(
-            std::move(options), GlobalEnvironment->comm_, br.get()
+            std::move(options), GlobalEnvironment->comm_, br
         );
     }
 
     rmm::cuda_stream_view stream;
     rmm::mr::cuda_memory_resource mr_cuda;
-    std::unique_ptr<rapidsmpf::BufferResource> br;
+    std::shared_ptr<rapidsmpf::BufferResource> br;
     std::shared_ptr<rapidsmpf::streaming::Context> ctx;
 };

--- a/python/rapidsmpf/rapidsmpf/streaming/core/context.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/context.pyx
@@ -4,7 +4,7 @@
 from cython.operator cimport dereference as deref
 from libcpp.utility cimport move
 
-from rapidsmpf.buffer.resource cimport BufferResource, cpp_BufferResource
+from rapidsmpf.buffer.resource cimport BufferResource
 from rapidsmpf.communicator.communicator cimport Communicator
 from rapidsmpf.config cimport Options
 from rapidsmpf.statistics cimport Statistics
@@ -42,7 +42,6 @@ cdef class Context:
     ):
         self._comm = comm
         self._br = br
-        cdef cpp_BufferResource* _br = br.ptr()
 
         self._options = options
         if self._options is None:
@@ -58,7 +57,7 @@ cdef class Context:
             self._handle = make_shared[cpp_Context](
                 self._options._handle,
                 self._comm._handle,
-                _br,
+                self._br._handle,
                 self._statistics._handle,
             )
 


### PR DESCRIPTION
To simplify buffer resource lifetime management in Python, `Context` now holds a `std::shared_ptr` to its buffer resource instead of a raw pointer.

Previously, in Python, a `cpp_Context` could outlive its associated `cpp_BufferResource` because the former was kept alive by a shared pointer on the C++ side, while the latter was only referenced as a raw pointer and was freed when the Python `BufferResource` wrapper went out of scope.
