### PR TITLE
Remove CMAKE_CXX_SCAN_FOR_MODULES workaround now that sccache is updated

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -27,11 +27,6 @@ project(
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
-# For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
-# version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
-# gcc>=14. We can remove this once we upgrade to a newer sccache version.
-set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
-
 # Write the version header
 rapids_cmake_write_version_file(include/rapidsmpf/version_config.hpp)
 


### PR DESCRIPTION
Now that sccache has been updated in CI to a version that correctly handles the `-M*` flags generated by CMake's C++ module scanning, we can remove the `set(CMAKE_CXX_SCAN_FOR_MODULES OFF)` workaround that was added to suppress this behavior.