### PR TITLE
Update clang-format's include order

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -58,9 +58,11 @@ IncludeCategories:
     Priority: 30 # CUDA includes
   - Regex: '^<(thrust|cub|cuda)/'
     Priority: 40 # CCCL includes
-  - Regex: '^<(cudf.*|rmm|cugraph|cuml|raft|kvikio)'
+  - Regex: '^<(cudf.*|rmm|cugraph|cuml|raft|kvikio|cucascade)'
     Priority: 50 # RAPIDS includes
   - Regex: '^<rapidsmpf/'
-    Priority: 60
+    Priority: 70 # RapidsMPF project includes
+  - Regex: '^<.*>'
+    Priority: 60 # Other angle bracket includes (e.g., third-party libraries)
   - Regex: '^"'
-    Priority: 70 # quoted includes
+    Priority: 80 # Local/quoted includes (always last)

--- a/cpp/benchmarks/streaming/ndsh/bench_read.cpp
+++ b/cpp/benchmarks/streaming/ndsh/bench_read.cpp
@@ -23,6 +23,8 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 
+#include <coro/when_all.hpp>
+
 #include <rapidsmpf/memory/memory_type.hpp>
 #include <rapidsmpf/nvtx.hpp>
 #include <rapidsmpf/streaming/core/channel.hpp>
@@ -32,8 +34,6 @@
 #include <rapidsmpf/streaming/cudf/parquet.hpp>
 
 #include "utils.hpp"
-
-#include <coro/when_all.hpp>
 
 namespace {
 

--- a/cpp/benchmarks/streaming/ndsh/q21.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q21.cpp
@@ -25,6 +25,8 @@
 #include <cudf/types.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 
+#include <coro/when_all.hpp>
+
 #include <rapidsmpf/communicator/communicator.hpp>
 #include <rapidsmpf/integrations/cudf/bloom_filter.hpp>
 #include <rapidsmpf/nvtx.hpp>
@@ -46,8 +48,6 @@
 #include "parquet_writer.hpp"
 #include "sort.hpp"
 #include "utils.hpp"
-
-#include <coro/when_all.hpp>
 
 namespace {
 

--- a/cpp/include/rapidsmpf/streaming/coll/allgather.hpp
+++ b/cpp/include/rapidsmpf/streaming/coll/allgather.hpp
@@ -9,14 +9,14 @@
 #include <memory>
 #include <vector>
 
+#include <coro/event.hpp>
+#include <coro/task.hpp>
+
 #include <rapidsmpf/coll/allgather.hpp>
 #include <rapidsmpf/communicator/communicator.hpp>
 #include <rapidsmpf/memory/packed_data.hpp>
 #include <rapidsmpf/streaming/core/channel.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
-
-#include <coro/event.hpp>
-#include <coro/task.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/include/rapidsmpf/streaming/core/channel.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/channel.hpp
@@ -11,15 +11,15 @@
 #include <stdexcept>
 #include <utility>
 
+#include <coro/coro.hpp>
+#include <coro/queue.hpp>
+#include <coro/semaphore.hpp>
+
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/streaming/core/coro_executor.hpp>
 #include <rapidsmpf/streaming/core/message.hpp>
 #include <rapidsmpf/streaming/core/node.hpp>
 #include <rapidsmpf/streaming/core/spillable_messages.hpp>
-
-#include <coro/coro.hpp>
-#include <coro/queue.hpp>
-#include <coro/semaphore.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/include/rapidsmpf/streaming/core/context.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/context.hpp
@@ -8,6 +8,8 @@
 #include <memory>
 #include <thread>
 
+#include <coro/coro.hpp>
+
 #include <rapidsmpf/communicator/communicator.hpp>
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/error.hpp>
@@ -17,8 +19,6 @@
 #include <rapidsmpf/streaming/core/coro_executor.hpp>
 #include <rapidsmpf/streaming/core/memory_reserve_or_wait.hpp>
 #include <rapidsmpf/streaming/core/queue.hpp>
-
-#include <coro/coro.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/include/rapidsmpf/streaming/core/coro_executor.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/coro_executor.hpp
@@ -7,11 +7,11 @@
 #include <memory>
 #include <thread>
 
+#include <coro/coro.hpp>
+
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/statistics.hpp>
-
-#include <coro/coro.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
@@ -8,14 +8,14 @@
 #include <optional>
 #include <set>
 
+#include <coro/task.hpp>
+
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
 #include <rapidsmpf/streaming/core/coro_executor.hpp>
 #include <rapidsmpf/streaming/core/coro_utils.hpp>
 #include <rapidsmpf/streaming/core/node.hpp>
 #include <rapidsmpf/utils/misc.hpp>
-
-#include <coro/task.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/include/rapidsmpf/streaming/core/queue.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/queue.hpp
@@ -10,14 +10,14 @@
 #include <optional>
 #include <utility>
 
+#include <coro/queue.hpp>
+#include <coro/sync_wait.hpp>
+
 #include <rapidsmpf/streaming/core/channel.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
 #include <rapidsmpf/streaming/core/coro_utils.hpp>
 #include <rapidsmpf/streaming/core/message.hpp>
 #include <rapidsmpf/streaming/core/node.hpp>
-
-#include <coro/queue.hpp>
-#include <coro/sync_wait.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/include/rapidsmpf/streaming/cudf/table_chunk.hpp
+++ b/cpp/include/rapidsmpf/streaming/cudf/table_chunk.hpp
@@ -16,14 +16,14 @@
 #include <cudf/table/table_view.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
+#include <coro/task.hpp>
+
 #include <rapidsmpf/memory/content_description.hpp>
 #include <rapidsmpf/memory/packed_data.hpp>
 #include <rapidsmpf/owning_wrapper.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
 #include <rapidsmpf/streaming/core/memory_reserve_or_wait.hpp>
 #include <rapidsmpf/streaming/core/message.hpp>
-
-#include <coro/task.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/src/streaming/core/fanout.cpp
+++ b/cpp/src/streaming/core/fanout.cpp
@@ -8,6 +8,8 @@
 #include <ranges>
 #include <span>
 
+#include <coro/coro.hpp>
+
 #include <rapidsmpf/memory/memory_type.hpp>
 #include <rapidsmpf/streaming/core/channel.hpp>
 #include <rapidsmpf/streaming/core/coro_utils.hpp>
@@ -15,8 +17,6 @@
 #include <rapidsmpf/streaming/core/message.hpp>
 #include <rapidsmpf/streaming/core/node.hpp>
 #include <rapidsmpf/streaming/core/spillable_messages.hpp>
-
-#include <coro/coro.hpp>
 
 namespace rapidsmpf::streaming::node {
 namespace {

--- a/cpp/src/streaming/core/memory_reserve_or_wait.cpp
+++ b/cpp/src/streaming/core/memory_reserve_or_wait.cpp
@@ -11,12 +11,12 @@
 #include <stdexcept>
 #include <utility>
 
+#include <coro/sync_wait.hpp>
+
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
 #include <rapidsmpf/streaming/core/memory_reserve_or_wait.hpp>
 #include <rapidsmpf/utils/string.hpp>
-
-#include <coro/sync_wait.hpp>
 
 namespace rapidsmpf::streaming {
 

--- a/cpp/tests/streaming/test_allgather.cpp
+++ b/cpp/tests/streaming/test_allgather.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,8 @@
 #include <cuda_runtime_api.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <coro/latch.hpp>
 
 #include <rapidsmpf/communicator/single.hpp>
 #include <rapidsmpf/cuda_stream.hpp>
@@ -23,8 +25,6 @@
 #include <rapidsmpf/streaming/core/node.hpp>
 
 #include "base_streaming_fixture.hpp"
-
-#include <coro/latch.hpp>
 
 using namespace rapidsmpf;
 

--- a/cpp/tests/streaming/test_fanout.cpp
+++ b/cpp/tests/streaming/test_fanout.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <iostream>
@@ -10,6 +10,8 @@
 
 #include <cudf_test/table_utilities.hpp>
 
+#include <coro/coro.hpp>
+
 #include <rapidsmpf/memory/buffer.hpp>
 #include <rapidsmpf/memory/pinned_memory_resource.hpp>
 #include <rapidsmpf/streaming/core/coro_utils.hpp>
@@ -18,8 +20,6 @@
 #include <rapidsmpf/streaming/core/node.hpp>
 
 #include "base_streaming_fixture.hpp"
-
-#include <coro/coro.hpp>
 
 using namespace rapidsmpf;
 using namespace rapidsmpf::streaming;

--- a/cpp/tests/test_rrun.cpp
+++ b/cpp/tests/test_rrun.cpp
@@ -24,10 +24,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cucascade/memory/topology_discovery.hpp>
+
 #include <rapidsmpf/bootstrap/utils.hpp>
 #include <rapidsmpf/system_info.hpp>
-
-#include <cucascade/memory/topology_discovery.hpp>
 
 class TopologyBindingTest : public ::testing::Test {
   protected:

--- a/cpp/tools/check_resource_binding.cpp
+++ b/cpp/tools/check_resource_binding.cpp
@@ -31,10 +31,10 @@
 
 #include <cuda_runtime.h>
 
+#include <cucascade/memory/topology_discovery.hpp>
+
 #include <rapidsmpf/bootstrap/utils.hpp>
 #include <rapidsmpf/system_info.hpp>
-
-#include <cucascade/memory/topology_discovery.hpp>
 
 namespace {
 


### PR DESCRIPTION
stdlib → CUDA → CCCL → RAPIDS →  third-party → RapidsMPF → local.