### PR TITLE
Move away from deprecated `ucxx::Address::getString()`

### DIFF
--- a/cpp/src/bootstrap/ucxx.cpp
+++ b/cpp/src/bootstrap/ucxx.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<ucxx::UCXX> create_ucxx_comm(
         put(ctx,
             "ucxx_root_address",
             std::get<std::shared_ptr<::ucxx::Address>>(listener_address.address)
-                ->getString());
+                ->getStringView());
         sync(ctx);
     } else {
         // Non-root ranks: Retrieve root address via get() and connect.

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -629,7 +629,9 @@ void listener_address_pack_into(
                 auto address_size = remote_address->getLength();
                 encode(dest, &type, sizeof(type), offset);
                 encode(dest, &address_size, sizeof(address_size), offset);
-                encode(dest, remote_address->getString().data(), address_size, offset);
+                encode(
+                    dest, remote_address->getStringView().data(), address_size, offset
+                );
                 encode(
                     dest, &listener_address.rank, sizeof(listener_address.rank), offset
                 );

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<UCXX> init_using_mpi(
         root_listener_address = comm->listener_address();
         root_worker_address_str =
             std::get<std::shared_ptr<::ucxx::Address>>(root_listener_address.address)
-                ->getString();
+                ->getStringView();
     }
     broadcast_listener_address(mpi_comm, root_worker_address_str);
 

--- a/python/rapidsmpf/rapidsmpf/communicator/ucxx.pyx
+++ b/python/rapidsmpf/rapidsmpf/communicator/ucxx.pyx
@@ -169,7 +169,7 @@ def get_root_ucxx_address(Communicator comm not None):
 
     if address := get_if[shared_ptr[Address]](&listener_address.address):
         # Dereference twice: first the `get_if` result, then `shared_ptr`
-        return bytes(deref(deref(address)).getString())
+        return bytes(deref(deref(address)).getStringView())
     elif host_port_pair := get_if[HostPortPair](&listener_address.address):
         raise NotImplementedError("Accepting HostPortPair is not implemented yet")
         assert host_port_pair  # Prevent "defined but unused" error


### PR DESCRIPTION
Use the new `ucxx::Address::getStringView()` and remove the deprecated use of `ucxx::Address::getString()` that are treated as errors in RapidsMPF.