### PR TITLE
[MINOR] Prevent overbooking overflow

### DIFF
--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -62,7 +62,7 @@ std::pair<MemoryReservation, std::size_t> BufferResource::reserve(
         - (static_cast<std::int64_t>(reserved) + static_cast<std::int64_t>(size));
     // If negative, we are overbooking.
     std::size_t overbooking =
-        headroom < 0 ? static_cast<std::size_t>(std::abs(headroom)) : 0;
+        headroom < 0 ? std::min(static_cast<std::size_t>(std::abs(headroom)), size) : 0;
     if (overbooking > 0 && !allow_overbooking) {
         // Cancel the reservation, overbooking isn't allowed.
         return {MemoryReservation(mem_type, this, 0), overbooking};


### PR DESCRIPTION
Currently, when memory is not available, the overbooking value it returns, is relative to the memory resource. ie. it tells how much of memory is overbooked in total in the memory resource. 
My intuition was, this should be relative to the size you request. ie. how much was overbooked out of the size. So, essentially overbooking should return `min(overbooking, size)`