### PR TITLE
Update RMM imports for cuda_stream deprecation

### DIFF
--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -11,7 +11,7 @@ from libcpp.unordered_map cimport unordered_map
 from libcpp.utility cimport move
 from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
 
-from rmm.pylibrmm.stream import CudaStreamFlags
+from rmm.pylibrmm import CudaStreamFlags
 
 from rmm.pylibrmm.cuda_stream_pool cimport CudaStreamPool
 from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource


### PR DESCRIPTION
https://github.com/rapidsai/rmm/pull/2256 deprecated `rmm.pylibrmm.cuda_stream` in favor of `rmm.pylibrmm.stream` for importing `CudaStreamFlags`.

This should fix the import warnings showing up in
https://github.com/rapidsai/cudf/actions/runs/22411827835/job/64890756380?pr=21538.