### PR TITLE
One more C++ string utils

### DIFF
--- a/cpp/include/rapidsmpf/utils/string.hpp
+++ b/cpp/include/rapidsmpf/utils/string.hpp
@@ -4,7 +4,6 @@
  */
 #pragma once
 
-#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -266,5 +265,19 @@ T parse_string(std::string const& text) {
 template <>
 bool parse_string(std::string const& text);
 
+/**
+ * @brief Parse an optional string value.
+ *
+ * Returns `std::nullopt` if the input string represents a disabled value.
+ * Otherwise, the input string is returned unchanged.
+ *
+ * Disabled values are matched case-insensitively and may include surrounding
+ * whitespace. Recognized values include: `false`, `no`, `off`, `disable`,
+ * `disabled`, `none`, `n/a`, and `na`.
+ *
+ * @param text Input string to parse.
+ * @return std::optional<std::string> Parsed optional string.
+ */
+std::optional<std::string> parse_optional(std::string text);
 
 }  // namespace rapidsmpf

--- a/cpp/src/utils/string.cpp
+++ b/cpp/src/utils/string.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <optional>
 #include <ranges>
 #include <regex>
 
@@ -377,6 +378,17 @@ bool parse_string(std::string const& text) {
         return false;
     }
     throw std::invalid_argument("cannot parse \"" + std::string{text} + "\"");
+}
+
+std::optional<std::string> parse_optional(std::string text) {
+    static const std::regex disabled_re(
+        R"(^\s*(false|no|off|disable|disabled|none|n/a|na)\s*$)",
+        std::regex::ECMAScript | std::regex::icase
+    );
+    if (std::regex_match(text, disabled_re)) {
+        return std::nullopt;
+    }
+    return text;
 }
 
 }  // namespace rapidsmpf

--- a/cpp/tests/test_utils_string.cpp
+++ b/cpp/tests/test_utils_string.cpp
@@ -258,3 +258,32 @@ TEST(UtilsTest, ParseStringTest) {
     // Invalid boolean
     EXPECT_THROW(parse_string<bool>("not_a_bool"), std::invalid_argument);
 }
+
+TEST(UtilsTest, ParseOptional) {
+    // Pass-through
+    EXPECT_EQ(parse_optional(""), std::optional<std::string>{""});
+    EXPECT_EQ(parse_optional("foo"), std::optional<std::string>{"foo"});
+    EXPECT_EQ(parse_optional("  foo  "), std::optional<std::string>{"  foo  "});
+    EXPECT_EQ(parse_optional("0"), std::optional<std::string>{"0"});
+    EXPECT_EQ(parse_optional("1"), std::optional<std::string>{"1"});
+    EXPECT_EQ(parse_optional("true"), std::optional<std::string>{"true"});
+
+    // Disabled keywords (case-insensitive, ignores surrounding whitespace)
+    EXPECT_EQ(parse_optional("false"), std::nullopt);
+    EXPECT_EQ(parse_optional(" FALSE "), std::nullopt);
+    EXPECT_EQ(parse_optional("no"), std::nullopt);
+    EXPECT_EQ(parse_optional("\tNO\n"), std::nullopt);
+    EXPECT_EQ(parse_optional("off"), std::nullopt);
+    EXPECT_EQ(parse_optional("  oFf  "), std::nullopt);
+    EXPECT_EQ(parse_optional("disable"), std::nullopt);
+    EXPECT_EQ(parse_optional("DISABLED"), std::nullopt);
+    EXPECT_EQ(parse_optional("none"), std::nullopt);
+    EXPECT_EQ(parse_optional(" n/a "), std::nullopt);
+    EXPECT_EQ(parse_optional("NA"), std::nullopt);
+
+    // Must be a full match (no partial matches)
+    EXPECT_EQ(parse_optional("falsehood"), std::optional<std::string>{"falsehood"});
+    EXPECT_EQ(parse_optional("disabled_now"), std::optional<std::string>{"disabled_now"});
+    EXPECT_EQ(parse_optional("n/a2"), std::optional<std::string>{"n/a2"});
+    EXPECT_EQ(parse_optional("naive"), std::optional<std::string>{"naive"});
+}


### PR DESCRIPTION
Adding:
```c++
/**
 * @brief Parse an optional string value.
 *
 * Returns `std::nullopt` if the input string represents a disabled value.
 * Otherwise, the input string is returned unchanged.
 *
 * Disabled values are matched case-insensitively and may include surrounding
 * whitespace. Recognized values include: `false`, `no`, `off`, `disable`,
 * `disabled`, `none`, `n/a`, and `na`.
 *
 * @param text Input string to parse.
 * @return std::optional<std::string> Parsed optional string.
 */
std::optional<std::string> parse_optional(std::string text);
```