### PR TITLE
Install OpenMPI explicitly in Python test matrix

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -425,6 +425,7 @@ dependencies:
           - myst-nb
           - myst-parser
           - numpydoc
+          - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
           - pydata-sphinx-theme>=0.15.4
           - sphinx>=8.1.0
           - sphinx-autobuild


### PR DESCRIPTION
After https://github.com/conda-forge/openmpi-feedstock/pull/211, CI picks `openmpi` packages with the `external_*` build prefix instead of the full OpenMPI package. This change adds explicit dependencies for `openmpi` package in `dependencies.yaml` to workaround that issue for now.