### PR TITLE
Update Cython lower bound pin to 3.2.2

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - cuda-version=12.9
 - cudf==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.3,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - doxygen=1.9.1

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - cuda-version=12.9
 - cudf==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.3,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - doxygen=1.9.1

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - cuda-version=13.1
 - cudf==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.3,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - doxygen=1.9.1

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -21,7 +21,7 @@ dependencies:
 - cuda-version=13.1
 - cudf==26.4.*,>=0.0.0a0
 - cxx-compiler
-- cython>=3.0.3,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - dask-cudf==26.4.*,>=0.0.0a0
 - doxygen=1.9.1

--- a/conda/recipes/rapidsmpf/recipe.yaml
+++ b/conda/recipes/rapidsmpf/recipe.yaml
@@ -87,7 +87,7 @@ requirements:
     - cuda-cudart-dev
     - cuda-cupti-dev
     - cuda-version =${{ cuda_version }}
-    - cython >=3.0.3,<3.2.0
+    - cython >=3.2.2
     - librapidsmpf =${{ version }}
     - libnuma
     - mpi4py

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -228,7 +228,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - cython>=3.0.3,<3.2.0
+          - cython>=3.2.2
   checks:
     common:
       - output_types: conda

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -56,7 +56,7 @@ dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
     "cmake>=3.30.4",
-    "cython>=3.0.3,<3.2.0",
+    "cython>=3.2.2",
     "libcudf==26.4.*,>=0.0.0a0",
     "librapidsmpf==26.4.*,>=0.0.0a0",
     "librmm==26.4.*,>=0.0.0a0",


### PR DESCRIPTION
## Summary

Refs https://github.com/rapidsai/build-planning/issues/229

Updates the Cython lower bound pin to `>=3.2.2`. The `<3.2.0` upper bound was added as a workaround for a code-generation bug introduced in Cython 3.2.0. That bug was fixed in Cython 3.2.1 (https://github.com/cython/cython/pull/7313) and additional related fixes landed in Cython 3.2.2 (https://github.com/cython/cython/pull/7320). Cython 3.2.2 has been released, so we can now raise the lower bound and remove the upper bound cap.

Changes:
- Update `dependencies.yaml`: set `cython>=3.2.2` (no upper bound), remove the old workaround comment
- Update `conda/recipes/*/recipe.yaml`: same pin change (not managed by `rapids-dependency-file-generator`)
- Regenerate all derived files via `rapids-dependency-file-generator`