### PR TITLE
Backport #794: Enable Explicit Context Shutdown

### DIFF
--- a/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
+++ b/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """Basic streaming example."""
 
@@ -130,6 +130,12 @@ def main() -> int:
         table = TableChunk.from_message(msg).table_view()
         expect += table.num_rows()
     assert total_num_rows[0] == expect
+
+    # Shut down the context explicitly to ensure it happens on the same thread that
+    # created it. Alternatively, use `with Context(...) as ctx:` to shut it down
+    # automatically.
+    ctx.shutdown()
+
     return total_num_rows[0]
 
 

--- a/python/rapidsmpf/rapidsmpf/statistics.pyx
+++ b/python/rapidsmpf/rapidsmpf/statistics.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from cython.operator cimport dereference as deref
@@ -314,3 +314,4 @@ cdef class MemoryRecorder:
         if self._mr is not None:
             with nogil:
                 self._handle.reset()
+        return False  # do not suppress exceptions

--- a/python/rapidsmpf/rapidsmpf/streaming/core/context.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/context.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp.memory cimport shared_ptr
@@ -16,7 +16,7 @@ cdef extern from "<rapidsmpf/streaming/core/context.hpp>" nogil:
     cdef cppclass cpp_Context "rapidsmpf::streaming::Context":
         shared_ptr[cpp_Channel] create_channel() except +
         shared_ptr[cpp_SpillableMessages] spillable_messages() noexcept
-
+        void shutdown() noexcept
 
 cdef class Context:
     cdef shared_ptr[cpp_Context] _handle

--- a/python/rapidsmpf/rapidsmpf/streaming/core/context.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/context.pyi
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from rmm.pylibrmm.stream import Stream
 
 from rapidsmpf.communicator.communicator import Communicator
@@ -21,6 +23,14 @@ class Context:
         options: Options | None = None,
         statistics: Statistics | None = None,
     ) -> None: ...
+    def __enter__(self) -> Context: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: Any | None,
+    ) -> bool: ...
+    def shutdown(self) -> None: ...
     def options(self) -> Options: ...
     def comm(self) -> Communicator: ...
     def br(self) -> BufferResource: ...

--- a/python/rapidsmpf/rapidsmpf/streaming/core/context.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/context.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from cython.operator cimport dereference as deref
@@ -19,19 +19,44 @@ from rapidsmpf.streaming.core.channel cimport Channel, cpp_Channel
 
 cdef class Context:
     """
-    Context for streaming nodes (coroutines) in RapidsMPF.
+    Context for nodes (coroutines) in rapidsmpf.
+
+    The context owns shared resources used during execution, including the
+    coroutine executor and memory reservation infrastructure.
+
+    A ``Context`` instance must be created and shut down on the same thread.
+    Shutting down the context from a different thread results in program
+    termination. This is particularly important in coroutine-based code, where
+    execution and stack unwinding may occur on different threads if ownership
+    is not carefully managed.
+
+    In Python, it is easy to accidentally keep dangling references to a
+    ``Context`` instance, which may delay destruction and cause shutdown to
+    occur on an unintended thread. For this reason, it is strongly recommended
+    to use ``Context`` as a context manager (that is, via a ``with`` statement),
+    which guarantees that ``shutdown()`` is invoked deterministically and on
+    the same thread that created the context.
 
     Parameters
     ----------
     comm
         The communicator to use.
     br
-        Buffer resource to use.
+        The buffer resource to use.
     options
-        Configuration options to use. Missing config options are read
-        from environment variables.
+        The configuration options to use. Missing options are read from environment
+        variables.
     statistics
-        The statistics instance to use. If None, statistics are disabled.
+        The statistics to use. If None, statistics are disabled.
+
+    Examples
+    --------
+    >>> with streaming.Context(
+    ...     comm=...,
+    ...     br=BufferResource(...),
+    ...     options=Options(...),
+    ... ) as ctx:
+    ...     ch = ctx.create_channel()
     """
     def __cinit__(
         self,
@@ -65,9 +90,37 @@ cdef class Context:
             deref(self._handle).spillable_messages()
         )
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.shutdown()
+        return False  # do not suppress exceptions
+
     def __dealloc__(self):
+        # Shut down the C++ context explicitly to ensure shutdown happens immediately
+        # and not later via a dangling reference on another thread. Recall that
+        # shutting down a C++ context on a different thread than the one that created
+        # it results in program termination.
         with nogil:
+            deref(self._handle).shutdown()
             self._handle.reset()
+
+    def shutdown(self):
+        """
+        Shut down the context.
+
+        This method is idempotent and only performs shutdown once. Subsequent calls
+        have no effect.
+
+        Warnings
+        --------
+        Shutdown must be initiated from the same thread that constructed the
+        executor. Calling this method from a different thread results in program
+        termination.
+        """
+        with nogil:
+            deref(self._handle).shutdown()
 
     def options(self):
         """

--- a/python/rapidsmpf/rapidsmpf/streaming/core/fanout.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/fanout.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp.memory cimport make_unique
@@ -49,16 +49,17 @@ def fanout(Context ctx, Channel ch_in, chs_out, FanoutPolicy policy):
     Since messages are shallow-copied, releasing a payload (``release<T>()``)
     is only valid on messages that hold exclusive ownership of the payload.
 
-    Examples
-    --------
     >>> import rapidsmpf.streaming.core as streaming
-    >>> ctx = streaming.Context(...)
-    >>> ch_in = ctx.create_channel()
-    >>> ch_out1 = ctx.create_channel()
-    >>> ch_out2 = ctx.create_channel()
-    >>> node = streaming.fanout(
-    ...     ctx, ch_in, [ch_out1, ch_out2], streaming.FanoutPolicy.BOUNDED
-    ... )
+    >>> with streaming.Context(...) as ctx:
+    ...     ch_in = ctx.create_channel()
+    ...     ch_out1 = ctx.create_channel()
+    ...     ch_out2 = ctx.create_channel()
+    ...     node = streaming.fanout(
+    ...         ctx,
+    ...         ch_in,
+    ...         [ch_out1, ch_out2],
+    ...         streaming.FanoutPolicy.BOUNDED,
+    ...     )
     """
     cdef vector[shared_ptr[cpp_Channel]] _chs_out
     if len(chs_out) == 0:

--- a/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from cpython.object cimport PyObject
@@ -164,8 +164,8 @@ cdef class TableChunk:
         This reference is managed by the underlying C++ object, so it
         persists even when the chunk is transferred through Channels.
 
-        Warning
-        -------
+        Warnings
+        --------
         This object does not keep the provided stream alive. The caller must
         ensure the stream remains valid for the lifetime of the streaming pipeline.
         """

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/conftest.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/conftest.py
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -16,9 +17,12 @@ from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.streaming.core.context import Context
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 @pytest.fixture
-def context() -> Context:
+def context() -> Generator[Context, None, None]:
     """
     Fixture to get a streaming context.
     """
@@ -26,7 +30,9 @@ def context() -> Context:
     comm = single_process_comm(options)
     mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
     br = BufferResource(mr)
-    return Context(comm, br, options)
+
+    with Context(comm, br, options) as ctx:
+        yield ctx
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Backport of #794 to fix failing tests in L4 instances. Closes #795 .

As part of fixing [https://github.com/rapidsai/rapidsmpf/issues/789](https://github.com/rapidsai/rapidsmpf/issues/789) (with additional changes required in cudf-polars), this PR introduces explicit shutdown of `Context` and adds a Python context manager to ensure deterministic, same-thread shutdown.