### PR TITLE
Avoid using "p2p" shuffle in dask-cudf test

### DIFF
--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -487,9 +487,12 @@ def test_dask_cudf_join(
             # a RMPF shuffle multiple times. Therefore, we use left0
             # and right0 to generate the expected result (left and
             # right may be "pre-shuffled").
-            expected = left0.merge(
-                right0, left_on=left_on, right_on=right_on, how=how
-            ).compute()
+            expected = left0.compute().merge(
+                right0.compute(),
+                left_on=left_on,
+                right_on=right_on,
+                how=how,
+            )
             dd.assert_eq(joined, expected, check_index=False)
 
 


### PR DESCRIPTION
I noticed some [CI failures](https://github.com/rapidsai/rapidsmpf/actions/runs/22230507649/job/64309964935?pr=876) in https://github.com/rapidsai/rapidsmpf/pull/876, and found that there is some kind of bug in "p2p" shuffling in dask-cudf.

It seems that we _sometimes_ get an unexpected index column after a [to_pyarrow_table_dispatch](https://github.com/rapidsai/cudf/blob/d6616202d03e45ecc723d4b8f6f869b6516c0284/python/dask_cudf/dask_cudf/backends.py#L371) round-trip. I will try to find the "correct" fix for this in cudf/dask-cudf, but there is no reason for rapidsmpf to be testing the "p2p" shuffle. This PR simplifies the problematic test.