### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -49,7 +49,7 @@ dependencies:
 - pydata-sphinx-theme>=0.15.4
 - pylibcudf==26.4.*,>=0.0.0a0
 - pytest<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - rmm==26.4.*,>=0.0.0a0
 - scikit-build-core>=0.11.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -49,7 +49,7 @@ dependencies:
 - pydata-sphinx-theme>=0.15.4
 - pylibcudf==26.4.*,>=0.0.0a0
 - pytest<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - ray-default>=2.49,<2.52
 - rmm==26.4.*,>=0.0.0a0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -49,7 +49,7 @@ dependencies:
 - pydata-sphinx-theme>=0.15.4
 - pylibcudf==26.4.*,>=0.0.0a0
 - pytest<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - rmm==26.4.*,>=0.0.0a0
 - scikit-build-core>=0.11.0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -49,7 +49,7 @@ dependencies:
 - pydata-sphinx-theme>=0.15.4
 - pylibcudf==26.4.*,>=0.0.0a0
 - pytest<9.0.0
-- python>=3.10,<3.14
+- python>=3.11,<3.14
 - rapids-build-backend>=0.4.0,<0.5.0
 - ray-default>=2.49,<2.52
 - rmm==26.4.*,>=0.0.0a0

--- a/cpp/scripts/ndsh.py
+++ b/cpp/scripts/ndsh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "duckdb",
 #     "numpy",

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -274,10 +274,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.10"
-            packages:
-              - python=3.10
-          - matrix:
               py: "3.11"
             packages:
               - python=3.11
@@ -291,7 +287,7 @@ dependencies:
               - python=3.13
           - matrix:
             packages:
-              - python>=3.10,<3.14
+              - python>=3.11,<3.14
   test_cpp:
     common:
       - output_types: conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ addopts = [
 [tool.ruff]
 line-length = 88
 indent-width = 4
-target-version = "py310"
+target-version = "py311"
 fix = true
 
 [tool.ruff.lint]

--- a/python/librapidsmpf/pyproject.toml
+++ b/python/librapidsmpf/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "libcudf==26.4.*,>=0.0.0a0",
     "librmm==26.4.*,>=0.0.0a0",

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cuda-python>=13.0.1,<14.0",
     "cupy-cuda13x>=13.6.0",
@@ -31,7 +31,6 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/246

Finishes the work of dropping Python 3.10 support.

This project stopped building / testing against Python 3.10 as of https://github.com/rapidsai/shared-workflows/pull/494
This PR updates configuration and docs to reflect that.

## Followups before merging

Check that there are no remaining uses like this:

```shell
git grep -E '3\.10'
git grep '310'
git grep 'py310'
```
