### PR TITLE
Fix finding of preexisting rapidsmpf build (for environments like devcontainers)

### DIFF
--- a/python/librapidsmpf/CMakeLists.txt
+++ b/python/librapidsmpf/CMakeLists.txt
@@ -13,7 +13,7 @@ rapids_cpm_init()
 include(rapids-cuda)
 include(rapids-find)
 
-rapids_cuda_init_architectures(librapidsmpf)
+rapids_cuda_init_architectures(librapidsmpf-python)
 
 project(
   librapidsmpf-python


### PR DESCRIPTION
Without this change build-librapidsmpf-python is rebuilding the C++ library.