### PR TITLE
Accept & work with `std::string_view` in `ucxx_utils.cpp`

### DIFF
--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -31,7 +31,9 @@ namespace {
  * @param listener_address object containing the listener address of the root,
  * which will be read from in rank 0 and stored to in all other ranks.
  */
-void broadcast_listener_address(MPI_Comm mpi_comm, std::string_view root_worker_address_str) {
+void broadcast_listener_address(
+    MPI_Comm mpi_comm, std::string_view root_worker_address_str
+) {
     std::size_t address_size{root_worker_address_str.size()};
 
     RAPIDSMPF_MPI(

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -40,9 +40,13 @@ void broadcast_listener_address(
         MPI_Bcast(&address_size, sizeof(address_size), MPI_UINT8_T, 0, mpi_comm)
     );
 
-    RAPIDSMPF_MPI(
-        MPI_Bcast(reinterpret_cast<void*>(root_worker_address_str.data()), address_size, MPI_UINT8_T, 0, mpi_comm)
-    );
+    RAPIDSMPF_MPI(MPI_Bcast(
+        reinterpret_cast<void*>(root_worker_address_str.data()),
+        address_size,
+        MPI_UINT8_T,
+        0,
+        mpi_comm
+    ));
 }
 
 }  // namespace

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -41,7 +41,7 @@ void broadcast_listener_address(
     );
 
     RAPIDSMPF_MPI(MPI_Bcast(
-        reinterpret_cast<void*>(root_worker_address_str.data()),
+        const_cast<char*>(root_worker_address_str.data()),
         address_size,
         MPI_UINT8_T,
         0,

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -41,7 +41,7 @@ void broadcast_listener_address(
     );
 
     RAPIDSMPF_MPI(
-        MPI_Bcast(root_worker_address_str.data(), address_size, MPI_UINT8_T, 0, mpi_comm)
+        MPI_Bcast(reinterpret_cast<void*>(root_worker_address_str.data()), address_size, MPI_UINT8_T, 0, mpi_comm)
     );
 }
 

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
 #include <cuda_device_runtime_api.h>
 #include <ucxx/listener.h>
 

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -40,8 +40,6 @@ void broadcast_listener_address(
         MPI_Bcast(&address_size, sizeof(address_size), MPI_UINT8_T, 0, mpi_comm)
     );
 
-    root_worker_address_str.resize(address_size);
-
     RAPIDSMPF_MPI(
         MPI_Bcast(root_worker_address_str.data(), address_size, MPI_UINT8_T, 0, mpi_comm)
     );

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <cuda_device_runtime_api.h>
@@ -31,7 +32,7 @@ namespace {
  * @param listener_address object containing the listener address of the root,
  * which will be read from in rank 0 and stored to in all other ranks.
  */
-void broadcast_listener_address(MPI_Comm mpi_comm, std::string& root_worker_address_str) {
+void broadcast_listener_address(MPI_Comm mpi_comm, std::string_view root_worker_address_str) {
     std::size_t address_size{root_worker_address_str.size()};
 
     RAPIDSMPF_MPI(

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <string>
 #include <string_view>
 #include <utility>
 
@@ -63,7 +62,7 @@ std::shared_ptr<UCXX> init_using_mpi(
     RAPIDSMPF_MPI(MPI_Comm_size(mpi_comm, &nranks));
 
     auto root_listener_address = ListenerAddress{.rank = 0};
-    std::string root_worker_address_str{};
+    std::string_view root_worker_address_str{};
     std::shared_ptr<UCXX> comm;
     if (rank == 0) {
         auto ucxx_initialized_rank = init(nullptr, nranks, std::nullopt, options);

--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<UCXX> init_using_mpi(
     RAPIDSMPF_MPI(MPI_Comm_size(mpi_comm, &nranks));
 
     auto root_listener_address = ListenerAddress{.rank = 0};
-    std::string_view root_worker_address_str{};
+    std::string_view root_worker_address_str{""};
     std::shared_ptr<UCXX> comm;
     if (rank == 0) {
         auto ucxx_initialized_rank = init(nullptr, nranks, std::nullopt, options);


### PR DESCRIPTION
Updates `ucxx_utils.cpp` to accept any `std::string_view` supporting type in `broadcast_listener_address`. Also now that `init_using_mpi`'s `root_worker_address_str` is assigned a value from `getStringView`, its type needs to match `std::string_view` (or a copy to `std::string` would be needed). Go ahead and align the type given anywhere `root_worker_address_str` is used a `std::string_view` is accepted. Lastly ensure C++ standard library `#include`s are added to cover the types used in `ucxx_utils.cpp`.