### PR TITLE
Fix UCXX import for pip installations

### DIFF
--- a/python/rapidsmpf/rapidsmpf/communicator/__init__.py
+++ b/python/rapidsmpf/rapidsmpf/communicator/__init__.py
@@ -1,8 +1,14 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """Submodule for communication abstraction (e.g. UCXX and MPI)."""
 
 from __future__ import annotations
+
+# Ensure ucxx Python module is imported so its __init__ runs and
+# loads libucxx_python.so (required when installed via pip).
+# The ucxx.pyx bindings only use `cimport`, so the Python module
+# is otherwise never imported and its initialization is skipped.
+import ucxx  # noqa: F401
 
 from rapidsmpf.communicator.communicator import _available_communicators
 


### PR DESCRIPTION
Explicitly import the `ucxx` Python module to ensure its shared library is loaded.

Importing RapidsMPF’s UCXX communicator (`rapidsmpf.communicator.ucxx`) fails when using the pip package, while it works in Conda environments.

The root cause is that our Cython bindings only use `cimport` for UCXX. This bypasses execution of `ucxx.__init__`, so `libucxx_python.so` is never loaded.

As a result, users hit import errors such as: `ImportError: libucxx_python.so not found`