### PR TITLE
Add `devcontainers` output to `dependencies.yaml` that excludes keys that pull in ray-default

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,6 +27,7 @@ files:
       - depends_on_pylibcudf
       - depends_on_rmm
       - depends_on_ucxx
+      - depends_on_ray
       - py_version
       - rapids_build_skbuild
       - test_cpp
@@ -36,7 +37,7 @@ files:
   devcontainers:
     output: none
     includes:
-      # "devcontainers" includes everything in "all" except anything that includes ray-default (test_python and docs)
+      # "devcontainers" includes everything in "all" except "depends_on_ray"
       - build-universal
       - build-cpp
       - build-python
@@ -59,6 +60,8 @@ files:
       - rapids_build_skbuild
       - test_cpp
       - test_cpp_ndsh
+      - test_python
+      - docs
   test_cpp:
     output: none
     includes:
@@ -79,6 +82,7 @@ files:
       - depends_on_librapidsmpf
       - depends_on_librmm
       - depends_on_rapidsmpf
+      - depends_on_ray
       - depends_on_ucxx
       - py_version
       - run_rapidsmpf
@@ -110,6 +114,7 @@ files:
       - depends_on_ucxx
       - depends_on_librapidsmpf
       - depends_on_rapidsmpf
+      - depends_on_ray
       - docs
       - py_version
   py_build_librapidsmpf:
@@ -183,6 +188,7 @@ files:
       - depends_on_cudf
       - depends_on_dask_cuda
       - depends_on_dask_cudf
+      - depends_on_ray
       - test_python
 channels:
   - rapidsai-nightly
@@ -361,25 +367,6 @@ dependencies:
           - psutil  # Used for timeout_with_stack.py
           - pytest
           - nvidia-ml-py>=12
-    specific:
-      - output_types: conda
-        matrices:
-          # TODO: enable `ray-default` for Python 3.14 once `ray` supports 3.14
-          # https://github.com/rapidsai/rapidsmpf/issues/897
-          - matrix:
-              arch: x86_64
-              py: "3.14"
-            packages:
-          - matrix:
-              arch: x86_64
-              py: "3.*"
-            packages:
-              - ray-default>=2.49,<2.52
-          - matrix:
-              arch: aarch64
-            packages:
-          - matrix:
-            packages:
   run_rapidsmpf:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -482,23 +469,6 @@ dependencies:
           - sphinx>=8.1.0
           - sphinx-autobuild
           - sphinx-copybutton
-    specific:
-      - output_types: conda
-        matrices:
-          - matrix:
-              arch: x86_64
-              py: "3.14"
-            packages:
-          - matrix:
-              arch: x86_64
-              py: "3.*"
-            packages:
-              - ray-default>=2.49,<2.52
-          - matrix:
-              arch: aarch64
-            packages:
-          - matrix:
-            packages:
   depends_on_cudf:
     common:
       - output_types: conda
@@ -724,3 +694,23 @@ dependencies:
           - matrix:
             packages:
               - *ucxx_unsuffixed
+  depends_on_ray:
+    specific:
+      - output_types: conda
+        matrices:
+          # TODO: enable `ray-default` for Python 3.14 once `ray` supports 3.14
+          # https://github.com/rapidsai/rapidsmpf/issues/897
+          - matrix:
+              arch: x86_64
+              py: "3.14"
+            packages:
+          - matrix:
+              arch: x86_64
+              py: "3.*"
+            packages:
+              - ray-default>=2.49,<2.52
+          - matrix:
+              arch: aarch64
+            packages:
+          - matrix:
+            packages:


### PR DESCRIPTION
`ray-default` causes [conflicts](https://github.com/rapidsai/devcontainers/actions/runs/22774282651/job/66087412591?pr=670#step:9:2829) installing in envs with pytorch, so this adds a special key we can use in devcontainers that won't install ray.