### PR TITLE
Fix `non_device_size` calculation in unpack_and_concat

### DIFF
--- a/cpp/src/integrations/cudf/partition.cpp
+++ b/cpp/src/integrations/cudf/partition.cpp
@@ -168,9 +168,10 @@ std::unique_ptr<cudf::table> unpack_and_concat(
     size_t non_device_size = 0;
     for (auto& packed_data : partitions) {
         if (!packed_data.empty()) {
-            total_size += packed_data.data->size;
+            size_t size = packed_data.data->size;
+            total_size += size;
             if (packed_data.data->mem_type() != MemoryType::DEVICE) {
-                non_device_size += 0;
+                non_device_size += size;
             }
         }
     }


### PR DESCRIPTION
I believe this is intended to reflect the number of bytes not in device memory. We'll want to examine the other usage of `non_device_size` (in `br->reserve_device_memory_and_spill`) to ensure that we're OK with this change. IIUC, we'll end up reserving additional bytes equal to the number of bytes that were not in GPU memory.