### PR TITLE
Rename columns to column_names in q04

### DIFF
--- a/cpp/benchmarks/streaming/ndsh/q04.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q04.cpp
@@ -86,7 +86,7 @@ rapidsmpf::streaming::Node read_lineitem(
         rapidsmpf::ndsh::detail::get_table_path(input_directory, "lineitem")
     );
     auto options = cudf::io::parquet_reader_options::builder(cudf::io::source_info(files))
-                       .columns({
+                       .column_names({
                            "l_commitdate",  // used in filter
                            "l_receiptdate",  // used in filter
                            "l_orderkey",  // used in join
@@ -110,7 +110,7 @@ rapidsmpf::streaming::Node read_orders(
         rapidsmpf::ndsh::detail::get_table_path(input_directory, "orders")
     );
     auto options = cudf::io::parquet_reader_options::builder(cudf::io::source_info(files))
-                       .columns({
+                       .column_names({
                            "o_orderkey",  // used in join
                            "o_orderpriority",  // used in group by
                        })


### PR DESCRIPTION
The columns name is deprecated, hence switching to the new name.

- xref #835