### PR TITLE
Use the new `MemoryReserveOrWait` in the C++ queries

### DIFF
--- a/cpp/benchmarks/streaming/data_generator.hpp
+++ b/cpp/benchmarks/streaming/data_generator.hpp
@@ -1,10 +1,11 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
+#include <cstdint>
 
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
@@ -55,8 +56,10 @@ inline Node random_table_generator(
     ShutdownAtExit c{ch_out};
     co_await ctx->executor()->schedule();
     auto nbytes = static_cast<std::size_t>(ncolumns * nrows) * sizeof(std::int32_t);
+    auto device_memory = ctx->memory(MemoryType::DEVICE);
+    auto const net_memory_delta = static_cast<std::int64_t>(nbytes);
     for (std::uint64_t seq = 0; seq < num_blocks; ++seq) {
-        auto res = ctx->br()->reserve_device_memory_and_spill(nbytes, false);
+        auto res = device_memory->reserve_or_wait_or_fail(nbytes, net_memory_delta);
         co_await ch_out->send(to_message(
             seq,
             std::make_unique<TableChunk>(

--- a/cpp/benchmarks/streaming/ndsh/bench_read.cpp
+++ b/cpp/benchmarks/streaming/ndsh/bench_read.cpp
@@ -74,7 +74,7 @@ rapidsmpf::streaming::Node consume_channel_parallel(
                 break;
             }
             if (msg.holds<rapidsmpf::streaming::TableChunk>()) {
-                auto chunk = rapidsmpf::ndsh::to_device(
+                auto chunk = co_await rapidsmpf::ndsh::to_device(
                     ctx, msg.release<rapidsmpf::streaming::TableChunk>()
                 );
                 ctx->comm()->logger().print(

--- a/cpp/benchmarks/streaming/ndsh/concatenate.cpp
+++ b/cpp/benchmarks/streaming/ndsh/concatenate.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -66,7 +66,7 @@ streaming::Node concatenate(
         views.reserve(messages.size());
         for (auto&& msg : messages) {
             auto chunk = msg.release<streaming::TableChunk>();
-            chunk = to_device(ctx, std::move(chunk));
+            chunk = co_await to_device(ctx, std::move(chunk));
             cuda_stream_join(concat_stream, chunk.stream(), &event);
             views.push_back(chunk.table_view());
             chunks.push_back(std::move(chunk));

--- a/cpp/benchmarks/streaming/ndsh/groupby.cpp
+++ b/cpp/benchmarks/streaming/ndsh/groupby.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ streaming::Node chunkwise_group_by(
         if (msg.empty()) {
             break;
         }
-        auto chunk = to_device(ctx, msg.release<streaming::TableChunk>(), true);
+        auto chunk = co_await to_device(ctx, msg.release<streaming::TableChunk>());
         auto stream = chunk.stream();
         auto table = chunk.table_view();
         auto agg_requests = std::vector<cudf::groupby::aggregation_request>();

--- a/cpp/benchmarks/streaming/ndsh/join.cpp
+++ b/cpp/benchmarks/streaming/ndsh/join.cpp
@@ -57,7 +57,7 @@ coro::task<streaming::Message> broadcast(
             if (msg.empty()) {
                 break;
             }
-            auto chunk = to_device(ctx, msg.release<streaming::TableChunk>());
+            auto chunk = co_await to_device(ctx, msg.release<streaming::TableChunk>());
             cuda_stream_join(gather_stream, chunk.stream(), &event);
             views.push_back(chunk.table_view());
             chunks.push_back(std::move(chunk));
@@ -90,7 +90,7 @@ coro::task<streaming::Message> broadcast(
                 break;
             }
             // TODO: If this chunk is already in pack form, this is unnecessary.
-            auto chunk = to_device(ctx, msg.release<streaming::TableChunk>());
+            auto chunk = co_await to_device(ctx, msg.release<streaming::TableChunk>());
             auto pack =
                 cudf::pack(chunk.table_view(), chunk.stream(), ctx->br()->device_mr());
             auto packed_data = PackedData(
@@ -144,8 +144,8 @@ streaming::Node broadcast(
 /**
  * @brief Join a table chunk against a build hash table returning a message of the result.
  *
- * @param ctx Streaming context
- * @param right_chunk Chunk to join
+ * @param ctx Streaming context.
+ * @param right_chunk Chunk to join. Must be on device e.g. use to_device() on the chunk.
  * @param sequence Sequence number of the output
  * @param joiner hash_join object, representing the build table.
  * @param build_carrier Columns from the build-side table to be included in the output.
@@ -166,7 +166,6 @@ streaming::Message inner_join_chunk(
     CudaEvent* build_event
 ) {
     CudaEvent event;
-    right_chunk = to_device(ctx, std::move(right_chunk));
     auto chunk_stream = right_chunk.stream();
     build_event->stream_wait(chunk_stream);
     auto probe_table = right_chunk.table_view();
@@ -232,7 +231,7 @@ streaming::Node inner_join_broadcast(
     streaming::ShutdownAtExit c{left, right, ch_out};
     co_await ctx->executor()->schedule();
     ctx->comm()->logger().print("Inner broadcast join ", static_cast<int>(tag));
-    auto build_table = to_device(
+    auto build_table = co_await to_device(
         ctx,
         (co_await broadcast(ctx, left, tag, streaming::AllGather::Ordered::NO))
             .release<streaming::TableChunk>()
@@ -267,7 +266,7 @@ streaming::Node inner_join_broadcast(
         }
         co_await ch_out->send(inner_join_chunk(
             ctx,
-            right_msg.release<streaming::TableChunk>(),
+            co_await to_device(ctx, right_msg.release<streaming::TableChunk>()),
             right_msg.sequence_number(),
             joiner,
             build_carrier,
@@ -308,7 +307,8 @@ streaming::Node inner_join_shuffle(
             "Mismatching sequence numbers"
         );
         // TODO: currently always using left as build table.
-        auto build_chunk = to_device(ctx, left_msg.release<streaming::TableChunk>());
+        auto build_chunk =
+            co_await to_device(ctx, left_msg.release<streaming::TableChunk>());
         auto build_stream = build_chunk.stream();
         auto joiner = cudf::hash_join(
             build_chunk.table_view().select(left_on),
@@ -330,7 +330,7 @@ streaming::Node inner_join_shuffle(
         }
         co_await ch_out->send(inner_join_chunk(
             ctx,
-            right_msg.release<streaming::TableChunk>(),
+            co_await to_device(ctx, right_msg.release<streaming::TableChunk>()),
             left_msg.sequence_number(),
             joiner,
             build_carrier,
@@ -359,7 +359,7 @@ streaming::Node shuffle(
         if (msg.empty()) {
             break;
         }
-        auto chunk = to_device(ctx, msg.release<streaming::TableChunk>());
+        auto chunk = co_await to_device(ctx, msg.release<streaming::TableChunk>());
         auto packed = partition_and_pack(
             chunk.table_view(),
             keys,

--- a/cpp/benchmarks/streaming/ndsh/parquet_writer.cpp
+++ b/cpp/benchmarks/streaming/ndsh/parquet_writer.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -32,7 +32,7 @@ rapidsmpf::streaming::Node write_parquet(
     auto builder = cudf::io::chunked_parquet_writer_options::builder(sink);
     auto msg = co_await ch_in->receive();
     RAPIDSMPF_EXPECTS(!msg.empty(), "Writing from empty channel not supported");
-    auto chunk = to_device(ctx, msg.release<streaming::TableChunk>());
+    auto chunk = co_await to_device(ctx, msg.release<streaming::TableChunk>());
     auto table = chunk.table_view();
     auto metadata = cudf::io::table_input_metadata(table);
     CudaEvent event;
@@ -53,7 +53,7 @@ rapidsmpf::streaming::Node write_parquet(
         if (msg.empty()) {
             break;
         }
-        chunk = to_device(ctx, msg.release<streaming::TableChunk>());
+        chunk = co_await to_device(ctx, msg.release<streaming::TableChunk>());
         table = chunk.table_view();
         RAPIDSMPF_EXPECTS(
             static_cast<std::size_t>(table.num_columns()) == column_names.size(),

--- a/cpp/benchmarks/streaming/ndsh/q01.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q01.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -154,8 +154,9 @@ rapidsmpf::streaming::Node postprocess_group_by(
     RAPIDSMPF_EXPECTS(
         (co_await ch_in->receive()).empty(), "Expecting concatenated input at this point"
     );
-    auto chunk =
-        rapidsmpf::ndsh::to_device(ctx, msg.release<rapidsmpf::streaming::TableChunk>());
+    auto chunk = co_await rapidsmpf::ndsh::to_device(
+        ctx, msg.release<rapidsmpf::streaming::TableChunk>()
+    );
     auto stream = chunk.stream();
     auto columns =
         cudf::table{chunk.table_view(), stream, ctx->br()->device_mr()}.release();
@@ -217,7 +218,7 @@ rapidsmpf::streaming::Node select_columns_for_groupby(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
         auto chunk_stream = chunk.stream();

--- a/cpp/benchmarks/streaming/ndsh/q03.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q03.cpp
@@ -259,7 +259,7 @@ rapidsmpf::streaming::Node select_columns_for_groupby(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
         auto chunk_stream = chunk.stream();
@@ -340,7 +340,7 @@ rapidsmpf::streaming::Node top_k_by(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
         auto const indices = cudf::sorted_order(
@@ -405,7 +405,7 @@ rapidsmpf::streaming::Node fanout_bounded(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
         // Here, we know that copying ch1_cols (a single col) is better than copying

--- a/cpp/benchmarks/streaming/ndsh/q09.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q09.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -174,7 +174,7 @@ rapidsmpf::streaming::Node filter_part(
             break;
         }
         co_await ctx->executor()->schedule();
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
         auto chunk_stream = chunk.stream();
@@ -216,7 +216,7 @@ rapidsmpf::streaming::Node select_columns(
             break;
         }
         co_await ctx->executor()->schedule();
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
         auto chunk_stream = chunk.stream();
@@ -292,8 +292,9 @@ rapidsmpf::streaming::Node round_sum_profit(
     RAPIDSMPF_EXPECTS(!msg.empty(), "Expecting to see a single chunk");
     auto next = co_await ch_in->receive();
     RAPIDSMPF_EXPECTS(next.empty(), "Not expecting to see a second chunk");
-    auto chunk =
-        rapidsmpf::ndsh::to_device(ctx, msg.release<rapidsmpf::streaming::TableChunk>());
+    auto chunk = co_await rapidsmpf::ndsh::to_device(
+        ctx, msg.release<rapidsmpf::streaming::TableChunk>()
+    );
     auto table = chunk.table_view();
     auto rounded = cudf::round(
         table.column(2),

--- a/cpp/benchmarks/streaming/ndsh/q21.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q21.cpp
@@ -237,7 +237,7 @@ rapidsmpf::streaming::Node filter_lineitem(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
 
@@ -280,7 +280,7 @@ rapidsmpf::streaming::Node filter_grouped_greater(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
 
@@ -325,7 +325,7 @@ rapidsmpf::streaming::Node filter_grouped_equal(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
 
@@ -372,7 +372,7 @@ rapidsmpf::streaming::Node fanout_bounded(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
         // Here, we know that copying ch1_cols (a single col) is better than copying
@@ -435,7 +435,7 @@ rapidsmpf::streaming::Node slice(
         if (msg.empty()) {
             break;
         }
-        auto chunk = rapidsmpf::ndsh::to_device(
+        auto chunk = co_await rapidsmpf::ndsh::to_device(
             ctx, msg.release<rapidsmpf::streaming::TableChunk>()
         );
 
@@ -539,7 +539,7 @@ std::vector<rapidsmpf::ndsh::groupby_request> sum_groupby_request(
             if (msg.empty()) {
                 break;
             }
-            auto chunk = rapidsmpf::ndsh::to_device(
+            auto chunk = co_await rapidsmpf::ndsh::to_device(
                 ctx, msg.release<rapidsmpf::streaming::TableChunk>()
             );
             auto stream = chunk.stream();

--- a/cpp/benchmarks/streaming/ndsh/sort.cpp
+++ b/cpp/benchmarks/streaming/ndsh/sort.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -56,7 +56,7 @@ rapidsmpf::streaming::Node chunkwise_sort_by(
         if (msg.empty()) {
             break;
         }
-        auto chunk = to_device(ctx, msg.release<streaming::TableChunk>());
+        auto chunk = co_await to_device(ctx, msg.release<streaming::TableChunk>());
         co_await ch_out->send(to_message(
             msg.sequence_number(),
             std::make_unique<streaming::TableChunk>(make_table(chunk), chunk.stream())

--- a/cpp/benchmarks/streaming/ndsh/utils.hpp
+++ b/cpp/benchmarks/streaming/ndsh/utils.hpp
@@ -67,11 +67,10 @@ namespace detail {
  *
  * @param ctx Streaming context
  * @param ch Channel to consume messages from.
+ * @return Coroutine representing consuming and discarding messages in channel.
  *
  * @note If the channel contains `TableChunk`s, moves them to device and prints small
  * amount of detail about them (row and column count).
- *
- * @return Coroutine representing consuming and discarding messages in channel.
  */
 [[nodiscard]] streaming::Node consume_channel(
     std::shared_ptr<streaming::Context> ctx, std::shared_ptr<streaming::Channel> ch_in
@@ -82,16 +81,13 @@ namespace detail {
  *
  * @param ctx Streaming context
  * @param chunk Chunk to move from device, is left in a moved-from state
- * @param allow_overbooking Whether reserving memory is allowed to overbook
- *
  * @return New `TableChunk` on device
+ *
  * @throws std::overflow_error if overbooking is not allowed and not enough memory is
  * available to reserve.
  */
-[[nodiscard]] streaming::TableChunk to_device(
-    std::shared_ptr<streaming::Context> ctx,
-    streaming::TableChunk&& chunk,
-    bool allow_overbooking = false
+[[nodiscard]] coro::task<streaming::TableChunk> to_device(
+    std::shared_ptr<streaming::Context> ctx, streaming::TableChunk&& chunk
 );
 
 ///< @brief Communicator type to use

--- a/cpp/include/rapidsmpf/communicator/communicator.hpp
+++ b/cpp/include/rapidsmpf/communicator/communicator.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -16,8 +16,7 @@
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/memory/buffer.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
-
-#include "rapidsmpf/utils.hpp"
+#include <rapidsmpf/utils.hpp>
 
 /**
  * @namespace rapidsmpf

--- a/cpp/include/rapidsmpf/streaming/cudf/table_chunk.hpp
+++ b/cpp/include/rapidsmpf/streaming/cudf/table_chunk.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -169,10 +169,25 @@ class TableChunk {
      * @param reservation Memory reservation for allocations if needed.
      * @return A new TableChunk with data available on device.
      *
-     * @note After this call, the current object is in a moved-from state;
-     *       only reassignment, movement, or destruction are valid.
+     * @note After this call, the current object is in a moved-from state; only
+     * reassignment, movement, or destruction are valid.
      */
     [[nodiscard]] TableChunk make_available(MemoryReservation& reservation);
+
+    /**
+     * @brief Moves this table chunk into a new one with its cudf table made available.
+     *
+     * Takes ownership of the memory reservation and consumes it entirely as part
+     * of making the data available on device. The full reservation is considered
+     * used, even if the actual allocation requires fewer bytes.
+     *
+     * @param reservation Memory reservation to be consumed for allocations.
+     * @return A new TableChunk with data available on device.
+     *
+     * @note After this call, the current object is in a moved-from state; only
+     * reassignment, movement, or destruction are valid.
+     */
+    [[nodiscard]] TableChunk make_available(MemoryReservation&& reservation);
 
     /**
      * @brief Returns a view of the underlying table.

--- a/cpp/src/streaming/cudf/table_chunk.cpp
+++ b/cpp/src/streaming/cudf/table_chunk.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -104,6 +104,11 @@ TableChunk TableChunk::make_available(MemoryReservation& reservation) {
         ),
         stream
     };
+}
+
+TableChunk TableChunk::make_available(MemoryReservation&& reservation) {
+    MemoryReservation& res = reservation;
+    return make_available(res);
 }
 
 cudf::table_view TableChunk::table_view() const {

--- a/cpp/tests/streaming/test_table_chunk.cpp
+++ b/cpp/tests/streaming/test_table_chunk.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -370,8 +370,9 @@ TEST_F(StreamingTableChunk, ToMessageRoundTrip) {
     // Copy the chunk back to device and verify.
     {
         auto chunk = m3.release<TableChunk>();
-        auto res = br->reserve_or_fail(chunk.make_available_cost(), MemoryType::DEVICE);
-        chunk = chunk.make_available(res);
+        chunk = chunk.make_available(
+            br->reserve_or_fail(chunk.make_available_cost(), MemoryType::DEVICE)
+        );
         CUDF_TEST_EXPECT_TABLES_EQUIVALENT(chunk.table_view(), expect);
     }
 


### PR DESCRIPTION
Use `MemoryReserveOrWait::reserve_or_wait_or_fail()` instead of `BufferResource::reserve_or_fail()`.