### PR TITLE
Switch to `std::string_view` where possible in `Backend`

### DIFF
--- a/cpp/include/rapidsmpf/bootstrap/backend.hpp
+++ b/cpp/include/rapidsmpf/bootstrap/backend.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 
 #include <rapidsmpf/bootstrap/types.hpp>
 
@@ -78,7 +79,7 @@ class Backend {
      *
      * @throws std::runtime_error if called by non-zero rank.
      */
-    virtual void put(std::string const& key, std::string const& value) = 0;
+    virtual void put(std::string const& key, std::string_view value) = 0;
 
     /**
      * @brief Retrieve a value, blocking until available or timeout occurs.

--- a/cpp/include/rapidsmpf/bootstrap/bootstrap.hpp
+++ b/cpp/include/rapidsmpf/bootstrap/bootstrap.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include <rapidsmpf/bootstrap/backend.hpp>
 #include <rapidsmpf/bootstrap/types.hpp>
@@ -96,7 +97,7 @@ void sync(Context const& ctx);
  *
  * @throws std::runtime_error if called by non-zero rank.
  */
-void put(Context const& ctx, std::string const& key, std::string const& value);
+void put(Context const& ctx, std::string const& key, std::string_view value);
 
 /**
  * @brief Retrieve a value from the coordination backend.

--- a/cpp/include/rapidsmpf/bootstrap/file_backend.hpp
+++ b/cpp/include/rapidsmpf/bootstrap/file_backend.hpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <string>
+#include <string_view>
 
 #include <rapidsmpf/bootstrap/backend.hpp>
 #include <rapidsmpf/bootstrap/bootstrap.hpp>
@@ -44,7 +45,7 @@ class FileBackend : public Backend {
     /**
      * @copydoc Backend::put
      */
-    void put(std::string const& key, std::string const& value) override;
+    void put(std::string const& key, std::string_view value) override;
 
     /**
      * @copydoc Backend::get
@@ -106,7 +107,7 @@ class FileBackend : public Backend {
      * @param path Path to file.
      * @param content Content to write.
      */
-    void write_file(std::string const& path, std::string const& content);
+    void write_file(std::string const& path, std::string_view content);
 
     /**
      * @brief Read string from file.

--- a/cpp/include/rapidsmpf/bootstrap/slurm_backend.hpp
+++ b/cpp/include/rapidsmpf/bootstrap/slurm_backend.hpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <chrono>
 #include <string>
+#include <string_view>
 
 #include <pmix.h>
 
@@ -70,7 +71,7 @@ class SlurmBackend : public Backend {
      *
      * @throws std::runtime_error if PMIx operation fails.
      */
-    void put(std::string const& key, std::string const& value) override;
+    void put(std::string const& key, std::string_view value) override;
 
     /**
      * @copydoc Backend::get()

--- a/cpp/src/bootstrap/bootstrap.cpp
+++ b/cpp/src/bootstrap/bootstrap.cpp
@@ -184,7 +184,7 @@ void sync(Context const& ctx) {
     ctx.backend->sync();
 }
 
-void put(Context const& ctx, std::string const& key, std::string const& value) {
+void put(Context const& ctx, std::string const& key, std::string_view value) {
     if (!ctx.backend) {
         throw std::runtime_error("Context not properly initialized - backend is null");
     }

--- a/cpp/src/bootstrap/file_backend.cpp
+++ b/cpp/src/bootstrap/file_backend.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 #include <system_error>
 #include <thread>
 
@@ -63,7 +64,7 @@ FileBackend::~FileBackend() {
     cleanup_coordination_directory();
 }
 
-void FileBackend::put(std::string const& key, std::string const& value) {
+void FileBackend::put(std::string const& key, std::string_view value) {
     if (ctx_.rank != 0) {
         throw std::runtime_error(
             "put() can only be called by rank 0, but was called by rank "
@@ -191,7 +192,7 @@ bool FileBackend::wait_for_file(std::string const& path, Duration timeout) {
     }
 }
 
-void FileBackend::write_file(std::string const& path, std::string const& content) {
+void FileBackend::write_file(std::string const& path, std::string_view content) {
     std::string tmp_path = path + ".tmp." + std::to_string(getpid());
 
     // Write to temporary file
@@ -199,7 +200,7 @@ void FileBackend::write_file(std::string const& path, std::string const& content
     if (!ofs) {
         throw std::runtime_error("Failed to open temporary file: " + tmp_path);
     }
-    ofs << content;
+    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
     ofs.close();
 
     // Atomic rename

--- a/cpp/src/bootstrap/slurm_backend.cpp
+++ b/cpp/src/bootstrap/slurm_backend.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <cstring>
 #include <stdexcept>
+#include <string_view>
 #include <thread>
 #include <utility>
 
@@ -125,7 +126,7 @@ SlurmBackend::~SlurmBackend() {
     PMIx_Finalize(nullptr, 0);
 }
 
-void SlurmBackend::put(std::string const& key, std::string const& value) {
+void SlurmBackend::put(std::string const& key, std::string_view value) {
     if (ctx_.rank != 0) {
         throw std::runtime_error(
             "put() can only be called by rank 0, but was called by rank "

--- a/cpp/src/bootstrap/ucxx.cpp
+++ b/cpp/src/bootstrap/ucxx.cpp
@@ -44,11 +44,10 @@ std::shared_ptr<ucxx::UCXX> create_ucxx_comm(
         );
 
         auto listener_address = comm->listener_address();
-        auto root_worker_address_str =
+        put(ctx,
+            "ucxx_root_address",
             std::get<std::shared_ptr<::ucxx::Address>>(listener_address.address)
-                ->getString();
-
-        put(ctx, "ucxx_root_address", root_worker_address_str);
+                ->getString());
         sync(ctx);
     } else {
         // Non-root ranks: Retrieve root address via get() and connect.


### PR DESCRIPTION
Use a more appropriate `std::string_view` for operations that only read from the string passed as an argument in `Backend`.