### PR TITLE
fix links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ on RAPIDS components.
 
 ## Documentation
 
-- [Getting Started](https://docs.rapids.ai/api/rapidsmpf/stable/getting-started/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/getting-started/))
-- [Background](https://docs.rapids.ai/api/rapidsmpf/stable/background/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/background/))
-- [Configuration Options](https://docs.rapids.ai/api/rapidsmpf/stable/configuration/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/configuration/))
-- [Python API Reference](https://docs.rapids.ai/api/rapidsmpf/stable/python/api/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/python/api/))
-- [C++ API Reference](https://docs.rapids.ai/api/librapidsmpf/stable/) ([nightly](https://docs.rapids.ai/api/librapidsmpf/nightly/))
-- [Glossary](https://docs.rapids.ai/api/rapidsmpf/stable/glossary/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/glossary/))
+- [Getting Started](https://docs.rapids.ai/api/rapidsmpf/nightly/getting-started/)
+- [Background](https://docs.rapids.ai/api/rapidsmpf/nightly/background/)
+- [Configuration Options](https://docs.rapids.ai/api/rapidsmpf/nightly/configuration/)
+- [Python API Reference](https://docs.rapids.ai/api/rapidsmpf/nightly/python/api/)
+- [C++ API Reference](https://docs.rapids.ai/api/librapidsmpf/nightly/)
+- [Glossary](https://docs.rapids.ai/api/rapidsmpf/nightly/glossary/)
 
 ## Build from Source
 
@@ -22,5 +22,5 @@ mamba env create --name rapidsmpf-dev --file conda/environments/all_cuda-131_arc
 ./build.sh
 ```
 
-See the [Getting Started guide](https://docs.rapids.ai/api/rapidsmpf/stable/getting-started/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/getting-started/))
+See the [Getting Started guide](https://docs.rapids.ai/api/rapidsmpf/nightly/getting-started/)
 for debug builds, AddressSanitizer, MPI/UCX test suites, and rrun launcher details.

--- a/cpp/doxygen/main_page.md
+++ b/cpp/doxygen/main_page.md
@@ -4,5 +4,5 @@ RapidsMPF exposes a full C++ API for building high-performance distributed GPU
 workloads. It provides communications primitives, an out-of-core distributed shuffle
 service, and an asynchronous multi-GPU streaming engine built on RAPIDS components.
 
-- [Full documentation](https://docs.rapids.ai/api/rapidsmpf/stable/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/))
-- [Python API Reference](https://docs.rapids.ai/api/rapidsmpf/stable/python/api/) ([nightly](https://docs.rapids.ai/api/rapidsmpf/nightly/python/api/))
+- [Full documentation](https://docs.rapids.ai/api/rapidsmpf/nightly/)
+- [Python API Reference](https://docs.rapids.ai/api/rapidsmpf/nightly/python/api/)

--- a/docs/source/cpp/index.md
+++ b/docs/source/cpp/index.md
@@ -5,8 +5,7 @@ workloads without a Python runtime. The C++ layer is the foundation on which the
 Python bindings are built.
 
 The C++ API reference is available at
-[docs.rapids.ai/api/librapidsmpf/stable](https://docs.rapids.ai/api/librapidsmpf/stable/)
-([nightly](https://docs.rapids.ai/api/librapidsmpf/nightly/)).
+[docs.rapids.ai/api/librapidsmpf/nightly](https://docs.rapids.ai/api/librapidsmpf/nightly/).
 
 ## Coverage
 


### PR DESCRIPTION
For now, we don't have updated `stable` docs 