### PR TITLE
Install OpenMPI explicitly in CI matrices

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -303,6 +303,8 @@ dependencies:
       - output_types: conda
         packages:
           - gdb
+          - mpi4py
+          - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
       - output_types: [conda, pyproject, requirements]
         packages:
           - psutil  # Used for timeout_with_stack.py
@@ -423,6 +425,7 @@ dependencies:
           - myst-nb
           - myst-parser
           - numpydoc
+          - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
           - pydata-sphinx-theme>=0.15.4
           - sphinx>=8.1.0
           - sphinx-autobuild


### PR DESCRIPTION
Backport of #720 for the 25.12 release.

After https://github.com/conda-forge/openmpi-feedstock/pull/211, CI picks `openmpi` packages with the `external_*` build prefix instead of the full OpenMPI package. This change adds explicit dependencies for `openmpi` package in `dependencies.yaml` to workaround that issue for now.