### PR TITLE
Revert "Add static library for `cudf_tests` (#733)"

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -42,70 +42,46 @@ endfunction(rapidsmpf_mpirun_test_add)
 # ${RAPIDSMPF_BINARY_DIR}/gtests) is created to seamlessly run ctest from ${RAPIDSMPF_BINARY_DIR}.
 file(CREATE_LINK "${RAPIDSMPF_BINARY_DIR}/gtests" "${CMAKE_CURRENT_BINARY_DIR}/gtests" SYMBOLIC)
 
-# Use a static library for test sources to avoid recompiling (especially cudf_tests) them for each
-# executable.
-add_library(test_sources STATIC)
-set_target_properties(
-  test_sources
-  PROPERTIES CXX_STANDARD 20
-             CXX_STANDARD_REQUIRED ON
-             # For std:: support of __int128_t. Can be removed once using cuda::std
-             CXX_EXTENSIONS ON
-             CUDA_STANDARD 20
-             CUDA_STANDARD_REQUIRED ON
-)
-target_include_directories(test_sources PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
-target_compile_options(
-  test_sources PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
-                       "$<$<COMPILE_LANGUAGE:CUDA>:${RAPIDSMPF_CUDA_FLAGS}>"
-)
-target_link_libraries(
-  test_sources
-  PRIVATE rapidsmpf::rapidsmpf cudf::cudftestutil cudf::cudftestutil_impl
-          $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa>
-  PUBLIC GTest::gmock GTest::gtest
-)
-disable_sign_conversion_warning(test_sources)
-
+add_library(test_sources INTERFACE)
 target_sources(
   test_sources
-  PRIVATE test_allgather.cpp
-          test_buffer_resource.cpp
-          test_chunk.cpp
-          test_communicator.cpp
-          test_config.cpp
-          test_cuda_stream.cpp
-          test_cudf_utils.cpp
-          test_cupti_monitor.cpp
-          test_error_macros.cpp
-          test_metadata_payload_exchange.cpp
-          test_partition.cpp
-          test_pausable_thread_loop.cpp
-          test_pinned_resources.cpp
-          test_progress_thread.cpp
-          test_rmm_resource_adaptor.cpp
-          test_shuffler_many_streams.cpp
-          test_shuffler.cpp
-          test_spill_manager.cpp
-          test_statistics.cpp
-          test_utils.cpp
+  INTERFACE test_allgather.cpp
+            test_buffer_resource.cpp
+            test_chunk.cpp
+            test_communicator.cpp
+            test_config.cpp
+            test_cuda_stream.cpp
+            test_cudf_utils.cpp
+            test_cupti_monitor.cpp
+            test_error_macros.cpp
+            test_metadata_payload_exchange.cpp
+            test_partition.cpp
+            test_pausable_thread_loop.cpp
+            test_pinned_resources.cpp
+            test_progress_thread.cpp
+            test_rmm_resource_adaptor.cpp
+            test_shuffler_many_streams.cpp
+            test_shuffler.cpp
+            test_spill_manager.cpp
+            test_statistics.cpp
+            test_utils.cpp
 )
 
 # if streaming is enabled, add the streaming test sources
 if(RAPIDSMPF_HAVE_STREAMING)
   target_sources(
     test_sources
-    PRIVATE streaming/test_allgather.cpp
-            streaming/test_error_handling.cpp
-            streaming/test_fanout.cpp
-            streaming/test_leaf_node.cpp
-            streaming/test_lineariser.cpp
-            streaming/test_message.cpp
-            streaming/test_partition.cpp
-            streaming/test_read_parquet.cpp
-            streaming/test_shuffler.cpp
-            streaming/test_spillable_messages.cpp
-            streaming/test_table_chunk.cpp
+    INTERFACE streaming/test_allgather.cpp
+              streaming/test_error_handling.cpp
+              streaming/test_fanout.cpp
+              streaming/test_leaf_node.cpp
+              streaming/test_lineariser.cpp
+              streaming/test_message.cpp
+              streaming/test_partition.cpp
+              streaming/test_read_parquet.cpp
+              streaming/test_shuffler.cpp
+              streaming/test_spillable_messages.cpp
+              streaming/test_table_chunk.cpp
   )
 endif()
 
@@ -130,6 +106,8 @@ if(RAPIDSMPF_HAVE_MPI)
   target_link_libraries(
     mpi_tests
     PRIVATE rapidsmpf::rapidsmpf
+            cudf::cudftestutil
+            cudf::cudftestutil_impl
             GTest::gmock
             GTest::gtest
             $<TARGET_NAME_IF_EXISTS:MPI::MPI_C>
@@ -163,6 +141,8 @@ if(RAPIDSMPF_HAVE_MPI)
     target_link_libraries(
       ucxx_tests
       PRIVATE rapidsmpf::rapidsmpf
+              cudf::cudftestutil
+              cudf::cudftestutil_impl
               GTest::gmock
               GTest::gtest
               ucxx::ucxx
@@ -222,8 +202,15 @@ target_compile_options(
 )
 target_link_libraries(
   single_tests
-  PRIVATE rapidsmpf::rapidsmpf GTest::gmock GTest::gtest $<TARGET_NAME_IF_EXISTS:conda_env>
-          $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa> maybe_asan test_sources
+  PRIVATE rapidsmpf::rapidsmpf
+          cudf::cudftestutil
+          cudf::cudftestutil_impl
+          GTest::gmock
+          GTest::gtest
+          $<TARGET_NAME_IF_EXISTS:conda_env>
+          $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa>
+          maybe_asan
+          test_sources
 )
 disable_sign_conversion_warning(single_tests)
 add_test(NAME single_tests COMMAND "gtests/single_tests")


### PR DESCRIPTION
After #733 some tests are not running anymore. Revert it for now to unblock CI.