### PR TITLE
Force BUILD_TESTING flag for CTest

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -350,6 +350,12 @@ endif()
 # ##################################################################################################
 # * add tests -------------------------------------------------------------------------------------
 if(RAPIDSMPF_BUILD_TESTS)
+  # Set BUILD_TESTING to ON. It may be set to OFF by libcoro's CMake code and is needed for CTest to
+  # generate test lists.
+  set(BUILD_TESTING
+      ON
+      CACHE BOOL "Build the testing tree." FORCE
+  )
   include(CTest)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
Ensures BUILD_TESTING remains ON even if libcoro sets it to OFF, allowing CTest to generate test lists properly.

This is one fix needed to make `test-rapidsmpf-cpp` work in a unified pip devcontainer. There is another issue with MPI+CUDA tests that I am not investigating yet.