### PR TITLE
Execute PyActors in asyncio.TaskGroup

### DIFF
--- a/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
+++ b/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
@@ -29,7 +29,9 @@ from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 from rapidsmpf.utils.cudf import cudf_to_pylibcudf_table
 
 if TYPE_CHECKING:
-    from rapidsmpf.streaming.core.actor import CppActor, PyActor
+    from collections.abc import Awaitable
+
+    from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
 
 
@@ -107,7 +109,7 @@ def main() -> int:
     # Actors return None, so if we want an "output" value we can use either a closure
     # or an output parameter like `total_num_rows`.
     total_num_rows = [0]  # Wrap scalar in a list to make it mutable in-place.
-    actor2: PyActor = count_num_rows(
+    actor2: Awaitable[None] = count_num_rows(
         ctx, ch_in=ch1, ch_out=ch2, total_num_rows=total_num_rows
     )
 

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyi
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Collection, Generator
+from collections.abc import Awaitable, Callable, Collection
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Concatenate, ParamSpec
+from typing import Concatenate, ParamSpec
 
 from rapidsmpf.streaming.core.channel import Channel
 from rapidsmpf.streaming.core.context import Context
@@ -15,17 +15,14 @@ P = ParamSpec("P")
 class CppActor:
     pass
 
-class PyActor(Awaitable[None]):
-    def __await__(self) -> Generator[Any, None, None]: ...
-
 def define_actor(
     *, extra_channels: Collection[Channel] = ()
 ) -> Callable[
     [Callable[Concatenate[Context, P], Awaitable[None]]],
-    Callable[Concatenate[Context, P], PyActor],
+    Callable[Concatenate[Context, P], Awaitable[None]],
 ]: ...
 def run_actor_network(
     *,
-    actors: Collection[CppActor | PyActor],
+    actors: Collection[CppActor | Awaitable[None]],
     py_executor: ThreadPoolExecutor | None = None,
 ) -> None: ...

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
@@ -133,7 +133,14 @@ cdef decorate_actor(extra_channels, func):
 
 async def run_py_actors(py_actors):
     """Await all ``py_actors`` concurrently."""
-    return await asyncio.gather(*py_actors)
+    async with asyncio.TaskGroup() as tg:
+        for actor in py_actors:
+            tg.create_task(_await_actor(actor))
+
+
+async def _await_actor(actor):
+    """Thin wrapper to turn an awaitable PyActor into a coroutine for TaskGroup."""
+    return await actor
 
 
 def define_actor(*, extra_channels=()):

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
@@ -7,7 +7,7 @@ from libcpp.utility cimport move
 
 import asyncio
 import inspect
-from collections.abc import Awaitable, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from functools import partial, wraps
 
 from rapidsmpf.streaming.core.channel import Channel
@@ -80,45 +80,6 @@ cdef class CppActor:
         return move(self._handle)
 
 
-class PyActor(Awaitable[None]):
-    """
-    A streaming actor implemented in Python.
-
-    This runs as an Python coroutine (asyncio), which means it comes with a significant
-    Python overhead. The GIL is released while C++ actors are executing.
-    """
-    def __init__(self, func, extra_channels, /, *args, **kwargs):
-        if len(args) < 1 or not isinstance(args[0], Context):
-            raise TypeError(
-                "expect a Context as the first positional argument "
-                "(not as a keyword argument)"
-            )
-        self._func = func
-        self._args = args
-        self._kwargs = kwargs
-        self._channels_to_shutdown = (
-            *collect_channels(args, kwargs), *extra_channels
-        )
-
-    @staticmethod
-    async def run(Context ctx not None, channels_to_shutdown, coro):
-        """
-        Run the coroutine and shutdown the channels when done.
-        """
-        try:
-            return await coro
-        finally:
-            for ch in channels_to_shutdown:
-                await ch.shutdown(ctx)
-
-    def __await__(self):
-        return self.run(
-            self._args[0],
-            self._channels_to_shutdown,
-            self._func(*self._args, **self._kwargs)
-        ).__await__()
-
-
 def collect_channels(*objs):
     """Recursively yield all `Channel` instances found in ``objs``."""
     for obj in objs:
@@ -132,23 +93,39 @@ def collect_channels(*objs):
             yield from collect_channels(*obj)
 
 
+async def py_actor(func, extra_channels, /, *args, **kwargs):
+    """
+    A streaming actor implemented in Python.
+
+    This runs as an Python coroutine (asyncio), which means it comes with a significant
+    Python overhead. The GIL is released while C++ actors are executing.
+    """
+    if len(args) < 1 or not isinstance(args[0], Context):
+        raise TypeError(
+            "expect a Context as the first positional argument "
+            "(not as a keyword argument)"
+        )
+    ctx = args[0]
+    channels_to_shutdown = (*collect_channels(args, kwargs), *extra_channels)
+    try:
+        return await func(*args, **kwargs)
+    finally:
+        for ch in channels_to_shutdown:
+            await ch.shutdown(ctx)
+
+
 cdef decorate_actor(extra_channels, func):
     """Validate ``func`` is async and wrap it as a PyActor."""
     if not inspect.iscoroutinefunction(func):
         raise TypeError(f"`{func.__qualname__}` must be an async function")
-    return wraps(func)(partial(PyActor, func, extra_channels))
+    return wraps(func)(partial(py_actor, func, extra_channels))
 
 
 async def run_py_actors(py_actors):
     """Await all ``py_actors`` concurrently."""
     async with asyncio.TaskGroup() as tg:
         for actor in py_actors:
-            tg.create_task(_await_actor(actor))
-
-
-async def _await_actor(actor):
-    """Thin wrapper to turn an awaitable PyActor into a coroutine for TaskGroup."""
-    return await actor
+            tg.create_task(actor)
 
 
 def define_actor(*, extra_channels=()):
@@ -263,12 +240,8 @@ def run_actor_network(*, actors, py_executor = None):
     for actor in actors:
         if isinstance(actor, CppActor):
             cpp_actors.push_back(move(deref((<CppActor>actor).release_handle())))
-        elif isinstance(actor, PyActor):
-            py_actors.append(actor)
         else:
-            raise ValueError(
-                "Unknown actor type, did you forget to use `@define_actor()`?"
-            )
+            py_actors.append(actor)
 
     if len(py_actors) > 0:
         if py_executor is None:

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_allgather.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_allgather.py
@@ -21,10 +21,11 @@ from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 from rapidsmpf.testing import assert_eq
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from concurrent.futures import ThreadPoolExecutor
 
     from rapidsmpf.communicator.communicator import Communicator
-    from rapidsmpf.streaming.core.actor import CppActor, PyActor
+    from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
 
@@ -139,7 +140,7 @@ def test_allgather_object_interface(
 ) -> None:
     ch_in: Channel[PackedDataChunk] = context.create_channel()
     ch_out: Channel[TableChunk] = context.create_channel()
-    actors: list[CppActor | PyActor] = []
+    actors: list[CppActor | Awaitable[None]] = []
     num_rows = 100
     num_chunks = 10
     op_id = 0

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_arbitrary_chunk.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_arbitrary_chunk.py
@@ -12,10 +12,11 @@ from rapidsmpf.streaming.core.leaf_actor import pull_from_channel, push_to_chann
 from rapidsmpf.streaming.core.message import Message
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from concurrent.futures import ThreadPoolExecutor
     from typing import Any
 
-    from rapidsmpf.streaming.core.actor import CppActor, PyActor
+    from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
 
@@ -127,7 +128,7 @@ def test_with_channel(context: Context, py_executor: ThreadPoolExecutor) -> None
             )
         await ch_out.drain(ctx)
 
-    actors: list[CppActor | PyActor] = [
+    actors: list[CppActor | Awaitable[None]] = [
         push_to_channel(context, ch_in, inputs),
         increment(context, ch_in, ch_out),
     ]

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_bloom_filter.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_bloom_filter.py
@@ -20,10 +20,12 @@ from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 from rapidsmpf.testing import assert_eq
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from rmm.pylibrmm.stream import Stream
 
     from rapidsmpf.communicator.communicator import Communicator
-    from rapidsmpf.streaming.core.actor import CppActor, PyActor
+    from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
     from rapidsmpf.streaming.cudf.bloom_filter import BloomFilterChunk
@@ -78,7 +80,7 @@ def run_bloom_filter_pipeline(
     ch_probe: Channel[TableChunk] = context.create_channel()
     ch_out: Channel[TableChunk] = context.create_channel()
 
-    actors: list[CppActor | PyActor] = [
+    actors: list[CppActor | Awaitable[None]] = [
         push_to_channel(context, ch_build, [build_msg]),
         push_to_channel(context, ch_probe, [probe_msg]),
         bloom_pipeline(context, bloom, ch_build, ch_probe, ch_out),

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_channel.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_channel.py
@@ -179,7 +179,7 @@ def test_producer_raises_after_metadata(
         throwing_producer(context, ch),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
-    with pytest.raises(RuntimeError, match="producer failed"):
+    with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="producer failed")):
         run_actor_network(actors=actors, py_executor=py_executor)
 
 
@@ -198,5 +198,5 @@ def test_consumer_raises_with_metadata(
         send_metadata_then_data(context, ch, [1], 0, 1),
         throwing_consumer(context, ch),
     ]
-    with pytest.raises(RuntimeError, match="consumer failed"):
+    with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="consumer failed")):
         run_actor_network(actors=actors, py_executor=py_executor)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_channel.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_channel.py
@@ -12,9 +12,9 @@ from rapidsmpf.streaming.core.actor import define_actor, run_actor_network
 from rapidsmpf.streaming.core.message import Message
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from concurrent.futures import ThreadPoolExecutor
 
-    from rapidsmpf.streaming.core.actor import PyActor
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
 
@@ -95,7 +95,7 @@ def test_data_roundtrip_without_metadata(
 ) -> None:
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     outputs: list[int] = []
-    actors: list[PyActor] = [
+    actors: list[Awaitable[None]] = [
         send_data(context, ch, 0, 3),
     ]
 
@@ -119,7 +119,7 @@ def test_metadata_then_data_roundtrip(
     metadata_out: list[int] = []
     data_out: list[int] = []
 
-    actors: list[PyActor] = [
+    actors: list[Awaitable[None]] = [
         send_metadata_then_data(context, ch, [10, 20], 0, 2),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
@@ -135,7 +135,7 @@ def test_data_only_with_metadata_shutdown(
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     metadata_out: list[int] = []
     data_out: list[int] = []
-    actors: list[PyActor] = [
+    actors: list[Awaitable[None]] = [
         send_data_only_with_metadata_shutdown(context, ch, 5, 2),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
@@ -151,7 +151,7 @@ def test_metadata_only_with_data_shutdown(
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     metadata_out: list[int] = []
     data_out: list[int] = []
-    actors: list[PyActor] = [
+    actors: list[Awaitable[None]] = [
         send_metadata_only(context, ch, [30, 31]),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
@@ -175,7 +175,7 @@ def test_producer_raises_after_metadata(
         await ch_out.send_metadata(ctx, Message(0, ArbitraryChunk(99)))
         raise RuntimeError("producer failed")
 
-    actors: list[PyActor] = [
+    actors: list[Awaitable[None]] = [
         throwing_producer(context, ch),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
@@ -194,7 +194,7 @@ def test_consumer_raises_with_metadata(
     ) -> None:
         raise RuntimeError("consumer failed")
 
-    actors: list[PyActor] = [
+    actors: list[Awaitable[None]] = [
         send_metadata_then_data(context, ch, [1], 0, 1),
         throwing_consumer(context, ch),
     ]

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_define_actor.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_define_actor.py
@@ -98,9 +98,11 @@ def test_send_error(context: Context, py_executor: ThreadPoolExecutor) -> None:
     ch1: Channel[TableChunk] = context.create_channel()
     actor2, output = pull_from_channel(context, ch_in=ch1)
 
-    with pytest.raises(
-        RuntimeError,
-        match="MyError",
+    with pytest.RaisesGroup(
+        pytest.RaisesExc(
+            RuntimeError,
+            match="MyError",
+        )
     ):
         run_actor_network(
             actors=[

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_exceptions.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_exceptions.py
@@ -43,7 +43,7 @@ def test_task_exceptions(context: Context, py_executor: ThreadPoolExecutor) -> N
         pull_task,
     ]
 
-    with pytest.raises(RuntimeError, match="Throwing in task"):
+    with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="Throwing in task")):
         run_actor_network(actors=actors, py_executor=py_executor)
 
     messages = deferred.release()

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_exceptions.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_exceptions.py
@@ -11,9 +11,10 @@ from rapidsmpf.streaming.core.actor import define_actor, run_actor_network
 from rapidsmpf.streaming.core.leaf_actor import pull_from_channel
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from concurrent.futures import ThreadPoolExecutor
 
-    from rapidsmpf.streaming.core.actor import CppActor, PyActor
+    from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
     from rapidsmpf.streaming.core.message import Payload
@@ -37,7 +38,7 @@ def test_task_exceptions(context: Context, py_executor: ThreadPoolExecutor) -> N
 
     pull_task, deferred = pull_from_channel(context, ch3)
 
-    actors: list[CppActor | PyActor] = [
+    actors: list[CppActor | Awaitable[None]] = [
         task_that_throws(context, ch1, ch2),
         task_that_spins(context, ch3),
         pull_task,

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
@@ -30,6 +30,7 @@ from rapidsmpf.testing import assert_eq
 from rapidsmpf.utils.cudf import cudf_to_pylibcudf_table, pylibcudf_to_cudf_dataframe
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from concurrent.futures import ThreadPoolExecutor
 
     from rmm.pylibrmm.stream import Stream
@@ -39,7 +40,7 @@ if TYPE_CHECKING:
         PartitionMapChunk,
         PartitionVectorChunk,
     )
-    from rapidsmpf.streaming.core.actor import CppActor, PyActor
+    from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
 
@@ -188,7 +189,7 @@ def test_shuffler_runtime_obeys_contiguous_assignment(
     py_executor: ThreadPoolExecutor,
     num_partitions: int,
 ) -> None:
-    actors: list[CppActor | PyActor] = []
+    actors: list[CppActor | Awaitable[None]] = []
 
     num_rows = 200
     num_chunks = 3
@@ -231,7 +232,7 @@ def test_shuffler_object_interface(
     comm: Communicator,
     py_executor: ThreadPoolExecutor,
 ) -> None:
-    actors: list[CppActor | PyActor] = []
+    actors: list[CppActor | Awaitable[None]] = []
 
     num_partitions = 5
     num_rows = 100


### PR DESCRIPTION
Similar what was done in cudf_polars, https://github.com/rapidsai/cudf/pull/21858, now that Python 3.11 is the minimum version, it would be good to start running PyActors in an `asyncio.TaskGroup` to have the nice benefit of canceling other PyActor if one fails.

Once difference is that `asyncio.TaskGroup`s return `ExceptionGroup`s instead of regular `Exceptions` like

```python
  |   File "/conda/envs/rapidsmpf-dev/lib/python3.14/asyncio/taskgroups.py", line 174, in _aexit
  |     raise BaseExceptionGroup(
  |     ...<2 lines>...
  |     ) from None
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "rapidsmpf/streaming/core/actor.pyx", line 143, in _await_actor
    |     return await actor
    |     ^^^^^^^
    |   File "rapidsmpf/streaming/core/actor.pyx", line 105, in run
    |     return await coro
    |     
    |   File "/rapidsmpf/python/rapidsmpf/rapidsmpf/tests/streaming/test_exceptions.py", line 24, in task_that_throws
    |     raise RuntimeError("Throwing in task")
    | RuntimeError: Throwing in task
    +------------------------------------
```

which I think is OK as it provides a little more context about the exception.