### PR TITLE
Add missing memory type parameters docs

### DIFF
--- a/cpp/include/rapidsmpf/memory/memory_type.hpp
+++ b/cpp/include/rapidsmpf/memory/memory_type.hpp
@@ -33,7 +33,13 @@ constexpr char const* to_string(MemoryType mem_type) {
     return MEMORY_TYPE_NAMES[static_cast<std::size_t>(mem_type)];
 }
 
-/// @brief Overload to write type name to the output stream.
+/**
+ * @brief Overload to write type name to the output stream.
+ *
+ * @param os The output stream.
+ * @param mem_type The memory type to write name of to the output stream.
+ * @return The output stream.
+ */
 inline std::ostream& operator<<(std::ostream& os, MemoryType mem_type) {
     return os << to_string(mem_type);
 }


### PR DESCRIPTION
Some parameters of MemoryType are not documented, causing failures with check-style.