### PR TITLE
Add rapids-generate-version

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,6 +11,8 @@ export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
 
+rapids-generate-version > ./VERSION
+
 rapids-logger "Begin py build"
 
 CPP_CHANNEL=$(rapids-download-conda-from-github cpp)


### PR DESCRIPTION
rapidsmpf Python conda packages were not pinning to the appropriate nightly version during builds. This fixes it.
