### PR TITLE
Fix images

### DIFF
--- a/docs/source/background/channels.md
+++ b/docs/source/background/channels.md
@@ -3,8 +3,15 @@
 
 Channels are asynchronous messaging queue used to move messages between {term}`Node`s in the rapidsmpf streaming network.
 
-<img src="../_static/animation-legend.png" alt="Animation Legend" style="width: 320px;"/>
-<img src="../_static/buffers-animated.gif" alt="Animated buffer pipeline" style="max-width: 4500px;"/>
+```{image} ../_static/animation-legend.png
+:width: 320px
+:alt: Animation Legend
+```
+
+```{image} ../_static/buffers-animated.gif
+:width: 4500px
+:alt: Animated buffer pipeline
+```
 
 <br/>
 As buffers move through the graph, the channels (arrows) move from empty (dashed line) to full (solid line).


### PR DESCRIPTION
PR fixes missing images in https://docs.rapids.ai/api/rapidsmpf/nightly/background/channels/ .  I think something odd is happening with rendering where _static is moved to _images.  Using raw html seems to fail here.  Using markdown isn't a clean option as we need to fiddle with the size of the images for proper layout.  Thus, we use rst (inside markdown) for proper rendering, linking, and layout.

Note: this should be part of the upcoming 25.12 release