### PR TITLE
Enable merge barriers

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -7,3 +7,4 @@ label_checker: true
 release_drafter: false
 recently_updated: false
 forward_merger: true
+merge_barriers: true


### PR DESCRIPTION
Enable the `merge_barriers` setting in `.github/ops-bot.yaml` to enable the new merge barriers plugin.
