### PR TITLE
Update RMM includes from `<rmm/mr/device/*>` to `<rmm/mr/*>`

### DIFF
--- a/cpp/benchmarks/bench_memory_resources.cpp
+++ b/cpp/benchmarks/bench_memory_resources.cpp
@@ -10,7 +10,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
 #include <rapidsmpf/buffer/pinned_memory_resource.hpp>

--- a/cpp/benchmarks/bench_partition.cpp
+++ b/cpp/benchmarks/bench_partition.cpp
@@ -14,8 +14,8 @@
 #include <cudf/types.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
 
 #include <rapidsmpf/integrations/cudf/partition.hpp>
 

--- a/cpp/benchmarks/utils/rmm_stack.hpp
+++ b/cpp/benchmarks/utils/rmm_stack.hpp
@@ -7,11 +7,11 @@
 #include <string>
 
 #include <cudf/utilities/memory_resource.hpp>
-#include <rmm/mr/device/cuda_async_memory_resource.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/managed_memory_resource.hpp>
-#include <rmm/mr/device/owning_wrapper.hpp>
-#include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/managed_memory_resource.hpp>
+#include <rmm/mr/owning_wrapper.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
 
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/rmm_resource_adaptor.hpp>

--- a/cpp/include/rapidsmpf/rmm_resource_adaptor.hpp
+++ b/cpp/include/rapidsmpf/rmm_resource_adaptor.hpp
@@ -16,7 +16,7 @@
 #include <unordered_set>
 
 #include <rmm/error.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 namespace rapidsmpf {

--- a/cpp/tests/streaming/base_streaming_fixture.hpp
+++ b/cpp/tests/streaming/base_streaming_fixture.hpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <cudf/utilities/default_stream.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/buffer/buffer.hpp>
 #include <rapidsmpf/communicator/single.hpp>

--- a/cpp/tests/streaming/test_read_parquet.cpp
+++ b/cpp/tests/streaming/test_read_parquet.cpp
@@ -30,7 +30,7 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 
 #include <rapidsmpf/allgather/allgather.hpp>
 #include <rapidsmpf/buffer/packed_data.hpp>

--- a/cpp/tests/streaming/test_table_chunk.cpp
+++ b/cpp/tests/streaming/test_table_chunk.cpp
@@ -15,7 +15,7 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 
 #include <rapidsmpf/owning_wrapper.hpp>
 #include <rapidsmpf/streaming/core/channel.hpp>

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -13,8 +13,8 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/debug_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
-#include <rmm/mr/device/limiting_resource_adaptor.hpp>
-#include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/limiting_resource_adaptor.hpp>
+#include <rmm/mr/owning_wrapper.hpp>
 
 #include <rapidsmpf/buffer/buffer.hpp>
 #include <rapidsmpf/buffer/resource.hpp>

--- a/cpp/tests/test_communicator.cpp
+++ b/cpp/tests/test_communicator.cpp
@@ -6,8 +6,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <rapidsmpf/buffer/buffer.hpp>

--- a/cpp/tests/test_metadata_payload_exchange.cpp
+++ b/cpp/tests/test_metadata_payload_exchange.cpp
@@ -6,8 +6,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <rapidsmpf/buffer/buffer.hpp>

--- a/cpp/tests/test_pinned_resources.cpp
+++ b/cpp/tests/test_pinned_resources.cpp
@@ -14,7 +14,7 @@
 #include <rmm/cuda_stream_pool.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/cuda_async_memory_resource.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <rapidsmpf/buffer/pinned_memory_resource.hpp>

--- a/cpp/tests/test_rmm_resource_adaptor.cpp
+++ b/cpp/tests/test_rmm_resource_adaptor.cpp
@@ -14,7 +14,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/rmm_resource_adaptor.hpp>

--- a/cpp/tests/test_spill_manager.cpp
+++ b/cpp/tests/test_spill_manager.cpp
@@ -10,8 +10,8 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/debug_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
-#include <rmm/mr/device/limiting_resource_adaptor.hpp>
-#include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/limiting_resource_adaptor.hpp>
+#include <rmm/mr/owning_wrapper.hpp>
 
 #include <rapidsmpf/buffer/buffer.hpp>
 #include <rapidsmpf/buffer/resource.hpp>


### PR DESCRIPTION
This updates RMM memory resource includes to use the header path `<rmm/mr/*>` instead of `<rmm/mr/device/*>`.

xref: https://github.com/rapidsai/rmm/issues/2141
