### PR TITLE
Address RMM setup in ``bootstrap_dask_cluster``

### DIFF
--- a/python/rapidsmpf/rapidsmpf/integrations/core.py
+++ b/python/rapidsmpf/rapidsmpf/integrations/core.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """Shuffler integration with external libraries."""
 
@@ -670,6 +670,128 @@ def spill_func(
     return ctx.spill_collection.spill(amount, stream=DEFAULT_STREAM, device_mr=mr)
 
 
+def setup_rmm_pool(
+    option_prefix: str,
+    options: Options,
+    worker: Any = None,
+) -> rmm.mr.DeviceMemoryResource:
+    """
+    Set up an RMM memory pool based on configuration options.
+
+    This function mirrors the logic in dask-cuda's RMMSetup plugin to ensure
+    consistent behavior when rapidsmpf manages RMM instead of Dask or another
+    orchestrator.
+
+    Parameters
+    ----------
+    option_prefix
+        Prefix for config-option names (e.g., "dask_").
+    options
+        Configuration options.
+    worker
+        Optional worker reference (for logging filenames).
+
+    Returns
+    -------
+    The configured RMM memory resource, or the current device resource
+    if no RMM options are specified.
+
+    Notes
+    -----
+    If no RMM configuration options are provided, this function returns
+    the current device resource without modification.
+    """
+    # Parse RMM configuration options
+    # Note: Use Optional(None) as default for byte-size options. OptionalBytes can't
+    # be used because it calls parse_bytes() before checking for disabled keywords.
+    # When the user provides a value, we parse it with OptionalBytes.
+    initial_pool_size_opt = options.get_or_default(
+        f"{option_prefix}rmm_pool_size", default_value=Optional(None)
+    ).value
+    initial_pool_size = (
+        OptionalBytes(initial_pool_size_opt).value
+        if initial_pool_size_opt is not None
+        else None
+    )
+    maximum_pool_size_opt = options.get_or_default(
+        f"{option_prefix}rmm_maximum_pool_size", default_value=Optional(None)
+    ).value
+    maximum_pool_size = (
+        OptionalBytes(maximum_pool_size_opt).value
+        if maximum_pool_size_opt is not None
+        else None
+    )
+    managed_memory = options.get_or_default(
+        f"{option_prefix}rmm_managed_memory", default_value=False
+    )
+    async_alloc = options.get_or_default(
+        f"{option_prefix}rmm_async", default_value=False
+    )
+    release_threshold_opt = options.get_or_default(
+        f"{option_prefix}rmm_release_threshold", default_value=Optional(None)
+    ).value
+    release_threshold = (
+        OptionalBytes(release_threshold_opt).value
+        if release_threshold_opt is not None
+        else None
+    )
+    track_allocations = options.get_or_default(
+        f"{option_prefix}rmm_track_allocations", default_value=False
+    )
+
+    # If no RMM options specified, return current resource unchanged
+    if (
+        initial_pool_size is None
+        and not managed_memory
+        and not async_alloc
+        and not track_allocations
+    ):
+        return rmm.mr.get_current_device_resource()
+
+    # Validation (same as dask-cuda)
+    if async_alloc and managed_memory:
+        raise ValueError("`rmm_managed_memory` is incompatible with `rmm_async`.")
+    if not async_alloc and release_threshold is not None:
+        raise ValueError("`rmm_release_threshold` requires `rmm_async`.")
+
+    # Setup based on mode (mirrors dask-cuda's RMMSetup plugin)
+    if async_alloc:
+        # Async allocation path using CudaAsyncMemoryResource
+        mr = rmm.mr.CudaAsyncMemoryResource(
+            initial_pool_size=initial_pool_size or 0,
+            release_threshold=release_threshold or 0,
+        )
+        if maximum_pool_size is not None:
+            mr = rmm.mr.LimitingResourceAdaptor(mr, allocation_limit=maximum_pool_size)
+        rmm.mr.set_current_device_resource(mr)
+    elif initial_pool_size is not None or managed_memory:
+        # Pool/managed allocation path
+        # Choose the upstream memory resource
+        if managed_memory:
+            upstream_mr = rmm.mr.ManagedMemoryResource()
+        else:
+            upstream_mr = rmm.mr.CudaMemoryResource()
+
+        # Create pool if initial_pool_size is specified
+        if initial_pool_size is not None:
+            mr = rmm.mr.PoolMemoryResource(
+                upstream_mr=upstream_mr,
+                initial_pool_size=initial_pool_size,
+                maximum_pool_size=maximum_pool_size,
+            )
+        else:
+            # Only managed memory, no pool
+            mr = upstream_mr
+        rmm.mr.set_current_device_resource(mr)
+
+    # Optionally wrap with tracking adaptor
+    if track_allocations:
+        mr = rmm.mr.get_current_device_resource()
+        rmm.mr.set_current_device_resource(rmm.mr.TrackingResourceAdaptor(mr))
+
+    return rmm.mr.get_current_device_resource()
+
+
 def rmpf_worker_setup(
     worker: Any,
     option_prefix: str,
@@ -698,10 +820,13 @@ def rmpf_worker_setup(
 
     Warnings
     --------
-    This function creates a new RMM memory pool, and
-    sets it as the current device resource.
+    This function may create a new RMM memory pool (if configured),
+    and sets the RMM resource adaptor as the current device resource.
     """
-    # Insert RMM resource adaptor on top of the current RMM resource stack.
+    # Set up RMM pool if configured (otherwise uses existing resource)
+    setup_rmm_pool(option_prefix, options, worker)
+
+    # Insert RMM resource adaptor on top of the (now configured) RMM resource stack.
     mr = RmmResourceAdaptor(
         upstream_mr=rmm.mr.get_current_device_resource(),
         fallback_mr=(

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -19,7 +19,7 @@ from rapidsmpf.examples.dask import (
     dask_cudf_join,
     dask_cudf_shuffle,
 )
-from rapidsmpf.integrations.core import _parse_pool_size, setup_rmm_pool
+from rapidsmpf.integrations.core import setup_rmm_pool
 from rapidsmpf.integrations.dask.core import get_worker_context
 from rapidsmpf.integrations.dask.shuffler import (
     clear_shuffle_statistics,
@@ -208,30 +208,6 @@ def test_rmm_setup_validation_errors() -> None:
                 }
             ),
         )
-
-
-# Use a fixed total memory for deterministic tests
-_TOTAL_MEMORY = 16 * 1024 * 1024 * 1024  # 16 GiB
-
-
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        # None and zero return None
-        (None, None),
-        (0, None),
-        (0.0, None),
-        # Fractions (0 < value <= 1) are % of device memory
-        (0.5, 8 * 1024 * 1024 * 1024),  # 50% of 16 GiB = 8 GiB
-        (1.0, _TOTAL_MEMORY),  # 100% of device memory
-        # Values > 1 are byte counts (aligned to 256)
-        (1024 * 1024 * 1024, 1024 * 1024 * 1024),  # 1 GiB
-        (1000, 768),  # floor(1000 / 256) * 256
-    ],
-)
-def test_parse_pool_size(value: float | None, expected: int | None) -> None:
-    """Test _parse_pool_size with various inputs."""
-    assert _parse_pool_size(value, _TOTAL_MEMORY) == expected
 
 
 @pytest.mark.parametrize("partition_count", [None, 3])

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -9,6 +9,8 @@ import dask
 import dask.dataframe as dd
 import pytest
 
+import rmm.mr
+
 import rapidsmpf.integrations.single
 from rapidsmpf.communicator import COMMUNICATORS
 from rapidsmpf.config import Options
@@ -17,6 +19,7 @@ from rapidsmpf.examples.dask import (
     dask_cudf_join,
     dask_cudf_shuffle,
 )
+from rapidsmpf.integrations.core import setup_rmm_pool
 from rapidsmpf.integrations.dask.core import get_worker_context
 from rapidsmpf.integrations.dask.shuffler import (
     clear_shuffle_statistics,
@@ -77,6 +80,134 @@ async def test_dask_ucxx_cluster_sync() -> None:
 
         result = client.run(get_rank)
         assert set(result.values()) == set(range(len(cluster.workers)))
+
+
+def assert_workers_contain_mr_type(
+    client: Client, resource_type: type[rmm.mr.MemoryResource]
+) -> None:
+    """Assert that all workers contain the given resource type."""
+
+    def _has_rmm_resource_type() -> bool:
+        # The given resource type must be in the resource chain.
+        mr = rmm.mr.get_current_device_resource()
+        while mr is not None:
+            if isinstance(mr, resource_type):
+                return True
+            mr = getattr(mr, "upstream_mr", None)
+        return False
+
+    result = client.run(_has_rmm_resource_type)
+    for worker_addr, has_type in result.items():
+        assert has_type, (
+            f"Worker {worker_addr} does not have {resource_type.__name__} in chain."
+        )
+
+
+@gen_test(timeout=30)
+async def test_dask_rmm_setup_async() -> None:
+    """Test that rapidsmpf can set up RMM async pool during bootstrap."""
+    with (
+        LocalCUDACluster(
+            scheduler_port=0,
+            device_memory_limit=1,
+            # Don't let dask-cuda set up RMM - rapidsmpf will do it
+            rmm_pool_size=None,
+            rmm_async=False,
+        ) as cluster,
+        Client(cluster) as client,
+    ):
+        bootstrap_dask_cluster(
+            client,
+            options=Options(
+                {
+                    "dask_spill_device": "0.1",
+                    "dask_rmm_async": "true",
+                    "dask_rmm_pool_size": "128 MiB",
+                }
+            ),
+        )
+        assert_workers_contain_mr_type(client, rmm.mr.CudaAsyncMemoryResource)
+
+
+@gen_test(timeout=30)
+async def test_dask_rmm_setup_pool() -> None:
+    """Test that rapidsmpf can set up RMM pool (non-async) during bootstrap."""
+    with (
+        LocalCUDACluster(
+            scheduler_port=0,
+            device_memory_limit=1,
+            # Don't let dask-cuda set up RMM - rapidsmpf will do it
+            rmm_pool_size=None,
+            rmm_async=False,
+        ) as cluster,
+        Client(cluster) as client,
+    ):
+        bootstrap_dask_cluster(
+            client,
+            options=Options(
+                {
+                    "dask_spill_device": "0.1",
+                    "dask_rmm_async": "false",
+                    "dask_rmm_pool_size": "128 MiB",
+                }
+            ),
+        )
+
+        assert_workers_contain_mr_type(client, rmm.mr.PoolMemoryResource)
+
+
+@gen_test(timeout=30)
+async def test_dask_rmm_setup_track_allocations() -> None:
+    """Test that rapidsmpf can enable RMM tracking during bootstrap."""
+    with (
+        LocalCUDACluster(
+            scheduler_port=0,
+            device_memory_limit=1,
+            rmm_pool_size=None,
+            rmm_async=False,
+        ) as cluster,
+        Client(cluster) as client,
+    ):
+        bootstrap_dask_cluster(
+            client,
+            options=Options(
+                {
+                    "dask_spill_device": "0.1",
+                    "dask_rmm_track_allocations": "true",
+                }
+            ),
+        )
+
+        assert_workers_contain_mr_type(client, rmm.mr.TrackingResourceAdaptor)
+
+
+def test_rmm_setup_validation_errors() -> None:
+    """Test that invalid RMM option combinations raise errors."""
+
+    # rmm_managed_memory is incompatible with rmm_async
+    with pytest.raises(ValueError, match="incompatible"):
+        setup_rmm_pool(
+            "test_",
+            Options(
+                {
+                    "test_rmm_async": "true",
+                    "test_rmm_managed_memory": "true",
+                }
+            ),
+        )
+
+    # rmm_release_threshold requires rmm_async
+    with pytest.raises(ValueError, match="requires"):
+        setup_rmm_pool(
+            "test_",
+            Options(
+                {
+                    "test_rmm_async": "false",
+                    "test_rmm_pool_size": "128 MiB",
+                    "test_rmm_release_threshold": "64 MiB",
+                }
+            ),
+        )
 
 
 @pytest.mark.parametrize("partition_count", [None, 3])

--- a/python/rapidsmpf/rapidsmpf/tests/test_utils.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_utils.py
@@ -1,10 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import pytest
 
-from rapidsmpf.utils.string import format_bytes, parse_boolean, parse_bytes
+from rapidsmpf.utils.string import (
+    format_bytes,
+    parse_boolean,
+    parse_bytes,
+    parse_bytes_threshold,
+)
 
 
 def test_format_bytes() -> None:
@@ -41,3 +46,40 @@ def test_parse_boolean_false(input_str: str) -> None:
 def test_parse_boolean_invalid(invalid_str: str) -> None:
     with pytest.raises(ValueError, match="Cannot parse boolean"):
         parse_boolean(invalid_str)
+
+
+# Use a fixed total for deterministic tests
+_TOTAL = 16 * 1024 * 1024 * 1024  # 16 GiB
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # None and zero return None
+        (None, None),
+        (0, None),
+        (0.0, None),
+        # Fractions (0 < value <= 1) are % of total
+        (0.5, 8 * 1024 * 1024 * 1024),  # 50% of 16 GiB = 8 GiB
+        (1.0, _TOTAL),  # 100%
+        ("0.5", 8 * 1024 * 1024 * 1024),  # String fraction
+        # Values > 1 are byte counts
+        (1024 * 1024 * 1024, 1024 * 1024 * 1024),  # 1 GiB
+        ("1000000000", 1000000000),  # String byte count
+        # Byte strings (e.g., "12 GB", "128 MiB")
+        ("1 GiB", 1024 * 1024 * 1024),
+        ("12 GB", 12 * 1000 * 1000 * 1000),
+    ],
+)
+def test_parse_bytes_threshold(value: str | float | None, expected: int | None) -> None:
+    assert parse_bytes_threshold(value, _TOTAL) == expected
+
+
+def test_parse_bytes_threshold_alignment() -> None:
+    # Results should be aligned to the specified alignment
+    assert (
+        parse_bytes_threshold(1000, 1000, alignment=256) == 768
+    )  # floor(1000 / 256) * 256
+    assert (
+        parse_bytes_threshold(0.5, 1000, alignment=100) == 500
+    )  # 500 is divisible by 100

--- a/python/rapidsmpf/rapidsmpf/utils/string.py
+++ b/python/rapidsmpf/rapidsmpf/utils/string.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """Useful string utilities."""
 
@@ -116,6 +116,75 @@ def parse_bytes(s: str | int) -> int:
         raise ValueError(f"Unknown unit: '{unit}'")
 
     return int(number * unit_multipliers[unit])
+
+
+def parse_bytes_threshold(
+    threshold: str | float | None,
+    total: int,
+    *,
+    alignment: int = 1,
+) -> int | None:
+    """
+    Parse a threshold value that can be a fraction, byte count, or byte string.
+
+    Parameters
+    ----------
+    threshold
+        The threshold value. Can be:
+        - None: Returns None
+        - A float/string in (0, 1]: Interpreted as a fraction of `total`
+        - A float/string > 1: Interpreted as an absolute byte count
+        - A byte string like "12 GB" or "128 MiB": Parsed as bytes
+    total
+        The total size (e.g., total device memory) used to compute
+        fractional thresholds.
+    alignment
+        Byte alignment for the result.
+
+    Returns
+    -------
+    The parsed byte count aligned to `alignment`, or None.
+
+    Examples
+    --------
+    >>> parse_bytes_threshold(None, 1000)
+    >>> parse_bytes_threshold(0.5, 1000)
+    500
+    >>> parse_bytes_threshold("0.5", 1000)
+    500
+    >>> parse_bytes_threshold(100, 1000)
+    100
+    >>> parse_bytes_threshold("12 GB", 1000)
+    12000000000
+    >>> parse_bytes_threshold(100, 1000, alignment=256)
+    0
+    """
+    if threshold is None:
+        return None
+
+    # Try to parse as a byte string (e.g., "12 GB", "128 MiB")
+    try:
+        if (
+            isinstance(threshold, (str, int))
+            and (maybe_bytes := parse_bytes(threshold)) >= 1
+        ):
+            threshold = maybe_bytes
+    except (TypeError, ValueError):
+        pass
+
+    value = float(threshold)
+    if value == 0:
+        return None
+
+    if 0.0 < value <= 1.0:
+        # Fraction of total
+        byte_count = int(total * value)
+    else:
+        # Absolute byte count
+        byte_count = int(value)
+
+    # Align to alignment
+    return (byte_count // alignment) * alignment
 
 
 def parse_boolean(boolean: str) -> bool:


### PR DESCRIPTION
**Proposed Changes**:
- Adds a new `rapidsmpf.integrations.core.setup_rmm_pool` function to setup the RMM pool for a single "worker".
  - The logic is essentially copied from dask-cuda
  - **Motivation**: We do not want to rely on Dask/Dask-CUDA for this logic as we branch out to other deployment strategies.
- Adds a call to the new `setup_rmm_pool` function in `rapidsmpf.integrations.core.rmpf_worker_setup`
- Adds test coverage to `rapidsmpf/python/rapidsmpf/rapidsmpf/tests/test_dask.py`

@pentschev - Let me know what you think about "copying" the dask-cuda logic like this. Feel free to suggests something different.

@quasiben - Perhaps this makes multi-node deployment a bit easier? (i.e. we rely less on logic within `LocalCUDACluster`)