### PR TITLE
q09: fix `cudf::transform()` call.

### DIFF
--- a/cpp/benchmarks/streaming/ndsh/q09.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q09.cpp
@@ -281,6 +281,7 @@ static __device__ void calculate_amount(double *amount, double discount, double 
                 false,
                 std::nullopt,
                 cudf::null_aware::NO,
+                cudf::output_nullability::PRESERVE,
                 chunk_stream,
                 ctx->br()->device_mr()
             )


### PR DESCRIPTION
`cudf::transform()` now takes a `null_policy` argument.