### PR TITLE
Pin Ray<2.52

### DIFF
--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -47,7 +47,7 @@ dependencies:
 - pytest<9.0.0
 - python>=3.10,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
-- ray-default>=2.49
+- ray-default>=2.49,<2.52
 - rmm==26.2.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - sphinx-autobuild

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -47,7 +47,7 @@ dependencies:
 - pytest<9.0.0
 - python>=3.10,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
-- ray-default>=2.49
+- ray-default>=2.49,<2.52
 - rmm==26.2.*,>=0.0.0a0
 - scikit-build-core>=0.10.0
 - sphinx-autobuild

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -316,7 +316,7 @@ dependencies:
           - matrix:
               arch: x86_64
             packages:
-              - ray-default>=2.49
+              - ray-default>=2.49,<2.52
           - matrix:
               arch: aarch64
             packages:
@@ -436,7 +436,7 @@ dependencies:
           - matrix:
               arch: x86_64
             packages:
-              - ray-default>=2.49
+              - ray-default>=2.49,<2.52
           - matrix:
               arch: aarch64
             packages:


### PR DESCRIPTION
Some Ray tests have been non-deterministically segfaulting, the time the segfaults started coincided with the date when `ray=2.52` was release, therefore there's reason to believe it's a bug in that release. For now, pin `ray<2.52` to determine if that is in fact the source of the problem.

See https://github.com/rapidsai/rapidsmpf/pull/702 for previous discussion.