### PR TITLE
Convert `ucx_utils` `std::string_view` to `std::string`

### DIFF
--- a/cpp/src/communicator/ucxx_utils.cpp
+++ b/cpp/src/communicator/ucxx_utils.cpp
@@ -65,9 +65,10 @@ std::shared_ptr<UCXX> init_using_mpi(
         );
 
         root_listener_address = comm->listener_address();
-        root_worker_address_str =
+        root_worker_address_str = std::string{
             std::get<std::shared_ptr<::ucxx::Address>>(root_listener_address.address)
-                ->getStringView();
+                ->getStringView()
+        };
     }
     broadcast_listener_address(mpi_comm, root_worker_address_str);
 


### PR DESCRIPTION
Recently the use of `getString` here was changed to `getStringView` ( https://github.com/rapidsai/rapidsmpf/pull/953 ). However the return type would also change from `std::string` to `std::string_view`. Given `root_worker_address_str` is `std::string` and conversion from `std::string_view` to `std::string` needs to be done explicitly, this explicitly converts the result of `getStringView` to `std::string`.