### PR TITLE
Don't build pip devcontainer

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -163,6 +163,7 @@ jobs:
     with:
       arch: '["amd64", "arm64"]'
       cuda: '["13.0"]'
+      python_package_manager: '["conda"]'
       node_type: "cpu8"
       rapids-aux-secret-1: GIST_REPO_READ_ORG_GITHUB_TOKEN
       env: |


### PR DESCRIPTION
This build has never worked to produce usable C++ libraries because it depends on explicitly linking to all transitive link dependencies.

We previously didn't notice because none of the C++ examples/tests are run, but anything that depends on libcudf transitively depends on libkvikio, and the latter is not in rpath in the pip setup. We don't explicitly find_package/link against kvikio because rapidsmpf doesn't depend on it, and I am unwilling to do that to satisfy the vagaries of this setup.

There doesn't seem to be a way to avoid this without some omniscient knowledge of all the transitive link dependencies of all libraries we depend on. We don't have that, so let's just not bother building things.

The conda devcontainers should hopefully pick up any issues.