### PR TITLE
Avoid `fork` method in dask tests

### DIFF
--- a/python/rapidsmpf/rapidsmpf/_testing.py
+++ b/python/rapidsmpf/rapidsmpf/_testing.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rapidsmpf.integrations.dask.core import bootstrap_dask_cluster
+
+if TYPE_CHECKING:
+    import multiprocessing
+
+
+def connect_dask_client_from_subprocess(
+    scheduler_address: str, q: multiprocessing.Queue
+) -> None:
+    # This function needs to be serializable to be used in a subprocess.
+    from distributed import Client
+
+    client = Client(scheduler_address)
+    bootstrap_dask_cluster(client)
+    q.put(obj=True)

--- a/python/rapidsmpf/rapidsmpf/tests/__init__.py
+++ b/python/rapidsmpf/rapidsmpf/tests/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0

--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -10,6 +10,7 @@ import dask.dataframe as dd
 import pytest
 
 import rapidsmpf.integrations.single
+from rapidsmpf._testing import connect_dask_client_from_subprocess
 from rapidsmpf.communicator import COMMUNICATORS
 from rapidsmpf.config import Options
 from rapidsmpf.examples.dask import (
@@ -494,12 +495,6 @@ def test_dask_cudf_join(
             dd.assert_eq(joined, expected, check_index=False)
 
 
-def _connect_from_subprocess(scheduler_address: str, q: multiprocessing.Queue) -> None:
-    client = Client(scheduler_address)
-    bootstrap_dask_cluster(client)
-    q.put(obj=True)
-
-
 @gen_test(timeout=30)
 @pytest.mark.filterwarnings("ignore")
 async def test_bootstrap_multiple_clients(
@@ -518,7 +513,8 @@ async def test_bootstrap_multiple_clients(
 
         q: multiprocessing.Queue[bool] = ctx.Queue()
         p = ctx.Process(
-            target=_connect_from_subprocess, args=(cluster.scheduler_address, q)
+            target=connect_dask_client_from_subprocess,
+            args=(cluster.scheduler_address, q),
         )
         p.start()
         result = q.get(timeout=5)


### PR DESCRIPTION
This change lets use multiprocessing's `forkserver` method, the new default in 3.14 on posix systems.

We needed to move the closure to a top-level function and add a `__init__.py` to our test directory so that `_connect_from_subprocess` could be imported in the new process. 

Closes #899 