### PR TITLE
Fix option rename: `memory_reserve_timeout_ms => memory_reserve_timeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Each configuration option includes:
     memory reservation APIs, such as `reserve_memory()`.
 
     When enabled, high-level memory reservation requests may overbook memory
-    after the global `memory_reserve_timeout_ms` expires, allowing forward
+    after the global `memory_reserve_timeout` expires, allowing forward
     progress under memory pressure.
 
     When disabled, high-level memory reservation requests fail with an error if

--- a/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
@@ -241,7 +241,7 @@ cdef class MemoryReserveOrWait:
 
     A background task is spawned on demand to periodically check available memory and
     fulfill pending requests. If no reservation request can be satisfied within the
-    timeout specified by the ``"memory_reserve_timeout_ms"`` option, the scheduler
+    timeout specified by the ``"memory_reserve_timeout"`` option, the scheduler
     forces progress by selecting the smallest pending request and attempting to reserve
     memory for it. This attempt may result in an empty reservation if the request still
     cannot be satisfied.
@@ -253,8 +253,8 @@ cdef class MemoryReserveOrWait:
     Parameters
     ----------
     options
-        Configuration options. The option ``"memory_reserve_timeout_ms"`` controls the
-        global progress timeout and defaults to 100 ms.
+        Configuration options. The option ``"memory_reserve_timeout"`` controls the
+        global progress timeout.
     mem_type
         The memory type for which reservations are requested.
     ctx

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_memory_reserve_or_wait.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_memory_reserve_or_wait.py
@@ -64,7 +64,7 @@ def test_memory_is_available(py_executor: ThreadPoolExecutor) -> None:
 def test_reserve_zero_is_always_available(py_executor: ThreadPoolExecutor) -> None:
     with make_context(dev_limit=0) as context:
         mrow = MemoryReserveOrWait(
-            Options({"memory_reserve_timeout_ms": "11000"}), MemoryType.DEVICE, context
+            Options({"memory_reserve_timeout": "10m"}), MemoryType.DEVICE, context
         )
 
         @define_py_node()
@@ -84,7 +84,7 @@ def test_reserve_zero_is_always_available(py_executor: ThreadPoolExecutor) -> No
 def test_timeout(py_executor: ThreadPoolExecutor) -> None:
     with make_context(dev_limit=1024) as context:
         mrow = MemoryReserveOrWait(
-            Options({"memory_reserve_timeout_ms": "1"}), MemoryType.DEVICE, context
+            Options({"memory_reserve_timeout": "1ms"}), MemoryType.DEVICE, context
         )
 
         @define_py_node()
@@ -102,7 +102,7 @@ def test_timeout(py_executor: ThreadPoolExecutor) -> None:
 def test_shutdown(py_executor: ThreadPoolExecutor) -> None:
     with make_context(dev_limit=1024) as context:
         mrow = MemoryReserveOrWait(
-            Options({"memory_reserve_timeout_ms": "100000"}), MemoryType.DEVICE, context
+            Options({"memory_reserve_timeouts": "10m"}), MemoryType.DEVICE, context
         )
 
         @define_py_node()
@@ -144,7 +144,7 @@ def test_context_memory_returns_handle(py_executor: ThreadPoolExecutor) -> None:
 def test_reserve_or_wait_or_overbook(py_executor: ThreadPoolExecutor) -> None:
     with make_context(dev_limit=2048) as context:
         mrow = MemoryReserveOrWait(
-            Options({"memory_reserve_timeout_ms": "1"}), MemoryType.DEVICE, context
+            Options({"memory_reserve_timeout": "1ms"}), MemoryType.DEVICE, context
         )
 
         @define_py_node()
@@ -174,7 +174,7 @@ def test_reserve_or_wait_or_overbook(py_executor: ThreadPoolExecutor) -> None:
 def test_reserve_or_wait_or_fail(py_executor: ThreadPoolExecutor) -> None:
     with make_context(dev_limit=1024) as context:
         mrow = MemoryReserveOrWait(
-            Options({"memory_reserve_timeout_ms": "1"}), MemoryType.DEVICE, context
+            Options({"memory_reserve_timeout": "1ms"}), MemoryType.DEVICE, context
         )
 
         @define_py_node()
@@ -191,7 +191,7 @@ def test_reserve_or_wait_or_fail(py_executor: ThreadPoolExecutor) -> None:
 
 def test_reserve_memory_helper(py_executor: ThreadPoolExecutor) -> None:
     with make_context(
-        dev_limit=1024, overwrite_options={"memory_reserve_timeout_ms": "1"}
+        dev_limit=1024, overwrite_options={"memory_reserve_timeout": "1ms"}
     ) as context:
 
         @define_py_node()
@@ -241,7 +241,7 @@ def test_reserve_memory_helper_allow_overbooking_by_default(
     with make_context(
         dev_limit=1024,
         overwrite_options={
-            "memory_reserve_timeout_ms": "1",
+            "memory_reserve_timeout": "1ms",
             "allow_overbooking_by_default": "true",
         },
     ) as context:
@@ -267,7 +267,7 @@ def test_reserve_memory_helper_allow_overbooking_by_default(
     with make_context(
         dev_limit=1024,
         overwrite_options={
-            "memory_reserve_timeout_ms": "1",
+            "memory_reserve_timeout": "1ms",
             "allow_overbooking_by_default": "false",
         },
     ) as context:


### PR DESCRIPTION
https://github.com/rapidsai/rapidsmpf/pull/803 renames the option `memory_reserve_timeout_ms => memory_reserve_timeout`