### PR TITLE
docs-build: use Python 3.13 image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,6 @@ jobs:
       # TODO: switch to {rapids-version}-latest when there are 'ray' packages for Python 3.14
       #  ref: https://github.com/rapidsai/rapidsmpf/issues/897
       container_image: "rapidsai/ci-conda:26.06-cuda13.0.2-ubuntu22.04-py3.13"
-      script: "ci/build_docs.sh"
       date: ${{ inputs.date }}
       node_type: "cpu8"
       script: "ci/build_docs.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -239,7 +239,6 @@ jobs:
       #  ref: https://github.com/rapidsai/rapidsmpf/issues/897
       container_image: "rapidsai/ci-conda:26.06-cuda13.0.2-ubuntu22.04-py3.13"
       script: "ci/build_docs.sh"
-      script: "ci/build_docs.sh"
   devcontainer:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@release/26.04


### PR DESCRIPTION
docs builds are breaking here like this:

```text
WARNING: Failed to import rapidsmpf.integrations.ray.
Possible hints:
* AttributeError: module 'rapidsmpf.integrations' has no attribute 'ray'
* ModuleNotFoundError: No module named 'ray'
```

([build link](https://github.com/rapidsai/rapidsmpf/actions/runs/23301819724/job/67766153628#step:13:2122))

I think that's because `rapidsai/ci-conda:{rapids-version}-latest` now points to Python 3.14 images (https://github.com/rapidsai/ci-imgs/pull/383) and there aren't `ray` conda packages for Python 3.14 yet (#897).

This fixes that by pinning to a specific Python 3.13 image.
