### PR TITLE
tighten wheel size limits, expand CI-skipping logic, other small build changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,27 +36,94 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
     with:
       files_yaml: |
-        test_cpp:
-          - '**'
-          - '!.devcontainer/**'
-          - '!.pre-commit-config.yaml'
-          - '!.shellcheckrc'
-          - '!CONTRIBUTING.md'
-          - '!README.md'
-          - '!ci/release/update-version.sh'
-          - '!docs/**'
-          - '!python/**'
-        test_python:
+        build_docs:
           - '**'
           - '!.clang-tidy'
           - '!.devcontainer/**'
+          - '!.github/CODEOWNERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/labeler.yml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
+          - '!.pre-commit-config.yaml'
+          - '!.shellcheckrc'
+          - '!ci/build_wheel*.sh'
+          - '!ci/check_style.sh'
+          - '!ci/release/update-version.sh'
+          - '!ci/run*.sh'
+          - '!ci/test*.sh'
+          - '!ci/timeout_with_stack.py'
+          - '!ci/validate_topology_json.py'
+          - '!ci/validate_wheel.sh'
+          - '!valgrind.supp'
+        test_cpp:
+          - '**'
+          - '!.devcontainer/**'
+          - '!.github/CODEOWNERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/labeler.yml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/build_docs.sh'
+          - '!ci/build_python.sh'
+          - '!ci/build_wheel*.sh'
+          - '!ci/check_style.sh'
           - '!ci/release/update-version.sh'
+          - '!ci/test_python.sh'
+          - '!ci/test_wheel.sh'
+          - '!ci/validate_wheel.sh'
+          - '!docs/**'
+          - '!python/**'
+        test_python_conda:
+          - '**'
+          - '!.devcontainer/**'
+          - '!.github/CODEOWNERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/labeler.yml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
+          - '!.pre-commit-config.yaml'
+          - '!.shellcheckrc'
+          - '!CONTRIBUTING.md'
+          - '!README.md'
+          - '!ci/build_docs.sh'
+          - '!ci/build_wheel*.sh'
+          - '!ci/check_style.sh'
+          - '!ci/release/update-version.sh'
+          - '!ci/run_cpp*.sh'
+          - '!ci/test_cpp*.sh'
+          - '!ci/test_wheel.sh'
+          - '!ci/validate_wheel.sh'
           - '!cpp/.clang-format'
           - '!docs/**'
+        test_python_wheels:
+          - '**'
+          - '!.devcontainer/**'
+          - '!.github/CODEOWNERS'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/labeler.yml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
+          - '!.pre-commit-config.yaml'
+          - '!.shellcheckrc'
+          - '!CONTRIBUTING.md'
+          - '!README.md'
+          - '!ci/build_cpp.sh'
+          - '!ci/build_docs.sh'
+          - '!ci/build_python.sh'
+          - '!ci/check_style.sh'
+          - '!ci/release/update-version.sh'
+          - '!ci/run_cpp*.sh'
+          - '!ci/run_ctests.sh'
+          - '!ci/test_cpp*.sh'
+          - '!ci/test_python.sh'
+          - '!conda/**'
+          - '!cpp/.clang-format'
+          - '!docs/**''
   checks:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
@@ -96,7 +163,7 @@ jobs:
       package-type: python
       sccache-dist-token-secret-name: GIST_REPO_READ_ORG_GITHUB_TOKEN
   wheel-test:
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     needs: [changed-files, wheel-build-rapidsmpf]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
@@ -149,7 +216,7 @@ jobs:
       build_type: pull-request
       script: ci/build_python.sh
   conda-python-tests:
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     needs: [changed-files, conda-python-build]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
@@ -160,9 +227,10 @@ jobs:
       script: ci/test_python.sh
       sccache-dist-token-secret-name: GIST_REPO_READ_ORG_GITHUB_TOKEN
   docs-build:
-    needs: conda-python-build
+    needs: [conda-python-build, changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     with:
       build_type: pull-request
       node_type: "cpu8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
             ^CHANGELOG.md$
           )
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: 983e9631686b9108451ddb4bbd6ac86cb252d4b1  # frozen: v1.2.1
+    rev: 623e513e1d407aa24c3b2c344c6670683b1627a3  # frozen: v1.3.3
     hooks:
       - id: verify-copyright
         args: [--fix, --spdx]
@@ -104,6 +104,12 @@ repos:
       - id: verify-alpha-spec
       - id: verify-codeowners
         args: [--fix, --project-prefix=rapidsmpf]
+      - id: verify-pyproject-license
+        # ignore the top-level pyproject.toml, which doesn't
+        # have or need a [project] table
+        exclude: |
+          (?x)
+            ^pyproject[.]toml$
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: 43302d278c4215036b7fe4b4af0a85f6fad39d2c  # frozen: v1.20.2
     hooks:

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,6 +9,8 @@ package_dir=$2
 
 source rapids-configure-sccache
 source rapids-date-string
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/wheel/preprocessor-cache"
@@ -32,7 +34,7 @@ RAPIDS_PIP_WHEEL_ARGS=(
 #
 # Passing '--build-constraint' and '--no-build-isolation` together results in an error from 'pip',
 # but we want to keep environment variable PIP_CONSTRAINT set unconditionally.
-# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/573
+# PIP_NO_BUILD_ISOLATION=0 means "add --no-build-isolation" (ref: https://github.com/pypa/pip/issues/5735)
 if [[ "${PIP_NO_BUILD_ISOLATION:-}" != "0" ]]; then
     RAPIDS_PIP_WHEEL_ARGS+=(--build-constraint="${PIP_CONSTRAINT}")
 fi

--- a/ci/build_wheel_librapidsmpf.sh
+++ b/ci/build_wheel_librapidsmpf.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 package_name="librapidsmpf"

--- a/ci/build_wheel_rapidsmpf.sh
+++ b/ci/build_wheel_rapidsmpf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -7,6 +7,8 @@ set -euo pipefail
 package_name="rapidsmpf"
 package_dir="python/rapidsmpf"
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"

--- a/ci/build_wheel_singlecomm.sh
+++ b/ci/build_wheel_singlecomm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # Tests building without MPI and without UCXX. This script only ensures the build
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 package_name="librapidsmpf"

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -eou pipefail
 
+RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX="true"
+export RAPIDS_INIT_PIP_REMOVE_NVIDIA_INDEX
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -346,12 +346,6 @@ dependencies:
       - output_types: conda
         packages:
           - cupy>=13.6.0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          # This index is needed for rmm, cubinlinker, ptxcompiler.
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [conda, requirements, pyproject]
         matrices:
@@ -381,7 +375,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -410,7 +403,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -467,7 +459,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -493,7 +484,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -519,7 +509,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -545,7 +534,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -571,7 +559,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -597,7 +584,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -623,7 +609,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -649,7 +634,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]
@@ -675,7 +659,6 @@ dependencies:
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       - output_types: [requirements, pyproject]

--- a/python/librapidsmpf/pyproject.toml
+++ b/python/librapidsmpf/pyproject.toml
@@ -37,6 +37,9 @@ test = [
 [project.urls]
 Homepage = "https://github.com/rapidsai/rapidsmpf"
 
+[project.entry-points."cmake.prefix"]
+librapidsmpf = "librapidsmpf"
+
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
@@ -68,12 +71,11 @@ provider = "scikit_build_core.metadata.regex"
 input = "librapidsmpf/VERSION"
 regex = "(?P<value>.*)"
 
-[project.entry-points."cmake.prefix"]
-librapidsmpf = "librapidsmpf"
-
 [tool.pydistcheck]
 select = [
     "distro-too-large-compressed",
 ]
 output_file_size_precision = 4
-max_allowed_size_compressed = '75M'
+
+# PyPI hard limit is 1GiB, but try to keep this as small as possible
+max_allowed_size_compressed = '30Mi'

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -82,3 +82,12 @@ wheel.exclude = ["*.pyx", "CMakeLists.txt"]
 provider = "scikit_build_core.metadata.regex"
 input = "rapidsmpf/VERSION"
 regex = "(?P<value>.*)"
+
+[tool.pydistcheck]
+select = [
+    "distro-too-large-compressed",
+]
+output_file_size_precision = 4
+
+# PyPI hard limit is 1GiB, but try to keep this as small as possible
+max_allowed_size_compressed = '15Mi'


### PR DESCRIPTION
## Description

Proposes a batch of miscellaneous build / packaging / CI changes.

## Changes

### Tightens wheel size limits

Contributes to https://github.com/rapidsai/build-planning/issues/219

To ensure surprising package-size growth is caught in CI, this PR tightens the limits in the following ways:

* setting all limits to `{compressed_size} + 10Mi`, rounded to the nearest 5Mi

### Expands CI-skipping logic

Contributes to https://github.com/rapidsai/build-planning/issues/243

Tries to avoid unnecessary CI runs by making the CI-skipping rules finer-grained. For example, PRs that only touch `.pre-commit-config.yaml` should now not require any runners with GPUs 😁 

### Removes reliance on `pypi.nvidia.com`

Contributes to https://github.com/rapidsai/build-planning/issues/241

```shell
git grep -i -E 'pypi\.nvidia\.com'
git grep -i -E 'rapids\-init\-pip'
```

And removed/updated all relevant references. This project does not need any wheels from `pypi.nvidia.com` at build-time or runtime, it can safely avoid searching that index.

### Enforces PEP 639 license metadata in `pyproject.toml`

Contributes to https://github.com/rapidsai/pre-commit-hooks/issues/95