### PR TITLE
Python bindings for `rrun.bind()`

### DIFF
--- a/cpp/include/rrun/rrun.hpp
+++ b/cpp/include/rrun/rrun.hpp
@@ -7,7 +7,9 @@
 
 #include <optional>
 
-#include <cucascade/memory/topology_discovery.hpp>
+namespace cucascade::memory {
+struct system_topology_info;
+}  // namespace cucascade::memory
 
 namespace rapidsmpf::rrun {
 

--- a/cpp/src/rrun/rrun.cpp
+++ b/cpp/src/rrun/rrun.cpp
@@ -18,6 +18,8 @@
 #include <numa.h>
 #endif
 
+#include <cucascade/memory/topology_discovery.hpp>
+
 #include <rrun/rrun.hpp>
 
 namespace rapidsmpf::rrun {

--- a/cpp/tools/rrun.cpp
+++ b/cpp/tools/rrun.cpp
@@ -37,6 +37,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <cucascade/memory/topology_discovery.hpp>
+
 #include <rrun/rrun.hpp>
 
 #ifdef RAPIDSMPF_HAVE_SLURM

--- a/python/rapidsmpf/rapidsmpf/CMakeLists.txt
+++ b/python/rapidsmpf/rapidsmpf/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory(coll)
 add_subdirectory(memory)
 add_subdirectory(communicator)
 add_subdirectory(integrations/cudf)
+add_subdirectory(rrun)
 add_subdirectory(utils)
 
 if(RAPIDSMPF_HAVE_STREAMING)

--- a/python/rapidsmpf/rapidsmpf/rrun/CMakeLists.txt
+++ b/python/rapidsmpf/rapidsmpf/rrun/CMakeLists.txt
@@ -1,0 +1,14 @@
+# =================================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =================================================================================
+
+set(cython_modules rrun.pyx)
+
+rapids_cython_create_modules(
+  CXX
+  SOURCE_FILES "${cython_modules}"
+  LINKED_LIBRARIES rapidsmpf::rapidsmpf maybe_asan
+)

--- a/python/rapidsmpf/rapidsmpf/rrun/__init__.pxd
+++ b/python/rapidsmpf/rapidsmpf/rrun/__init__.pxd
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0

--- a/python/rapidsmpf/rapidsmpf/rrun/__init__.py
+++ b/python/rapidsmpf/rapidsmpf/rrun/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Resource binding utilities from the rrun launcher."""
+
+from __future__ import annotations
+
+from rapidsmpf.rrun.rrun import bind
+
+__all__ = [
+    "bind",
+]

--- a/python/rapidsmpf/rapidsmpf/rrun/rrun.pyi
+++ b/python/rapidsmpf/rapidsmpf/rrun/rrun.pyi
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+def bind(
+    gpu_id: int | None = None,
+    *,
+    cpu: bool = True,
+    memory: bool = True,
+    network: bool = True,
+    verbose: bool = False,
+) -> None: ...

--- a/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
+++ b/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
@@ -34,6 +34,14 @@ def bind(
     Discovers the system topology, then applies CPU affinity, NUMA memory
     binding, and/or network device configuration as requested.
 
+    .. warning::
+        This function is **not thread-safe**. It temporarily modifies the
+        ``CUDA_VISIBLE_DEVICES`` environment variable during topology
+        discovery and mutates process-wide state (CPU affinity, NUMA memory
+        policy, and the ``UCX_NET_DEVICES`` environment variable). It should
+        be called exactly once per process, ideally early in initialization
+        and before other threads are spawned.
+
     GPU resolution order:
 
     1. Use *gpu_id* if provided.

--- a/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
+++ b/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from libcpp cimport bool as cbool
+from libcpp.optional cimport optional
+
+from rapidsmpf._detail.exception_handling cimport ex_handler
+
+
+cdef extern from "<rrun/rrun.hpp>" namespace "rapidsmpf::rrun" nogil:
+    cdef cppclass cpp_bind_options "rapidsmpf::rrun::bind_options":
+        cbool cpu
+        cbool memory
+        cbool network
+        cbool verbose
+
+    void cpp_bind "rapidsmpf::rrun::bind"(
+        optional[unsigned int] gpu_id,
+        const cpp_bind_options& options,
+    ) except +ex_handler
+
+
+def bind(
+    gpu_id=None,
+    *,
+    cpu=True,
+    memory=True,
+    network=True,
+    verbose=False,
+):
+    """
+    Bind the calling process to resources topologically close to a GPU.
+
+    Discovers the system topology, then applies CPU affinity, NUMA memory
+    binding, and/or network device configuration as requested.
+
+    GPU resolution order:
+
+    1. Use *gpu_id* if provided.
+    2. Otherwise, parse the first entry of the ``CUDA_VISIBLE_DEVICES``
+       environment variable.
+    3. If neither is available, raise :class:`RuntimeError`.
+
+    Parameters
+    ----------
+    gpu_id : int or None
+        Physical GPU device index (as reported by ``nvidia-smi``).
+        When ``None``, the first GPU in ``CUDA_VISIBLE_DEVICES`` is used.
+    cpu : bool
+        Set CPU affinity to cores near the GPU (default ``True``).
+    memory : bool
+        Set NUMA memory policy to nodes near the GPU (default ``True``).
+    network : bool
+        Set ``UCX_NET_DEVICES`` to NICs near the GPU (default ``True``).
+    verbose : bool
+        Print warnings to stderr on binding failures (default ``False``).
+
+    Raises
+    ------
+    RuntimeError
+        If no GPU ID can be determined or the resolved GPU is not found
+        in the discovered topology.
+    """
+    cdef optional[unsigned int] c_gpu_id
+    if gpu_id is not None:
+        c_gpu_id = <unsigned int>gpu_id
+
+    cdef cpp_bind_options opts
+    opts.cpu = cpu
+    opts.memory = memory
+    opts.network = network
+    opts.verbose = verbose
+
+    with nogil:
+        cpp_bind(c_gpu_id, opts)

--- a/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
+++ b/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
@@ -75,16 +75,16 @@ def bind(
 
     Parameters
     ----------
-    gpu_id : int or None
+    gpu_id
         Physical GPU device index (as reported by ``nvidia-smi``).
         When ``None``, the first GPU in ``CUDA_VISIBLE_DEVICES`` is used.
-    cpu : bool
+    cpu
         Set CPU affinity to cores near the GPU (default ``True``).
-    memory : bool
+    memory
         Set NUMA memory policy to nodes near the GPU (default ``True``).
-    network : bool
+    network
         Set ``UCX_NET_DEVICES`` to NICs near the GPU (default ``True``).
-    verbose : bool
+    verbose
         Print warnings to stderr on binding failures (default ``False``).
 
     Raises

--- a/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
+++ b/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
@@ -68,7 +68,7 @@ def bind(
 
     GPU resolution order:
 
-    1. Use *gpu_id* if provided.
+    1. Use ``gpu_id`` if provided.
     2. Otherwise, parse the first entry of the ``CUDA_VISIBLE_DEVICES``
        environment variable.
     3. If neither is available, raise :class:`RuntimeError`.

--- a/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
+++ b/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
+from libc.stdlib cimport getenv as c_getenv
 from libcpp cimport bool as cbool
 from libcpp.optional cimport optional
 
@@ -18,6 +21,27 @@ cdef extern from "<rrun/rrun.hpp>" namespace "rapidsmpf::rrun" nogil:
         optional[unsigned int] gpu_id,
         const cpp_bind_options& options,
     ) except +ex_handler
+
+
+# Environment variables that bind() may modify via C setenv().
+_ENV_VARS_MODIFIED_BY_BIND = ("UCX_NET_DEVICES", "CUDA_VISIBLE_DEVICES")
+
+
+cdef _sync_c_env_to_python():
+    """Propagate C-level environment changes made by bind() into os.environ.
+
+    The C++ bind() implementation uses setenv()/unsetenv() which modify the C
+    environment directly.  Python's os.environ is a cached dict that is only
+    updated when Python code writes to it, so we must manually synchronize the
+    variables that bind() may have touched.
+    """
+    cdef const char* val
+    for name in _ENV_VARS_MODIFIED_BY_BIND:
+        val = c_getenv(name.encode())
+        if val != NULL:
+            os.environ[name] = val.decode()
+        else:
+            os.environ.pop(name, None)
 
 
 def bind(
@@ -81,3 +105,4 @@ def bind(
 
     with nogil:
         cpp_bind(c_gpu_id, opts)
+    _sync_c_env_to_python()

--- a/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
+++ b/python/rapidsmpf/rapidsmpf/rrun/rrun.pyx
@@ -92,9 +92,15 @@ def bind(
     RuntimeError
         If no GPU ID can be determined or the resolved GPU is not found
         in the discovered topology.
+    ValueError
+        If ``gpu_id`` is not a non-negative integer.
     """
     cdef optional[unsigned int] c_gpu_id
     if gpu_id is not None:
+        if not isinstance(gpu_id, int) or gpu_id < 0:
+            raise ValueError(
+                f"gpu_id must be a non-negative integer, got {gpu_id!r}"
+            )
         c_gpu_id = <unsigned int>gpu_id
 
     cdef cpp_bind_options opts

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -51,7 +51,7 @@ def _run_in_subprocess(target: Callable[[], None]) -> None:
         proc.kill()
         proc.join()
         raise RuntimeError("Subprocess timed out after 30 seconds")
-        
+
     if parent_conn.poll():
         exc = parent_conn.recv()
         if exc is not None:

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -2,91 +2,131 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import multiprocessing
 import os
+import traceback
+from typing import TYPE_CHECKING
 
 import pytest
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 from rapidsmpf.rrun import bind
+
+
+def _run_in_subprocess(target: Callable[[], None]) -> None:
+    """Execute *target()* in a forked child process.
+
+    Because each call forks a new child, process-wide side-effects
+    (CPU affinity, NUMA policy, environment variables) never leak into the
+    pytest process.  Any exception raised by *target* is propagated back to
+    the caller.
+    """
+    ctx = multiprocessing.get_context("fork")
+    parent_conn, child_conn = ctx.Pipe()
+
+    def _wrapper() -> None:
+        try:
+            target()
+            child_conn.send(None)
+        except BaseException as exc:
+            try:
+                child_conn.send(exc)
+            except Exception:
+                child_conn.send(
+                    RuntimeError(
+                        f"{type(exc).__name__}: {exc}\n"
+                        f"{''.join(traceback.format_tb(exc.__traceback__))}"
+                    )
+                )
+        finally:
+            child_conn.close()
+
+    proc = ctx.Process(target=_wrapper)
+    proc.start()
+    proc.join(timeout=30)
+
+    if parent_conn.poll():
+        exc = parent_conn.recv()
+        if exc is not None:
+            raise exc
+
+    if proc.exitcode != 0:
+        raise RuntimeError(f"Subprocess exited with code {proc.exitcode}")
 
 
 class TestBindResolution:
     """GPU-ID resolution tests (no real binding side-effects)."""
 
     def test_explicit_gpu_id(self) -> None:
-        bind(gpu_id=0, cpu=False, memory=False, network=False)
+        def body() -> None:
+            bind(gpu_id=0, cpu=False, memory=False, network=False)
+
+        _run_in_subprocess(body)
 
     def test_cuda_visible_devices_fallback(self) -> None:
-        old = os.environ.get("CUDA_VISIBLE_DEVICES")
-        try:
+        def body() -> None:
             os.environ["CUDA_VISIBLE_DEVICES"] = "0"
             bind(cpu=False, memory=False, network=False)
-        finally:
-            if old is None:
-                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-            else:
-                os.environ["CUDA_VISIBLE_DEVICES"] = old
+
+        _run_in_subprocess(body)
 
     def test_no_gpu_id_raises(self) -> None:
-        old = os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-        try:
+        def body() -> None:
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
             with pytest.raises(RuntimeError, match="no GPU ID specified"):
                 bind(cpu=False, memory=False, network=False)
-        finally:
-            if old is not None:
-                os.environ["CUDA_VISIBLE_DEVICES"] = old
+
+        _run_in_subprocess(body)
 
     def test_invalid_cuda_visible_devices_raises(self) -> None:
-        old = os.environ.get("CUDA_VISIBLE_DEVICES")
-        try:
+        def body() -> None:
             os.environ["CUDA_VISIBLE_DEVICES"] = "GPU-abcdef12-3456"
             with pytest.raises(RuntimeError, match="not a valid GPU ID"):
                 bind(cpu=False, memory=False, network=False)
-        finally:
-            if old is None:
-                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-            else:
-                os.environ["CUDA_VISIBLE_DEVICES"] = old
+
+        _run_in_subprocess(body)
 
 
 class TestBindEffect:
     """Verify that bind() actually applies resource bindings."""
 
     def test_cpu_affinity_changes(self) -> None:
-        before = os.sched_getaffinity(0)
-        bind(gpu_id=0, cpu=True, memory=False, network=False)
-        after = os.sched_getaffinity(0)
-        # Binding should restrict the affinity (unless the system has only
-        # one NUMA domain and all cores are already assigned to GPU 0).
-        if len(before) > 1:
-            assert len(after) <= len(before), (
-                f"Expected affinity to narrow; before={before}, after={after}"
-            )
-        os.sched_setaffinity(0, before)
+        def body() -> None:
+            before = os.sched_getaffinity(0)
+            bind(gpu_id=0, cpu=True, memory=False, network=False)
+            after = os.sched_getaffinity(0)
+            if len(before) > 1:
+                assert len(after) <= len(before), (
+                    f"Expected affinity to narrow; before={before}, after={after}"
+                )
+
+        _run_in_subprocess(body)
 
     def test_cpu_binding_skipped_when_disabled(self) -> None:
-        before = os.sched_getaffinity(0)
-        bind(gpu_id=0, cpu=False, memory=False, network=False)
-        after = os.sched_getaffinity(0)
-        assert before == after
+        def body() -> None:
+            before = os.sched_getaffinity(0)
+            bind(gpu_id=0, cpu=False, memory=False, network=False)
+            after = os.sched_getaffinity(0)
+            assert before == after
+
+        _run_in_subprocess(body)
 
     def test_network_binding_sets_ucx_net_devices(self) -> None:
-        old = os.environ.pop("UCX_NET_DEVICES", None)
-        try:
+        def body() -> None:
+            os.environ.pop("UCX_NET_DEVICES", None)
             bind(gpu_id=0, cpu=False, memory=False, network=True)
             val = os.environ.get("UCX_NET_DEVICES")
             assert val is not None
             assert len(val) > 0
-        finally:
-            if old is None:
-                os.environ.pop("UCX_NET_DEVICES", None)
-            else:
-                os.environ["UCX_NET_DEVICES"] = old
+
+        _run_in_subprocess(body)
 
     def test_network_binding_skipped_when_disabled(self) -> None:
-        old = os.environ.pop("UCX_NET_DEVICES", None)
-        try:
+        def body() -> None:
+            os.environ.pop("UCX_NET_DEVICES", None)
             bind(gpu_id=0, cpu=False, memory=False, network=False)
             assert os.environ.get("UCX_NET_DEVICES") is None
-        finally:
-            if old is not None:
-                os.environ["UCX_NET_DEVICES"] = old
+
+        _run_in_subprocess(body)

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -2,26 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import ctypes
 import os
 
 import pytest
 
 from rapidsmpf.rrun import bind
-
-_libc = ctypes.CDLL(None, use_errno=True)
-_libc.getenv.restype = ctypes.c_char_p
-_libc.getenv.argtypes = [ctypes.c_char_p]
-
-
-def _c_getenv(name: str) -> str | None:
-    """Read an environment variable via C getenv().
-
-    Python's os.environ is a cached dict that does not reflect changes made by
-    C-level setenv() (e.g. from the C++ bind() implementation).
-    """
-    val = _libc.getenv(name.encode())
-    return val.decode() if val is not None else None
 
 
 class TestBindResolution:
@@ -85,24 +70,23 @@ class TestBindEffect:
         assert before == after
 
     def test_network_binding_sets_ucx_net_devices(self) -> None:
-        old = _c_getenv("UCX_NET_DEVICES")
+        old = os.environ.pop("UCX_NET_DEVICES", None)
         try:
             bind(gpu_id=0, cpu=False, memory=False, network=True)
-            val = _c_getenv("UCX_NET_DEVICES")
+            val = os.environ.get("UCX_NET_DEVICES")
             assert val is not None
             assert len(val) > 0
         finally:
             if old is None:
-                os.unsetenv("UCX_NET_DEVICES")
+                os.environ.pop("UCX_NET_DEVICES", None)
             else:
-                os.putenv("UCX_NET_DEVICES", old)
+                os.environ["UCX_NET_DEVICES"] = old
 
     def test_network_binding_skipped_when_disabled(self) -> None:
-        old = _c_getenv("UCX_NET_DEVICES")
-        os.unsetenv("UCX_NET_DEVICES")
+        old = os.environ.pop("UCX_NET_DEVICES", None)
         try:
             bind(gpu_id=0, cpu=False, memory=False, network=False)
-            assert _c_getenv("UCX_NET_DEVICES") is None
+            assert os.environ.get("UCX_NET_DEVICES") is None
         finally:
             if old is not None:
-                os.putenv("UCX_NET_DEVICES", old)
+                os.environ["UCX_NET_DEVICES"] = old

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -80,6 +80,20 @@ class TestBindResolution:
 
         _run_in_subprocess(body)
 
+    def test_negative_gpu_id_raises(self) -> None:
+        def body() -> None:
+            with pytest.raises(ValueError, match="non-negative integer"):
+                bind(gpu_id=-1, cpu=False, memory=False, network=False)
+
+        _run_in_subprocess(body)
+
+    def test_non_integer_gpu_id_raises(self) -> None:
+        def body() -> None:
+            with pytest.raises(ValueError, match="non-negative integer"):
+                bind(gpu_id="0", cpu=False, memory=False, network=False)  # type: ignore[arg-type]
+
+        _run_in_subprocess(body)
+
     def test_invalid_cuda_visible_devices_raises(self) -> None:
         def body() -> None:
             os.environ["CUDA_VISIBLE_DEVICES"] = "GPU-abcdef12-3456"

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -47,6 +47,11 @@ def _run_in_subprocess(target: Callable[[], None]) -> None:
     proc.start()
     proc.join(timeout=30)
 
+    if proc.is_alive():
+        proc.kill()
+        proc.join()
+        raise RuntimeError("Subprocess timed out after 30 seconds")
+        
     if parent_conn.poll():
         exc = parent_conn.recv()
         if exc is not None:

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import ctypes
+import os
+
+import pytest
+
+from rapidsmpf.rrun import bind
+
+_libc = ctypes.CDLL(None, use_errno=True)
+_libc.getenv.restype = ctypes.c_char_p
+_libc.getenv.argtypes = [ctypes.c_char_p]
+
+
+def _c_getenv(name: str) -> str | None:
+    """Read an environment variable via C getenv().
+
+    Python's os.environ is a cached dict that does not reflect changes made by
+    C-level setenv() (e.g. from the C++ bind() implementation).
+    """
+    val = _libc.getenv(name.encode())
+    return val.decode() if val is not None else None
+
+
+class TestBindResolution:
+    """GPU-ID resolution tests (no real binding side-effects)."""
+
+    def test_explicit_gpu_id(self) -> None:
+        bind(gpu_id=0, cpu=False, memory=False, network=False)
+
+    def test_cuda_visible_devices_fallback(self) -> None:
+        old = os.environ.get("CUDA_VISIBLE_DEVICES")
+        try:
+            os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+            bind(cpu=False, memory=False, network=False)
+        finally:
+            if old is None:
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            else:
+                os.environ["CUDA_VISIBLE_DEVICES"] = old
+
+    def test_no_gpu_id_raises(self) -> None:
+        old = os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        try:
+            with pytest.raises(RuntimeError, match="no GPU ID specified"):
+                bind(cpu=False, memory=False, network=False)
+        finally:
+            if old is not None:
+                os.environ["CUDA_VISIBLE_DEVICES"] = old
+
+    def test_invalid_cuda_visible_devices_raises(self) -> None:
+        old = os.environ.get("CUDA_VISIBLE_DEVICES")
+        try:
+            os.environ["CUDA_VISIBLE_DEVICES"] = "GPU-abcdef12-3456"
+            with pytest.raises(RuntimeError, match="not a valid GPU ID"):
+                bind(cpu=False, memory=False, network=False)
+        finally:
+            if old is None:
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            else:
+                os.environ["CUDA_VISIBLE_DEVICES"] = old
+
+
+class TestBindEffect:
+    """Verify that bind() actually applies resource bindings."""
+
+    def test_cpu_affinity_changes(self) -> None:
+        before = os.sched_getaffinity(0)
+        bind(gpu_id=0, cpu=True, memory=False, network=False)
+        after = os.sched_getaffinity(0)
+        # Binding should restrict the affinity (unless the system has only
+        # one NUMA domain and all cores are already assigned to GPU 0).
+        if len(before) > 1:
+            assert len(after) <= len(before), (
+                f"Expected affinity to narrow; before={before}, after={after}"
+            )
+        os.sched_setaffinity(0, before)
+
+    def test_cpu_binding_skipped_when_disabled(self) -> None:
+        before = os.sched_getaffinity(0)
+        bind(gpu_id=0, cpu=False, memory=False, network=False)
+        after = os.sched_getaffinity(0)
+        assert before == after
+
+    def test_network_binding_sets_ucx_net_devices(self) -> None:
+        old = _c_getenv("UCX_NET_DEVICES")
+        try:
+            bind(gpu_id=0, cpu=False, memory=False, network=True)
+            val = _c_getenv("UCX_NET_DEVICES")
+            assert val is not None
+            assert len(val) > 0
+        finally:
+            if old is None:
+                os.unsetenv("UCX_NET_DEVICES")
+            else:
+                os.putenv("UCX_NET_DEVICES", old)
+
+    def test_network_binding_skipped_when_disabled(self) -> None:
+        old = _c_getenv("UCX_NET_DEVICES")
+        os.unsetenv("UCX_NET_DEVICES")
+        try:
+            bind(gpu_id=0, cpu=False, memory=False, network=False)
+            assert _c_getenv("UCX_NET_DEVICES") is None
+        finally:
+            if old is not None:
+                os.putenv("UCX_NET_DEVICES", old)

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -138,8 +138,11 @@ class TestBindEffect:
             os.environ.pop("UCX_NET_DEVICES", None)
             bind(gpu_id=0, cpu=False, memory=False, network=True)
             val = os.environ.get("UCX_NET_DEVICES")
-            assert val is not None
-            assert len(val) > 0
+            # On systems without topology-adjacent NICs (e.g. CI without
+            # mlx5 devices) bind() legitimately leaves UCX_NET_DEVICES
+            # unset.  We only assert the value is non-empty when present.
+            if val is not None:
+                assert len(val) > 0
 
         _run_in_subprocess(body)
 

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -16,11 +16,11 @@ from rapidsmpf.rrun import bind
 
 
 def _run_in_subprocess(target: Callable[[], None]) -> None:
-    """Execute *target()* in a forked child process.
+    """Execute ``target()`` in a forked child process.
 
     Because each call forks a new child, process-wide side-effects
     (CPU affinity, NUMA policy, environment variables) never leak into the
-    pytest process.  Any exception raised by *target* is propagated back to
+    pytest process. Any exception raised by ``target`` is propagated back to
     the caller.
     """
     ctx = multiprocessing.get_context("fork")
@@ -57,7 +57,7 @@ def _run_in_subprocess(target: Callable[[], None]) -> None:
 
 
 class TestBindResolution:
-    """GPU-ID resolution tests (no real binding side-effects)."""
+    """GPU-ID resolution tests."""
 
     def test_explicit_gpu_id(self) -> None:
         def body() -> None:
@@ -90,7 +90,15 @@ class TestBindResolution:
 
 
 class TestBindEffect:
-    """Verify that bind() actually applies resource bindings."""
+    """Verify that bind() actually applies resource bindings.
+
+    Because ``cucascade::memory::topology_discovery`` is not currently exposed
+    to Python, the expected binding values (CPU cores, NUMA nodes, network
+    devices) cannot be obtained from Python directly.  Tests here therefore
+    perform basic smoke checks -- verifying that the call succeeds and that
+    observable process state changes in the expected direction -- rather than
+    asserting exact topology-derived values.
+    """
 
     def test_cpu_affinity_changes(self) -> None:
         def body() -> None:
@@ -110,6 +118,18 @@ class TestBindEffect:
             bind(gpu_id=0, cpu=False, memory=False, network=False)
             after = os.sched_getaffinity(0)
             assert before == after
+
+        _run_in_subprocess(body)
+
+    def test_memory_binding_succeeds(self) -> None:
+        def body() -> None:
+            bind(gpu_id=0, cpu=False, memory=True, network=False)
+
+        _run_in_subprocess(body)
+
+    def test_memory_binding_skipped_when_disabled(self) -> None:
+        def body() -> None:
+            bind(gpu_id=0, cpu=False, memory=False, network=False)
 
         _run_in_subprocess(body)
 


### PR DESCRIPTION
Add Python bindings for resource binding directly from a Python application (e.g., Dask or Ray worker). Since `TopologyDiscovery` is not exposed to Python at this time only basic smoke testing is included.