### PR TITLE
Disable sccache for clang-tidy builds

### DIFF
--- a/ci/cpp_linters.sh
+++ b/ci/cpp_linters.sh
@@ -19,7 +19,8 @@ set +u
 conda activate clang_tidy
 set -u
 
-source rapids-configure-sccache
+# Disable sccache for clang-tidy to prevent build errors with libcudf and librmm.
+# source rapids-configure-sccache
 
 # Run the build via CMake, which will run clang-tidy when RAPIDSMPF_CLANG_TIDY is enabled.
 cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release -DRAPIDSMPF_CLANG_TIDY=ON -DCMAKE_CUDA_ARCHITECTURES=75 -GNinja


### PR DESCRIPTION
Currently clang-tidy builds are failing when including libcudf and librmm, and this can be prevented disabling sccache, thus temporarily disable it.