### PR TITLE
wheel builds: react to changes in pip's handling of build constraints

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -21,11 +21,27 @@ cd "${package_dir}"
 sccache --stop-server 2>/dev/null || true
 
 rapids-logger "Building '${package_name}' wheel"
+RAPIDS_PIP_WHEEL_ARGS=(
+  -w dist
+  -v
+  --no-deps
+  --disable-pip-version-check
+)
+
+# Only use --build-constraint when build isolation is enabled.
+#
+# Passing '--build-constraint' and '--no-build-isolation` together results in an error from 'pip',
+# but we want to keep environment variable PIP_CONSTRAINT set unconditionally.
+# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/573
+if [[ "${PIP_NO_BUILD_ISOLATION:-}" != "0" ]]; then
+    RAPIDS_PIP_WHEEL_ARGS+=(--build-constraint="${PIP_CONSTRAINT}")
+fi
+
+# unset PIP_CONSTRAINT (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and
+# results in an error from 'pip wheel' when set and --build-constraint is also passed
+unset PIP_CONSTRAINT
 rapids-pip-retry wheel \
-    -w dist \
-    -v \
-    --no-deps \
-    --disable-pip-version-check \
+    "${RAPIDS_PIP_WHEEL_ARGS[@]}" \
     .
 
 sccache --show-adv-stats


### PR DESCRIPTION
## Description
Contributes to https://github.com/rapidsai/build-planning/issues/242

Modifying `ci/build_wheel.sh` to

- pass`--build-constraint="${PIP_CONSTRAINT}"` unless build isolation is enabled.
- unset `PIP_CONSTRAINT` (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and results in an error from `pip wheel` when set and `--build-constraint` is also passed