### PR TITLE
Implement a sparse alltoall exchange pattern

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -227,6 +227,7 @@ if(RAPIDSMPF_HAVE_STREAMING)
             src/streaming/coll/allgather.cpp
             src/streaming/coll/allreduce.cpp
             src/streaming/coll/shuffler.cpp
+            src/streaming/coll/sparse_alltoall.cpp
             src/streaming/core/actor.cpp
             src/streaming/core/channel.cpp
             src/streaming/core/context.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -182,6 +182,7 @@ add_library(
   rapidsmpf
   src/coll/allgather.cpp
   src/coll/allreduce.cpp
+  src/coll/sparse_alltoall.cpp
   src/coll/utils.cpp
   src/bootstrap/bootstrap.cpp
   src/bootstrap/file_backend.cpp

--- a/cpp/benchmarks/bench_partition.cpp
+++ b/cpp/benchmarks/bench_partition.cpp
@@ -71,7 +71,7 @@ static void BM_PartitionAndPack(benchmark::State& state) {
     for (auto _ : state) {
         auto pack_partitions = rapidsmpf::partition_and_pack(
             *table,
-            std::move(columns_to_hash),
+            columns_to_hash,
             num_partitions,
             cudf::hash_id::HASH_MURMUR3,
             cudf::DEFAULT_HASH_SEED,
@@ -123,7 +123,7 @@ static void BM_PartitionAndPackCurrentImpl(benchmark::State& state) {
         for (int i = 0; i < num_partitions; i++) {
             auto pack_partitions = rapidsmpf::partition_and_pack(
                 *table,
-                std::move(columns_to_hash),
+                columns_to_hash,
                 total_npartitions,
                 cudf::hash_id::HASH_MURMUR3,
                 cudf::DEFAULT_HASH_SEED,

--- a/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
+++ b/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include <rapidsmpf/coll/utils.hpp>
+#include <rapidsmpf/communicator/communicator.hpp>
+#include <rapidsmpf/memory/buffer_resource.hpp>
+#include <rapidsmpf/memory/packed_data.hpp>
+#include <rapidsmpf/progress_thread.hpp>
+
+namespace rapidsmpf::coll {
+
+/**
+ * @brief Sparse all-to-all collective over explicit source and destination peer sets.
+ *
+ * Each rank may send zero or more messages to ranks listed in `dsts` and
+ * receives zero or more messages from ranks listed in `srcs`. Sender order is defined by
+ * the local order of calls to `insert(dst, ...)` for each destination rank.
+ *
+ * This object is logically collective over the communicator and identified by `op_id`.
+ * Local extraction is only valid after `wait()` has completed.
+ */
+class SparseAlltoall {
+  public:
+    /**
+     * @brief Construct a sparse all-to-all collective instance.
+     *
+     * @param comm Communicator for the collective.
+     * @param op_id Collective operation identifier.
+     * @param br Buffer resource used for allocations.
+     * @param srcs Ranks this rank will receive from.
+     * @param dsts Ranks this rank will send to.
+     * @param finished_callback Optional callback invoked exactly once when the collective
+     * is locally complete. The callback should be fast and non-blocking. Ideally it
+     * should only be used to signal a thread to do the actual work of extraction. Note in
+     * particular that the callback should not extract any data.
+     *
+     * @note It is safe to reuse the `op_id` as soon as `wait` has completed
+     * locally or the `finished_callback` has been invoked.
+     *
+     * @note The caller promises that inserted buffers are stream-ordered with respect
+     * to their own stream, and extracted buffers are likewise guaranteed to be stream-
+     * ordered with respect to their own stream.
+     *
+     * @note Collectively the src and dst pairs of participating ranks must be consistent
+     * (not checked for). That is if rank-A advertises that rank-B is in its dst set,
+     * rank-B must advertise that rank-A is in its src set. If we ever need to relax this
+     * restriction we could have each rank advertise its send set and bootstrap the
+     * two-sided information using the non-blocking consensus algorithm of Hoefler,
+     * Siebert, and Lumsdaine, ACM SIGPLAN (2010),
+     * https://dl.acm.org/doi/10.1145/1837853.1693476.
+     */
+    SparseAlltoall(
+        std::shared_ptr<Communicator> comm,
+        OpID op_id,
+        BufferResource* br,
+        std::vector<Rank> srcs,
+        std::vector<Rank> dsts,
+        std::function<void()>&& finished_callback = nullptr
+    );
+
+    ~SparseAlltoall() noexcept;
+
+    SparseAlltoall(SparseAlltoall const&) = delete;
+    SparseAlltoall& operator=(SparseAlltoall const&) = delete;
+    SparseAlltoall(SparseAlltoall&&) = delete;
+    SparseAlltoall& operator=(SparseAlltoall&&) = delete;
+
+    /**
+     * @brief Gets the communicator associated with this SparseAlltoall.
+     *
+     * @return Shared pointer to communicator.
+     */
+    [[nodiscard]] std::shared_ptr<Communicator> const& comm() const noexcept;
+
+    /**
+     * @brief Insert data to send to a destination rank.
+     *
+     * The order the destination rank obtains the sent data is given by the insertion
+     * order on the send side. If inserting concurrently to the same destination, the
+     * caller must establish a total order of the insertions, otherwise the reconstruction
+     * order on the receive side is unspecified.
+     *
+     * @note Concurrent insertion by multiple threads is supported, the caller must ensure
+     * that `insert_finished()` is called _after_ all `insert()` calls have completed.
+     *
+     * @param dst Destination rank. Must be present in the constructor's `dsts`.
+     * @param packed_data Packed payload and metadata to send.
+     */
+    void insert(Rank dst, PackedData&& packed_data);
+
+    /**
+     * @brief Indicate that no more data will be inserted for any destination.
+     *
+     * Must be called exactly once.
+     *
+     * @note If multiple threads are `insert()`ing, you must establish a happens-before
+     * relationship between the completion of all `insert()`s and the final call to
+     * `insert_finished()`.
+     */
+    void insert_finished();
+
+    /**
+     * @brief Wait for local completion.
+     *
+     * @param timeout Optional timeout. Negative values mean no timeout.
+     *
+     * @throws std::runtime_error If the timeout is reached.
+     */
+    void wait(std::chrono::milliseconds timeout = std::chrono::milliseconds{-1});
+
+    /**
+     * @brief Extract all received messages from a source rank.
+     *
+     * The returned vector is ordered by the sender's local insertion order.
+     *
+     * @param src Source rank. Must be present in the constructor's `srcs`.
+     * @return All messages received from `src`.
+     *
+     * @throws std::logic_error If extracting before the collective is complete.
+     */
+    [[nodiscard]] std::vector<PackedData> extract(Rank src);
+
+  private:
+    struct SourceState {
+        std::uint64_t expected_count{0};
+        std::uint64_t received_count{0};
+        std::vector<std::unique_ptr<detail::Chunk>> chunks;
+
+        [[nodiscard]] bool ready() const noexcept {
+            return expected_count > 0 && expected_count == received_count;
+        }
+    };
+
+    void send_ready_messages();
+    void receive_metadata_messages();
+    void receive_data_messages();
+    void complete_data_messages();
+    [[nodiscard]] bool containers_empty() const;
+    [[nodiscard]] ProgressThread::ProgressState event_loop();
+
+    std::shared_ptr<Communicator> comm_;
+    BufferResource* br_;
+    std::vector<Rank> srcs_;
+    std::vector<Rank> dsts_;
+    std::unordered_map<Rank, std::atomic<std::uint64_t>> next_ordinal_per_dst_;
+
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    OpID op_id_;
+    std::atomic<bool> locally_finished_{false};
+    bool can_extract_{false};
+
+    detail::PostBox outgoing_{};
+    std::unordered_map<Rank, std::vector<std::unique_ptr<detail::Chunk>>>
+        incoming_by_src_;
+    std::vector<std::unique_ptr<detail::Chunk>> receive_posted_;
+    std::vector<std::unique_ptr<Communicator::Future>> receive_futures_;
+    std::vector<std::unique_ptr<Communicator::Future>> fire_and_forget_;
+    std::unordered_map<Rank, SourceState> source_states_;
+    std::function<void()> finished_callback_;
+    ProgressThread::FunctionID function_id_;
+};
+
+}  // namespace rapidsmpf::coll

--- a/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
+++ b/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
@@ -93,8 +93,10 @@ class SparseAlltoall {
      * caller must establish a total order of the insertions, otherwise the reconstruction
      * order on the receive side is unspecified.
      *
-     * @note Concurrent insertion by multiple threads is supported, the caller must ensure
-     * that `insert_finished()` is called _after_ all `insert()` calls have completed.
+     * @note Concurrent insertion by multiple threads is supported.
+     *
+     * @note the caller must ensure that `insert_finished()` is called _after_ all
+     * `insert()` calls have completed.
      *
      * @param dst Destination rank. Must be present in the constructor's `dsts`.
      * @param packed_data Packed payload and metadata to send.
@@ -129,6 +131,9 @@ class SparseAlltoall {
      * @param src Source rank. Must be present in the constructor's `srcs`.
      * @return All messages received from `src`.
      *
+     * @note Concurrent extraction is supported, behaviour is undefined if two threads
+     * attempt to extract data from the same source.
+     *
      * @throws std::logic_error If extracting before the collective is complete.
      */
     [[nodiscard]] std::vector<PackedData> extract(Rank src);
@@ -144,11 +149,17 @@ class SparseAlltoall {
         }
     };
 
+    /// @brief Send all ready messages.
     void send_ready_messages();
+    /// @brief Post receives for any outstanding metadata messages.
     void receive_metadata_messages();
+    /// @brief Post receives for expected data messages.
     void receive_data_messages();
+    /// @brief Complete receives for data messages.
     void complete_data_messages();
+    /// @brief @return true if all internal containers are empty.
     [[nodiscard]] bool containers_empty() const;
+    /// @brief @return Progress the communication state and return the progress state.
     [[nodiscard]] ProgressThread::ProgressState event_loop();
 
     std::shared_ptr<Communicator> comm_;

--- a/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
+++ b/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
@@ -142,7 +142,8 @@ class SparseAlltoall {
     struct SourceState {
         std::uint64_t expected_count{0};
         std::uint64_t received_count{0};
-        std::vector<std::unique_ptr<detail::Chunk>> chunks;
+        std::vector<std::unique_ptr<detail::Chunk>> chunks{};
+        std::vector<std::unique_ptr<detail::Chunk>> incoming{};
 
         [[nodiscard]] bool ready() const noexcept {
             return expected_count > 0 && expected_count == received_count;
@@ -175,8 +176,6 @@ class SparseAlltoall {
     bool can_extract_{false};
 
     detail::PostBox outgoing_{};
-    std::unordered_map<Rank, std::vector<std::unique_ptr<detail::Chunk>>>
-        incoming_by_src_;
     std::vector<std::unique_ptr<detail::Chunk>> receive_posted_;
     std::vector<std::unique_ptr<Communicator::Future>> receive_futures_;
     std::vector<std::unique_ptr<Communicator::Future>> fire_and_forget_;

--- a/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
+++ b/cpp/include/rapidsmpf/coll/sparse_alltoall.hpp
@@ -47,6 +47,12 @@ class SparseAlltoall {
      * should only be used to signal a thread to do the actual work of extraction. Note in
      * particular that the callback should not extract any data.
      *
+     * @throws std::out_of_range If either `srcs` or `dsts` have invalid values. All
+     * source and destination ranks must be in `[0, ..., comm->nranks())`, and not equal
+     * to the current rank.
+     * @throws std::invalid_argument If the rank lists are not unique.
+     * @throws std::logic_error If the communicator or buffer resource pointers are null.
+     *
      * @note It is safe to reuse the `op_id` as soon as `wait` has completed
      * locally or the `finished_callback` has been invoked.
      *

--- a/cpp/include/rapidsmpf/streaming/coll/sparse_alltoall.hpp
+++ b/cpp/include/rapidsmpf/streaming/coll/sparse_alltoall.hpp
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <coro/event.hpp>
+#include <coro/task.hpp>
+
+#include <rapidsmpf/coll/sparse_alltoall.hpp>
+#include <rapidsmpf/communicator/communicator.hpp>
+#include <rapidsmpf/memory/packed_data.hpp>
+#include <rapidsmpf/streaming/core/context.hpp>
+
+namespace rapidsmpf::streaming {
+
+/**
+ * @brief Asynchronous (coroutine) interface to `coll::SparseAlltoall`.
+ *
+ * Many tasks may insert data concurrently. If multiple tasks insert data, the caller is
+ * responsible for arranging that `insert_finished()` is only called after all `insert()`
+ * operations have completed. Once `insert_finished()` is awaited, extraction is
+ * non-blocking.
+ */
+class SparseAlltoall {
+  public:
+    /**
+     * @brief Construct an asynchronous sparse all-to-all.
+     *
+     * @param ctx Streaming context.
+     * @param comm Communicator for the collective operation.
+     * @param op_id Unique identifier for the collective.
+     * @param srcs Ranks this rank expects to receive from.
+     * @param dsts Ranks this rank may send to.
+     */
+    SparseAlltoall(
+        std::shared_ptr<Context> ctx,
+        std::shared_ptr<Communicator> comm,
+        OpID op_id,
+        std::vector<Rank> srcs,
+        std::vector<Rank> dsts
+    );
+
+    SparseAlltoall(SparseAlltoall const&) = delete;
+    SparseAlltoall& operator=(SparseAlltoall const&) = delete;
+    SparseAlltoall(SparseAlltoall&&) = delete;
+    SparseAlltoall& operator=(SparseAlltoall&&) = delete;
+
+    ~SparseAlltoall() noexcept;
+
+    /**
+     * @brief Gets the streaming context associated with this object.
+     *
+     * @return Shared pointer to context.
+     */
+    [[nodiscard]] std::shared_ptr<Context> const& ctx() const noexcept;
+
+    /**
+     * @brief Gets the communicator associated with this SparseAlltoall.
+     *
+     * @return Shared pointer to communicator.
+     */
+    [[nodiscard]] std::shared_ptr<Communicator> const& comm() const noexcept;
+
+    /// @copydoc rapidsmpf::coll::SparseAlltoall::insert
+    void insert(Rank dst, PackedData&& packed_data);
+
+    /**
+     * @copydoc rapidsmpf::coll::SparseAlltoall::insert_finished
+     *
+     * @return Coroutine that completes once all data is ready for extraction.
+     */
+    [[nodiscard]] coro::task<void> insert_finished();
+
+    /// @copydoc rapidsmpf::coll::SparseAlltoall::extract
+    [[nodiscard]] std::vector<PackedData> extract(Rank src);
+
+  private:
+    coro::event
+        event_{};  ///< Event tracking whether all data has arrived and can be extracted.
+    std::shared_ptr<Context> ctx_;  ///< Streaming context.
+    coll::SparseAlltoall exchange_;  ///< Underlying sparse all-to-all.
+};
+
+}  // namespace rapidsmpf::streaming

--- a/cpp/src/coll/sparse_alltoall.cpp
+++ b/cpp/src/coll/sparse_alltoall.cpp
@@ -1,0 +1,261 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <rapidsmpf/coll/sparse_alltoall.hpp>
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/memory/buffer_resource.hpp>
+
+namespace rapidsmpf::coll {
+
+SparseAlltoall::SparseAlltoall(
+    std::shared_ptr<Communicator> comm,
+    OpID op_id,
+    BufferResource* br,
+    std::vector<Rank> srcs,
+    std::vector<Rank> dsts,
+    std::function<void()>&& finished_callback
+)
+    : comm_{std::move(comm)},
+      br_{br},
+      srcs_{std::move(srcs)},
+      dsts_{std::move(dsts)},
+      op_id_{op_id},
+      finished_callback_{std::move(finished_callback)} {
+    RAPIDSMPF_EXPECTS(comm_ != nullptr, "the communicator pointer cannot be null");
+    RAPIDSMPF_EXPECTS(br_ != nullptr, "the buffer resource pointer cannot be null");
+    auto const size = comm_->nranks();
+    auto const self = comm_->rank();
+    for (auto src : srcs_) {
+        RAPIDSMPF_EXPECTS(
+            src >= 0 && src < size && src != self, "SparseAlltoall invalid source rank."
+        );
+        RAPIDSMPF_EXPECTS(
+            incoming_by_src_.emplace(src, std::vector<std::unique_ptr<detail::Chunk>>{})
+                .second,
+            "SparseAlltoall source rank list must be unique"
+        );
+        source_states_.emplace(src, SourceState{});
+    }
+    for (auto dst : dsts_) {
+        RAPIDSMPF_EXPECTS(
+            dst >= 0 && dst < size && dst != self,
+            "SparseAlltoall invalid destination rank."
+        );
+        RAPIDSMPF_EXPECTS(
+            next_ordinal_per_dst_.emplace(dst, 0).second,
+            "SparseAlltoall destination rank list must be unique"
+        );
+    }
+    function_id_ =
+        comm_->progress_thread()->add_function([this]() { return event_loop(); });
+}
+
+SparseAlltoall::~SparseAlltoall() noexcept {
+    RAPIDSMPF_EXPECTS_FATAL(
+        locally_finished_.load(std::memory_order_acquire),
+        "Destroying SparseAlltoall without `insert_finished()`"
+    );
+    comm_->progress_thread()->remove_function(function_id_);
+}
+
+std::shared_ptr<Communicator> const& SparseAlltoall::comm() const noexcept {
+    return comm_;
+}
+
+void SparseAlltoall::insert(Rank dst, PackedData&& packed_data) {
+    RAPIDSMPF_EXPECTS(
+        !locally_finished_.load(std::memory_order_acquire),
+        "SparseAlltoall::insert cannot be called after insert_finished()"
+    );
+    auto ordinal_it = next_ordinal_per_dst_.find(dst);
+    RAPIDSMPF_EXPECTS(
+        ordinal_it != next_ordinal_per_dst_.end(),
+        "SparseAlltoall::insert destination is not a valid destination"
+    );
+    outgoing_.insert(
+        detail::Chunk::from_packed_data(
+            ordinal_it->second.fetch_add(1, std::memory_order_acq_rel),
+            comm_->rank(),
+            dst,
+            std::move(packed_data)
+        )
+    );
+}
+
+void SparseAlltoall::insert_finished() {
+    for (auto dst : dsts_) {
+        outgoing_.insert(
+            detail::Chunk::from_empty(
+                // Number of metadata messages we send to the destination rank, including
+                // this finish message.
+                next_ordinal_per_dst_.at(dst).load(std::memory_order_acquire) + 1,
+                comm_->rank(),
+                dst
+            )
+        );
+    }
+    locally_finished_.store(true, std::memory_order_release);
+}
+
+void SparseAlltoall::wait(std::chrono::milliseconds timeout) {
+    std::unique_lock lock(mutex_);
+    if (timeout < std::chrono::milliseconds{0}) {
+        cv_.wait(lock, [&]() { return can_extract_; });
+    } else {
+        RAPIDSMPF_EXPECTS(
+            cv_.wait_for(lock, timeout, [&]() { return can_extract_; }),
+            "SparseAlltoall::wait timeout reached",
+            std::runtime_error
+        );
+    }
+}
+
+std::vector<PackedData> SparseAlltoall::extract(Rank src) {
+    auto state_it = source_states_.find(src);
+    RAPIDSMPF_EXPECTS(
+        state_it != source_states_.end(),
+        "SparseAlltoall::extract provided source is not valid"
+    );
+    {
+        std::lock_guard lock{mutex_};
+        RAPIDSMPF_EXPECTS(can_extract_, "Extracting before all chunks are ready");
+    }
+    auto& state = state_it->second;
+    std::ranges::sort(state.chunks, std::less{}, [](auto const& chunk) {
+        return chunk->sequence();
+    });
+
+    std::vector<PackedData> result;
+    result.reserve(state.chunks.size());
+    for (auto& chunk : state.chunks) {
+        result.push_back(chunk->release());
+    }
+    state.chunks.clear();
+    return result;
+}
+
+void SparseAlltoall::send_ready_messages() {
+    Tag const metadata_tag{op_id_, 0};
+    Tag const payload_tag{op_id_, 1};
+    for (auto& chunk : outgoing_.extract_ready()) {
+        auto const dst = chunk->destination();
+        fire_and_forget_.push_back(comm_->send(chunk->serialize(), dst, metadata_tag));
+        if (chunk->data_size() > 0) {
+            fire_and_forget_.push_back(
+                comm_->send(chunk->release_data_buffer(), dst, payload_tag)
+            );
+        }
+    }
+}
+
+void SparseAlltoall::receive_metadata_messages() {
+    Tag const metadata_tag{op_id_, 0};
+    for (auto src : srcs_) {
+        auto& state = source_states_.at(src);
+        while (!state.ready()) {
+            auto msg = comm_->recv_from(src, metadata_tag);
+            if (!msg) {
+                break;
+            }
+            state.received_count++;
+            auto chunk = detail::Chunk::deserialize(*msg, br_);
+            RAPIDSMPF_EXPECTS(
+                chunk->origin() == src,
+                "SparseAlltoall received metadata with unexpected origin"
+            );
+            if (chunk->is_finish()) {
+                RAPIDSMPF_EXPECTS(
+                    state.expected_count == 0,
+                    "SparseAlltoall received duplicate finish control"
+                );
+                state.expected_count = chunk->sequence();
+            } else {
+                incoming_by_src_.at(src).push_back(std::move(chunk));
+            }
+        }
+    }
+}
+
+void SparseAlltoall::receive_data_messages() {
+    Tag const payload_tag{op_id_, 1};
+    for (auto src : srcs_) {
+        auto& queue = incoming_by_src_.at(src);
+        std::ptrdiff_t processed = 0;
+        for (auto& chunk : queue) {
+            if (!chunk->is_ready()) {
+                break;
+            }
+            processed++;
+            if (chunk->data_size() == 0) {
+                auto& state = source_states_.at(chunk->origin());
+                state.chunks.push_back(std::move(chunk));
+            } else {
+                auto buffer = chunk->release_data_buffer();
+                receive_posted_.push_back(std::move(chunk));
+                receive_futures_.push_back(
+                    comm_->recv(src, payload_tag, std::move(buffer))
+                );
+            }
+        }
+        queue.erase(queue.begin(), queue.begin() + processed);
+    }
+}
+
+void SparseAlltoall::complete_data_messages() {
+    for (auto& chunk : detail::test_some(receive_posted_, receive_futures_, comm_.get()))
+    {
+        RAPIDSMPF_EXPECTS(
+            !chunk->is_finish(), "SparseAlltoall can only complete non-finish chunks"
+        );
+        auto& state = source_states_.at(chunk->origin());
+        state.chunks.push_back(std::move(chunk));
+    }
+}
+
+bool SparseAlltoall::containers_empty() const {
+    return outgoing_.empty() && receive_posted_.empty() && receive_futures_.empty()
+           && fire_and_forget_.empty()
+           && std::ranges::all_of(incoming_by_src_, [](auto const& kv) {
+                  return kv.second.empty();
+              });
+}
+
+ProgressThread::ProgressState SparseAlltoall::event_loop() {
+    send_ready_messages();
+    receive_metadata_messages();
+    receive_data_messages();
+    complete_data_messages();
+    if (!fire_and_forget_.empty()) {
+        std::ignore = comm_->test_some(fire_and_forget_);
+    }
+
+    bool const have_all_data = std::ranges::all_of(source_states_, [&](auto const& src) {
+        return src.second.ready();
+    });
+    if (locally_finished_.load(std::memory_order_acquire) && have_all_data
+        && containers_empty())
+    {
+        {
+            std::lock_guard lock(mutex_);
+            can_extract_ = true;
+        }
+        cv_.notify_all();
+        if (auto callback = std::move(finished_callback_)) {
+            callback();
+        }
+        return ProgressThread::ProgressState::Done;
+    }
+    return ProgressThread::ProgressState::InProgress;
+}
+
+}  // namespace rapidsmpf::coll

--- a/cpp/src/coll/sparse_alltoall.cpp
+++ b/cpp/src/coll/sparse_alltoall.cpp
@@ -45,7 +45,7 @@ SparseAlltoall::SparseAlltoall(
             "SparseAlltoall source rank list must be unique"
         );
     }
-    next_ordinal_per_dst_.reserve(srcs_.size());
+    next_ordinal_per_dst_.reserve(dsts_.size());
     for (auto dst : dsts_) {
         RAPIDSMPF_EXPECTS(
             dst >= 0 && dst < size && dst != self,

--- a/cpp/src/coll/sparse_alltoall.cpp
+++ b/cpp/src/coll/sparse_alltoall.cpp
@@ -41,11 +41,9 @@ SparseAlltoall::SparseAlltoall(
             src >= 0 && src < size && src != self, "SparseAlltoall invalid source rank."
         );
         RAPIDSMPF_EXPECTS(
-            incoming_by_src_.emplace(src, std::vector<std::unique_ptr<detail::Chunk>>{})
-                .second,
+            source_states_.emplace(src, SourceState{}).second,
             "SparseAlltoall source rank list must be unique"
         );
-        source_states_.emplace(src, SourceState{});
     }
     next_ordinal_per_dst_.reserve(srcs_.size());
     for (auto dst : dsts_) {
@@ -185,7 +183,7 @@ void SparseAlltoall::receive_metadata_messages() {
                 );
                 state.expected_count = chunk->sequence();
             } else {
-                incoming_by_src_[src].push_back(std::move(chunk));
+                state.incoming.push_back(std::move(chunk));
             }
         }
     }
@@ -193,15 +191,15 @@ void SparseAlltoall::receive_metadata_messages() {
 
 void SparseAlltoall::receive_data_messages() {
     Tag const payload_tag{op_id_, 1};
-    for (auto& [src, queue] : incoming_by_src_) {
+    for (auto& [src, state] : source_states_) {
         std::ptrdiff_t processed = 0;
+        auto& queue = state.incoming;
         for (auto& chunk : queue) {
             if (!chunk->is_ready()) {
                 break;
             }
             processed++;
             if (chunk->data_size() == 0) {
-                auto& state = source_states_[src];
                 state.chunks.push_back(std::move(chunk));
             } else {
                 auto buffer = chunk->release_data_buffer();
@@ -229,8 +227,8 @@ void SparseAlltoall::complete_data_messages() {
 bool SparseAlltoall::containers_empty() const {
     return outgoing_.empty() && receive_posted_.empty() && receive_futures_.empty()
            && fire_and_forget_.empty()
-           && std::ranges::all_of(incoming_by_src_, [](auto const& kv) {
-                  return kv.second.empty();
+           && std::ranges::all_of(source_states_, [](auto const& kv) {
+                  return kv.second.incoming.empty();
               });
 }
 

--- a/cpp/src/coll/sparse_alltoall.cpp
+++ b/cpp/src/coll/sparse_alltoall.cpp
@@ -35,6 +35,7 @@ SparseAlltoall::SparseAlltoall(
     RAPIDSMPF_EXPECTS(br_ != nullptr, "the buffer resource pointer cannot be null");
     auto const size = comm_->nranks();
     auto const self = comm_->rank();
+    source_states_.reserve(srcs_.size());
     for (auto src : srcs_) {
         RAPIDSMPF_EXPECTS(
             src >= 0 && src < size && src != self, "SparseAlltoall invalid source rank."
@@ -46,6 +47,7 @@ SparseAlltoall::SparseAlltoall(
         );
         source_states_.emplace(src, SourceState{});
     }
+    next_ordinal_per_dst_.reserve(srcs_.size());
     for (auto dst : dsts_) {
         RAPIDSMPF_EXPECTS(
             dst >= 0 && dst < size && dst != self,
@@ -93,12 +95,16 @@ void SparseAlltoall::insert(Rank dst, PackedData&& packed_data) {
 }
 
 void SparseAlltoall::insert_finished() {
-    for (auto dst : dsts_) {
+    RAPIDSMPF_EXPECTS(
+        !locally_finished_.load(std::memory_order_acquire),
+        "SparseAlltoall::insert_finished can only be called once"
+    );
+    for (auto& [dst, ord] : next_ordinal_per_dst_) {
         outgoing_.insert(
             detail::Chunk::from_empty(
                 // Number of metadata messages we send to the destination rank, including
                 // this finish message.
-                next_ordinal_per_dst_.at(dst).load(std::memory_order_acquire) + 1,
+                ord.load(std::memory_order_acquire) + 1,
                 comm_->rank(),
                 dst
             )
@@ -160,8 +166,7 @@ void SparseAlltoall::send_ready_messages() {
 
 void SparseAlltoall::receive_metadata_messages() {
     Tag const metadata_tag{op_id_, 0};
-    for (auto src : srcs_) {
-        auto& state = source_states_.at(src);
+    for (auto& [src, state] : source_states_) {
         while (!state.ready()) {
             auto msg = comm_->recv_from(src, metadata_tag);
             if (!msg) {
@@ -180,7 +185,7 @@ void SparseAlltoall::receive_metadata_messages() {
                 );
                 state.expected_count = chunk->sequence();
             } else {
-                incoming_by_src_.at(src).push_back(std::move(chunk));
+                incoming_by_src_[src].push_back(std::move(chunk));
             }
         }
     }
@@ -188,8 +193,7 @@ void SparseAlltoall::receive_metadata_messages() {
 
 void SparseAlltoall::receive_data_messages() {
     Tag const payload_tag{op_id_, 1};
-    for (auto src : srcs_) {
-        auto& queue = incoming_by_src_.at(src);
+    for (auto& [src, queue] : incoming_by_src_) {
         std::ptrdiff_t processed = 0;
         for (auto& chunk : queue) {
             if (!chunk->is_ready()) {
@@ -197,7 +201,7 @@ void SparseAlltoall::receive_data_messages() {
             }
             processed++;
             if (chunk->data_size() == 0) {
-                auto& state = source_states_.at(chunk->origin());
+                auto& state = source_states_[src];
                 state.chunks.push_back(std::move(chunk));
             } else {
                 auto buffer = chunk->release_data_buffer();
@@ -217,7 +221,7 @@ void SparseAlltoall::complete_data_messages() {
         RAPIDSMPF_EXPECTS(
             !chunk->is_finish(), "SparseAlltoall can only complete non-finish chunks"
         );
-        auto& state = source_states_.at(chunk->origin());
+        auto& state = source_states_[chunk->origin()];
         state.chunks.push_back(std::move(chunk));
     }
 }

--- a/cpp/src/coll/sparse_alltoall.cpp
+++ b/cpp/src/coll/sparse_alltoall.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -38,22 +39,27 @@ SparseAlltoall::SparseAlltoall(
     source_states_.reserve(srcs_.size());
     for (auto src : srcs_) {
         RAPIDSMPF_EXPECTS(
-            src >= 0 && src < size && src != self, "SparseAlltoall invalid source rank."
+            src >= 0 && src < size && src != self,
+            "SparseAlltoall invalid source rank.",
+            std::out_of_range
         );
         RAPIDSMPF_EXPECTS(
             source_states_.emplace(src, SourceState{}).second,
-            "SparseAlltoall source rank list must be unique"
+            "SparseAlltoall source rank list must be unique",
+            std::invalid_argument
         );
     }
     next_ordinal_per_dst_.reserve(dsts_.size());
     for (auto dst : dsts_) {
         RAPIDSMPF_EXPECTS(
             dst >= 0 && dst < size && dst != self,
-            "SparseAlltoall invalid destination rank."
+            "SparseAlltoall invalid destination rank.",
+            std::out_of_range
         );
         RAPIDSMPF_EXPECTS(
             next_ordinal_per_dst_.emplace(dst, 0).second,
-            "SparseAlltoall destination rank list must be unique"
+            "SparseAlltoall destination rank list must be unique",
+            std::invalid_argument
         );
     }
     function_id_ =

--- a/cpp/src/streaming/coll/sparse_alltoall.cpp
+++ b/cpp/src/streaming/coll/sparse_alltoall.cpp
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <utility>
+
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/streaming/coll/sparse_alltoall.hpp>
+
+namespace rapidsmpf::streaming {
+
+SparseAlltoall::SparseAlltoall(
+    std::shared_ptr<Context> ctx,
+    std::shared_ptr<Communicator> comm,
+    OpID op_id,
+    std::vector<Rank> srcs,
+    std::vector<Rank> dsts
+)
+    : ctx_{std::move(ctx)},
+      exchange_{coll::SparseAlltoall(
+          std::move(comm),
+          op_id,
+          ctx_->br().get(),
+          std::move(srcs),
+          std::move(dsts),
+          [this]() {
+              // Schedule waiters to resume on the executor.
+              // This doesn't resume the frame immediately so we don't have to track
+              // completion of this callback with a task_group.
+              event_.set(ctx_->executor()->get());
+          }
+      )} {}
+
+SparseAlltoall::~SparseAlltoall() noexcept {
+    RAPIDSMPF_EXPECTS_FATAL(
+        event_.is_set(),
+        "~SparseAlltoall: not all notification tasks complete, did you forget to await "
+        "this->wait() or to call this->insert_finished()?"
+    );
+}
+
+std::shared_ptr<Context> const& SparseAlltoall::ctx() const noexcept {
+    return ctx_;
+}
+
+std::shared_ptr<Communicator> const& SparseAlltoall::comm() const noexcept {
+    return exchange_.comm();
+}
+
+void SparseAlltoall::insert(Rank dst, PackedData&& packed_data) {
+    exchange_.insert(dst, std::move(packed_data));
+}
+
+coro::task<void> SparseAlltoall::insert_finished() {
+    exchange_.insert_finished();
+    co_await event_;
+}
+
+std::vector<PackedData> SparseAlltoall::extract(Rank src) {
+    return exchange_.extract(src);
+}
+
+}  // namespace rapidsmpf::streaming

--- a/cpp/src/streaming/coll/sparse_alltoall.cpp
+++ b/cpp/src/streaming/coll/sparse_alltoall.cpp
@@ -36,7 +36,7 @@ SparseAlltoall::~SparseAlltoall() noexcept {
     RAPIDSMPF_EXPECTS_FATAL(
         event_.is_set(),
         "~SparseAlltoall: not all notification tasks complete, did you forget to await "
-        "this->wait() or to call this->insert_finished()?"
+        "this->insert_finished()?"
     );
 }
 

--- a/cpp/src/streaming/cudf/partition.cpp
+++ b/cpp/src/streaming/cudf/partition.cpp
@@ -40,7 +40,7 @@ Actor partition_and_pack(
         PartitionMapChunk partition_map{
             .data = rapidsmpf::partition_and_pack(
                 tbl.table_view(),
-                std::move(columns_to_hash),
+                columns_to_hash,
                 num_partitions,
                 hash_function,
                 seed,

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -115,6 +115,7 @@ if(RAPIDSMPF_HAVE_STREAMING)
             streaming/test_channel_metadata.cpp
             streaming/test_read_parquet.cpp
             streaming/test_shuffler.cpp
+            streaming/test_sparse_alltoall.cpp
             streaming/test_spillable_messages.cpp
             streaming/test_table_chunk.cpp
   )

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(
           test_pausable_thread_loop.cpp
           test_progress_thread.cpp
           test_rmm_resource_adaptor.cpp
+          test_sparse_alltoall.cpp
           test_shuffler_many_streams.cpp
           test_shuffler.cpp
           test_spill_manager.cpp

--- a/cpp/tests/streaming/test_sparse_alltoall.cpp
+++ b/cpp/tests/streaming/test_sparse_alltoall.cpp
@@ -1,0 +1,212 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <array>
+#include <cstring>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <coro/latch.hpp>
+
+#include <rapidsmpf/memory/buffer.hpp>
+#include <rapidsmpf/memory/packed_data.hpp>
+#include <rapidsmpf/streaming/coll/sparse_alltoall.hpp>
+#include <rapidsmpf/streaming/core/actor.hpp>
+
+#include "base_streaming_fixture.hpp"
+
+using namespace rapidsmpf;
+
+namespace {
+
+std::pair<std::vector<Rank>, std::vector<Rank>> ring_peers(
+    std::shared_ptr<Communicator> const& comm
+) {
+    if (comm->nranks() == 1) {
+        return {{}, {}};
+    }
+    auto const rank = comm->rank();
+    auto const nranks = comm->nranks();
+    return {
+        {static_cast<Rank>((rank + nranks - 1) % nranks)},
+        {static_cast<Rank>((rank + 1) % nranks)}
+    };
+}
+
+PackedData make_payload(
+    int metadata_value,
+    int payload_value,
+    MemoryType mem_type,
+    std::shared_ptr<BufferResource> const& br
+) {
+    auto stream = br->stream_pool().get_stream();
+    auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
+    std::memcpy(metadata->data(), &metadata_value, sizeof(int));
+
+    auto data = br->allocate(stream, br->reserve_or_fail(sizeof(int), mem_type));
+    data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
+        RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
+            ptr, &payload_value, sizeof(payload_value), cudaMemcpyDefault, op_stream
+        ));
+    });
+    return {std::move(metadata), std::move(data)};
+}
+
+int decode_metadata(PackedData const& packed_data) {
+    int result = -1;
+    std::memcpy(&result, packed_data.metadata->data(), sizeof(result));
+    return result;
+}
+
+int decode_payload(PackedData const& packed_data) {
+    int result = -1;
+    RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
+        &result,
+        packed_data.data->data(),
+        sizeof(result),
+        cudaMemcpyDefault,
+        packed_data.stream().value()
+    ));
+    packed_data.stream().synchronize();
+    return result;
+}
+
+}  // namespace
+
+class StreamingSparseAlltoall
+    : public BaseStreamingFixture,
+      public ::testing::WithParamInterface<std::tuple<int, MemoryType>> {
+  public:
+    void SetUp() override {
+        BaseStreamingFixture::SetUpWithThreads(std::get<0>(GetParam()));
+    }
+
+    void TearDown() override {
+        BaseStreamingFixture::TearDown();
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    StreamingSparseAlltoall,
+    StreamingSparseAlltoall,
+    ::testing::Combine(
+        ::testing::Values(1, 4), ::testing::Values(MemoryType::HOST, MemoryType::DEVICE)
+    ),
+    [](testing::TestParamInfo<StreamingSparseAlltoall::ParamType> const& info) {
+        return "nthreads_" + std::to_string(std::get<0>(info.param)) + "_mem_type_"
+               + (std::get<1>(info.param) == MemoryType::HOST ? "HOST" : "DEVICE");
+    }
+);
+
+TEST_P(StreamingSparseAlltoall, basic_ring_exchange) {
+    auto const mem_type = std::get<1>(GetParam());
+    auto comm = GlobalEnvironment->comm_;
+    auto [srcs, dsts] = ring_peers(comm);
+    streaming::SparseAlltoall exchange(ctx, comm, OpID{0}, srcs, dsts);
+
+    constexpr int n_inserts{16};
+    std::vector<int> metadata_result;
+    std::vector<int> payload_result;
+    coro::event ready_to_extract{};
+
+    auto insert_all = [&]() -> coro::task<void> {
+        for (auto dst : dsts) {
+            for (int insertion_id = 0; insertion_id < n_inserts; ++insertion_id) {
+                exchange.insert(
+                    dst,
+                    make_payload(
+                        comm->rank() * 100 + insertion_id,
+                        comm->rank() * 1000 + insertion_id,
+                        mem_type,
+                        ctx->br()
+                    )
+                );
+            }
+        }
+        co_await exchange.insert_finished();
+        ready_to_extract.set(ctx->executor()->get());
+    };
+
+    auto extract_all = [&]() -> coro::task<void> {
+        co_await ready_to_extract;
+        if (srcs.empty()) {
+            co_return;
+        }
+        auto data = exchange.extract(srcs.front());
+        for (auto& pd : data) {
+            metadata_result.push_back(decode_metadata(pd));
+            payload_result.push_back(decode_payload(pd));
+        }
+    };
+
+    std::vector<coro::task<void>> pipeline{};
+    pipeline.push_back(ctx->executor()->schedule(insert_all()));
+    pipeline.push_back(ctx->executor()->schedule(extract_all()));
+    streaming::run_actor_network(std::move(pipeline));
+
+    if (srcs.empty()) {
+        EXPECT_TRUE(metadata_result.empty());
+        EXPECT_TRUE(payload_result.empty());
+        return;
+    }
+    ASSERT_EQ(metadata_result.size(), n_inserts);
+    ASSERT_EQ(payload_result.size(), n_inserts);
+    auto const src = srcs.front();
+    for (int i = 0; i < n_inserts; ++i) {
+        EXPECT_EQ(metadata_result[i], src * 100 + i);
+        EXPECT_EQ(payload_result[i], src * 1000 + i);
+    }
+}
+
+TEST_P(StreamingSparseAlltoall, simultaneous_different_tags) {
+    auto comm = GlobalEnvironment->comm_;
+    auto [srcs, dsts] = ring_peers(comm);
+
+    std::array<std::vector<int>, 2> results{};
+
+    auto task = [&](OpID tag, int offset) -> coro::task<void> {
+        streaming::SparseAlltoall exchange(ctx, comm, tag, srcs, dsts);
+        for (auto dst : dsts) {
+            exchange.insert(
+                dst,
+                make_payload(
+                    offset + comm->rank(),
+                    offset * 10 + comm->rank(),
+                    MemoryType::HOST,
+                    ctx->br()
+                )
+            );
+        }
+        co_await exchange.insert_finished();
+        if (!srcs.empty()) {
+            auto data = exchange.extract(srcs.front());
+            EXPECT_EQ(data.size(), 1);
+            if (data.size() == 1) {
+                results[static_cast<std::size_t>(tag)] = {
+                    decode_metadata(data.front()), decode_payload(data.front())
+                };
+            }
+        }
+        co_return;
+    };
+
+    std::vector<coro::task<void>> pipeline{};
+    pipeline.push_back(ctx->executor()->schedule(task(OpID{0}, 10)));
+    pipeline.push_back(ctx->executor()->schedule(task(OpID{1}, 20)));
+    streaming::run_actor_network(std::move(pipeline));
+
+    if (srcs.empty()) {
+        EXPECT_TRUE(results[0].empty());
+        EXPECT_TRUE(results[1].empty());
+        return;
+    }
+    auto const src = srcs.front();
+    EXPECT_THAT(results[0], ::testing::ElementsAre(10 + src, 100 + src));
+    EXPECT_THAT(results[1], ::testing::ElementsAre(20 + src, 200 + src));
+}

--- a/cpp/tests/streaming/test_sparse_alltoall.cpp
+++ b/cpp/tests/streaming/test_sparse_alltoall.cpp
@@ -15,6 +15,7 @@
 #include <coro/latch.hpp>
 
 #include <rapidsmpf/memory/buffer.hpp>
+#include <rapidsmpf/memory/cuda_memcpy_async.hpp>
 #include <rapidsmpf/memory/packed_data.hpp>
 #include <rapidsmpf/streaming/coll/sparse_alltoall.hpp>
 #include <rapidsmpf/streaming/core/actor.hpp>
@@ -51,9 +52,11 @@ PackedData make_payload(
 
     auto data = br->allocate(stream, br->reserve_or_fail(sizeof(int), mem_type));
     data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
-        RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
-            ptr, &payload_value, sizeof(payload_value), cudaMemcpyDefault, op_stream
-        ));
+        RAPIDSMPF_CUDA_TRY(
+            rapidsmpf::cuda_memcpy_async(
+                ptr, &payload_value, sizeof(payload_value), op_stream
+            )
+        );
     });
     return {std::move(metadata), std::move(data)};
 }
@@ -66,13 +69,14 @@ int decode_metadata(PackedData const& packed_data) {
 
 int decode_payload(PackedData const& packed_data) {
     int result = -1;
-    RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
-        &result,
-        packed_data.data->data(),
-        sizeof(result),
-        cudaMemcpyDefault,
-        packed_data.stream().value()
-    ));
+    RAPIDSMPF_CUDA_TRY(
+        rapidsmpf::cuda_memcpy_async(
+            &result,
+            packed_data.data->data(),
+            sizeof(result),
+            packed_data.stream().value()
+        )
+    );
     packed_data.stream().synchronize();
     return result;
 }

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -1,0 +1,452 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <chrono>
+#include <cstring>
+#include <thread>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rapidsmpf/coll/sparse_alltoall.hpp>
+#include <rapidsmpf/error.hpp>
+#include <rapidsmpf/memory/buffer_resource.hpp>
+#include <rapidsmpf/memory/packed_data.hpp>
+
+#include "environment.hpp"
+
+extern Environment* GlobalEnvironment;
+
+namespace {
+
+std::pair<std::vector<rapidsmpf::Rank>, std::vector<rapidsmpf::Rank>> ring_peers(
+    std::shared_ptr<rapidsmpf::Communicator> const& comm
+) {
+    if (comm->nranks() == 1) {
+        return {{}, {}};
+    }
+    auto const rank = comm->rank();
+    auto const nranks = comm->nranks();
+    return {
+        {static_cast<rapidsmpf::Rank>((rank + nranks - 1) % nranks)},
+        {static_cast<rapidsmpf::Rank>((rank + 1) % nranks)}
+    };
+}
+
+void CUDART_CB sleep_on_stream(void* user_data) {
+    auto* delay = static_cast<std::chrono::milliseconds*>(user_data);
+    std::this_thread::sleep_for(*delay);
+    delete delay;
+}
+
+rapidsmpf::PackedData make_payload(
+    int metadata_value,
+    int payload_value,
+    rapidsmpf::MemoryType mem_type,
+    rmm::cuda_stream_view stream,
+    rapidsmpf::BufferResource& br
+) {
+    auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
+    std::memcpy(metadata->data(), &metadata_value, sizeof(int));
+
+    auto data = br.allocate(stream, br.reserve_or_fail(sizeof(int), mem_type));
+    data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
+        if (mem_type == rapidsmpf::MemoryType::DEVICE) {
+            RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
+                ptr, &payload_value, sizeof(payload_value), cudaMemcpyDefault, op_stream
+            ));
+        } else {
+            std::memcpy(ptr, &payload_value, sizeof(payload_value));
+        }
+    });
+    return {std::move(metadata), std::move(data)};
+}
+
+int decode_metadata(rapidsmpf::PackedData const& packed_data) {
+    int result;
+    std::memcpy(&result, packed_data.metadata->data(), sizeof(result));
+    return result;
+}
+
+int decode_payload(rapidsmpf::PackedData const& packed_data) {
+    int result = -1;
+    if (packed_data.data->mem_type() == rapidsmpf::MemoryType::DEVICE) {
+        RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
+            &result,
+            packed_data.data->data(),
+            sizeof(result),
+            cudaMemcpyDefault,
+            packed_data.data->stream()
+        ));
+        packed_data.data->stream().synchronize();
+    } else {
+        std::memcpy(&result, packed_data.data->data(), sizeof(result));
+    }
+    return result;
+}
+
+}  // namespace
+
+class SparseAlltoallTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        stream = cudf::get_default_stream();
+        mr = std::make_unique<rmm::mr::cuda_memory_resource>();
+        br = std::make_unique<rapidsmpf::BufferResource>(mr.get());
+    }
+
+    rmm::cuda_stream_view stream;
+    std::unique_ptr<rapidsmpf::BufferResource> br;
+    std::unique_ptr<rmm::mr::device_memory_resource> mr;
+};
+
+class SparseAlltoallValidateConstructorTest
+    : public SparseAlltoallTest,
+      public ::testing::WithParamInterface<
+          std::tuple<bool, std::vector<rapidsmpf::Rank>>> {};
+
+auto sparse_alltoall_validate_constructor_name(
+    ::testing::TestParamInfo<std::tuple<bool, std::vector<rapidsmpf::Rank>>> const& info
+) -> std::string {
+    auto const [invalid_srcs, invalid_peers] = info.param;
+    auto const which = invalid_srcs ? "srcs" : "dsts";
+    auto const peer = invalid_peers.front();
+    auto const shape = invalid_peers.size() > 1 ? "duplicate"
+                       : peer < 0               ? "negative"
+                       : peer == 0              ? "self"
+                                                : "out_of_range";
+    return std::string{which} + "_" + shape;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SparseAlltoall,
+    SparseAlltoallValidateConstructorTest,
+    ::testing::Values(
+        std::make_tuple(true, std::vector<rapidsmpf::Rank>{0}),
+        std::make_tuple(false, std::vector<rapidsmpf::Rank>{0}),
+        std::make_tuple(true, std::vector<rapidsmpf::Rank>{0, 0}),
+        std::make_tuple(false, std::vector<rapidsmpf::Rank>{0, 0}),
+        std::make_tuple(true, std::vector<rapidsmpf::Rank>{-1}),
+        std::make_tuple(false, std::vector<rapidsmpf::Rank>{-1}),
+        std::make_tuple(true, std::vector<rapidsmpf::Rank>{1 << 20}),
+        std::make_tuple(false, std::vector<rapidsmpf::Rank>{1 << 20})
+    ),
+    sparse_alltoall_validate_constructor_name
+);
+
+TEST_P(SparseAlltoallValidateConstructorTest, validate_constructor) {
+    auto const& comm = GlobalEnvironment->comm_;
+    auto const [invalid_srcs, invalid_peers] = GetParam();
+    auto const self = comm->rank();
+    auto invalid = invalid_peers;
+    if (invalid.size() == 1 && invalid.front() == 0) {
+        invalid.front() = self;
+    }
+    auto const valid_other = (self + 1) % comm->nranks();
+    auto const valid = self == valid_other ? std::vector<rapidsmpf::Rank>{}
+                                           : std::vector<rapidsmpf::Rank>{valid_other};
+    auto const srcs = invalid_srcs ? invalid : valid;
+    auto const dsts = invalid_srcs ? valid : invalid;
+    EXPECT_THROW(
+        std::ignore = rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), srcs, dsts),
+        std::logic_error
+    );
+}
+
+class SparseAlltoallMemoryTest
+    : public SparseAlltoallTest,
+      public ::testing::WithParamInterface<rapidsmpf::MemoryType> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    SparseAlltoall,
+    SparseAlltoallMemoryTest,
+    ::testing::Values(rapidsmpf::MemoryType::HOST, rapidsmpf::MemoryType::DEVICE),
+    [](auto const& info) {
+        return info.param == rapidsmpf::MemoryType::HOST ? "host" : "device";
+    }
+);
+
+TEST_P(SparseAlltoallMemoryTest, basic_ring_exchange) {
+    auto const& comm = GlobalEnvironment->comm_;
+    auto [srcs, dsts] = ring_peers(comm);
+    int callback_count{0};
+    std::mutex mutex;
+    std::condition_variable cv;
+    rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts, [&]() {
+        {
+            std::lock_guard lk{mutex};
+            callback_count++;
+        }
+        cv.notify_one();
+    });
+
+    auto const mem_type = GetParam();
+    if (!dsts.empty()) {
+        auto const dst = dsts.front();
+        for (int i = 0; i < 3; ++i) {
+            exchange.insert(
+                dst,
+                make_payload(
+                    comm->rank() * 10 + i, comm->rank() * 100 + i, mem_type, stream, *br
+                )
+            );
+        }
+    }
+    exchange.insert_finished();
+    {
+        std::unique_lock lk{mutex};
+        cv.wait_for(lk, std::chrono::seconds{30}, [&]() { return callback_count > 0; });
+    }
+    EXPECT_EQ(callback_count, 1);
+    if (!srcs.empty()) {
+        auto received = exchange.extract(srcs.front());
+        ASSERT_EQ(received.size(), 3);
+        auto const src = srcs.front();
+        for (int i = 0; i < 3; ++i) {
+            EXPECT_EQ(decode_metadata(received[i]), src * 10 + i);
+            EXPECT_EQ(decode_payload(received[i]), src * 100 + i);
+        }
+    }
+}
+
+TEST_F(SparseAlltoallTest, zero_message_edge_and_callback) {
+    auto const& comm = GlobalEnvironment->comm_;
+    auto [srcs, dsts] = ring_peers(comm);
+    int callback_count{0};
+    std::mutex mutex;
+    std::condition_variable cv;
+
+    rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts, [&]() {
+        {
+            std::lock_guard lk{mutex};
+            callback_count++;
+        }
+        cv.notify_one();
+    });
+    exchange.insert_finished();
+
+    {
+        std::unique_lock lk{mutex};
+        cv.wait_for(lk, std::chrono::seconds{30}, [&]() { return callback_count > 0; });
+    }
+    EXPECT_EQ(callback_count, 1);
+    if (!srcs.empty()) {
+        auto received = exchange.extract(srcs.front());
+        EXPECT_TRUE(received.empty());
+    }
+}
+
+TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
+    auto const& comm = GlobalEnvironment->comm_;
+    if (comm->nranks() < 3) {
+        GTEST_SKIP() << "requires at least 3 ranks";
+    }
+
+    std::vector<rapidsmpf::Rank> srcs;
+    std::vector<rapidsmpf::Rank> dsts;
+    switch (comm->rank()) {
+    case 0:
+        srcs = {2};
+        dsts = {1, 2};
+        break;
+    case 1:
+        srcs = {0};
+        dsts = {2};
+        break;
+    case 2:
+        srcs = {0, 1};
+        dsts = {0};
+        break;
+    default:
+        srcs = {};
+        dsts = {};
+        break;
+    }
+
+    rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts);
+    for (auto dst : dsts) {
+        exchange.insert(
+            dst,
+            make_payload(
+                comm->rank() * 10 + dst,
+                comm->rank() * 100 + dst,
+                rapidsmpf::MemoryType::DEVICE,
+                stream,
+                *br
+            )
+        );
+    }
+
+    exchange.insert_finished();
+    exchange.wait(std::chrono::seconds{30});
+
+    for (auto src : srcs) {
+        auto received = exchange.extract(src);
+        ASSERT_EQ(received.size(), 1);
+        EXPECT_EQ(decode_metadata(received.front()), src * 10 + comm->rank());
+        EXPECT_EQ(decode_payload(received.front()), src * 100 + comm->rank());
+    }
+}
+
+TEST_F(SparseAlltoallTest, ordered_by_sender_insertion_with_stream_reordering) {
+    auto const& comm = GlobalEnvironment->comm_;
+    if (comm->nranks() < 2) {
+        GTEST_SKIP() << "requires at least 2 ranks";
+    }
+
+    auto [srcs, dsts] = ring_peers(comm);
+    rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts);
+
+    auto const delayed_stream = br->stream_pool().get_stream(1);
+    auto const fast_stream = br->stream_pool().get_stream(2);
+    RAPIDSMPF_CUDA_TRY(cudaLaunchHostFunc(
+        delayed_stream.value(), sleep_on_stream, new std::chrono::milliseconds(100)
+    ));
+
+    exchange.insert(
+        dsts.front(),
+        make_payload(
+            comm->rank() * 10,
+            comm->rank() * 100,
+            rapidsmpf::MemoryType::DEVICE,
+            delayed_stream,
+            *br
+        )
+    );
+    exchange.insert(
+        dsts.front(),
+        make_payload(
+            comm->rank() * 10 + 1,
+            comm->rank() * 100 + 1,
+            rapidsmpf::MemoryType::DEVICE,
+            fast_stream,
+            *br
+        )
+    );
+
+    exchange.insert_finished();
+    exchange.wait(std::chrono::seconds{30});
+
+    auto received = exchange.extract(srcs.front());
+    ASSERT_EQ(received.size(), 2);
+    auto const src = srcs.front();
+    EXPECT_EQ(decode_metadata(received[0]), src * 10);
+    EXPECT_EQ(decode_payload(received[0]), src * 100);
+    EXPECT_EQ(decode_metadata(received[1]), src * 10 + 1);
+    EXPECT_EQ(decode_payload(received[1]), src * 100 + 1);
+}
+
+TEST_F(SparseAlltoallTest, invalid_usage) {
+    auto const& comm = GlobalEnvironment->comm_;
+    auto [srcs, dsts] = ring_peers(comm);
+    rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts);
+
+    EXPECT_THROW(
+        exchange.insert(
+            comm->rank(), make_payload(1, 2, rapidsmpf::MemoryType::DEVICE, stream, *br)
+        ),
+        std::logic_error
+    );
+
+    if (!srcs.empty()) {
+        EXPECT_THROW(std::ignore = exchange.extract(srcs.front()), std::logic_error);
+    }
+    exchange.insert_finished();
+    exchange.wait(std::chrono::seconds{30});
+    if (!srcs.empty()) {
+        EXPECT_THROW(std::ignore = exchange.extract(comm->rank()), std::logic_error);
+        std::ignore = exchange.extract(srcs.front());
+        EXPECT_TRUE(exchange.extract(srcs.front()).empty());
+    }
+}
+
+TEST_F(SparseAlltoallTest, tag_reuse_after_wait) {
+    auto const& comm = GlobalEnvironment->comm_;
+    auto [srcs, dsts] = ring_peers(comm);
+
+    for (int iteration = 0; iteration < 2; ++iteration) {
+        rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts);
+        if (!dsts.empty()) {
+            exchange.insert(
+                dsts.front(),
+                make_payload(
+                    iteration,
+                    comm->rank() * 1000 + iteration,
+                    rapidsmpf::MemoryType::DEVICE,
+                    stream,
+                    *br
+                )
+            );
+        }
+        exchange.insert_finished();
+        exchange.wait(std::chrono::seconds{30});
+        if (!srcs.empty()) {
+            auto received = exchange.extract(srcs.front());
+            ASSERT_EQ(received.size(), 1);
+            EXPECT_EQ(decode_metadata(received.front()), iteration);
+            EXPECT_EQ(decode_payload(received.front()), srcs.front() * 1000 + iteration);
+        }
+    }
+}
+
+TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
+    auto const& comm = GlobalEnvironment->comm_;
+    auto [srcs, dsts] = ring_peers(comm);
+    if (comm->nranks() < 2) {
+        GTEST_SKIP() << "requires at least 2 ranks";
+    }
+
+    rapidsmpf::coll::SparseAlltoall exchange0(comm, 0, br.get(), srcs, dsts);
+    rapidsmpf::coll::SparseAlltoall exchange1(comm, 1, br.get(), srcs, dsts);
+
+    if (!dsts.empty()) {
+        auto const dst = dsts.front();
+        for (int i = 0; i < 2; ++i) {
+            exchange0.insert(
+                dst,
+                make_payload(
+                    100 + i,
+                    comm->rank() * 1000 + 100 + i,
+                    rapidsmpf::MemoryType::DEVICE,
+                    stream,
+                    *br
+                )
+            );
+            exchange1.insert(
+                dst,
+                make_payload(
+                    200 + i,
+                    comm->rank() * 1000 + 200 + i,
+                    rapidsmpf::MemoryType::DEVICE,
+                    stream,
+                    *br
+                )
+            );
+        }
+    }
+
+    exchange0.insert_finished();
+    exchange1.insert_finished();
+    exchange0.wait(std::chrono::seconds{30});
+    exchange1.wait(std::chrono::seconds{30});
+
+    if (!srcs.empty()) {
+        auto const src = srcs.front();
+        auto received0 = exchange0.extract(src);
+        auto received1 = exchange1.extract(src);
+        ASSERT_EQ(received0.size(), 2);
+        ASSERT_EQ(received1.size(), 2);
+        for (int i = 0; i < 2; ++i) {
+            EXPECT_EQ(decode_metadata(received0[i]), 100 + i);
+            EXPECT_EQ(decode_payload(received0[i]), src * 1000 + 100 + i);
+            EXPECT_EQ(decode_metadata(received1[i]), 200 + i);
+            EXPECT_EQ(decode_payload(received1[i]), src * 1000 + 200 + i);
+        }
+    }
+}

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -16,7 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include <cudf/utilities/default_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/coll/sparse_alltoall.hpp>
 #include <rapidsmpf/error.hpp>
@@ -54,12 +55,12 @@ rapidsmpf::PackedData make_payload(
     int metadata_value,
     int payload_value,
     rapidsmpf::MemoryType mem_type,
-    rmm::cuda_stream_view stream,
     rapidsmpf::BufferResource& br
 ) {
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
     std::memcpy(metadata->data(), &metadata_value, sizeof(int));
 
+    auto const stream = br.stream_pool().get_stream();
     auto data = br.allocate(stream, br.reserve_or_fail(sizeof(int), mem_type));
     data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
         if (mem_type == rapidsmpf::MemoryType::DEVICE) {
@@ -104,14 +105,10 @@ int decode_payload(rapidsmpf::PackedData const& packed_data) {
 class SparseAlltoallTest : public ::testing::Test {
   protected:
     void SetUp() override {
-        stream = cudf::get_default_stream();
-        mr = std::make_unique<rmm::mr::cuda_memory_resource>();
-        br = std::make_unique<rapidsmpf::BufferResource>(mr.get());
+        br = std::make_unique<rapidsmpf::BufferResource>(rmm::mr::cuda_memory_resource{});
     }
 
-    rmm::cuda_stream_view stream;
     std::unique_ptr<rapidsmpf::BufferResource> br;
-    std::unique_ptr<rmm::mr::device_memory_resource> mr;
 };
 
 TEST_F(SparseAlltoallTest, validate_constructor) {
@@ -182,9 +179,7 @@ TEST_P(SparseAlltoallMemoryTest, basic_ring_exchange) {
         for (int i = 0; i < 3; ++i) {
             exchange.insert(
                 dst,
-                make_payload(
-                    comm->rank() * 10 + i, comm->rank() * 100 + i, mem_type, stream, *br
-                )
+                make_payload(comm->rank() * 10 + i, comm->rank() * 100 + i, mem_type, *br)
             );
         }
     }
@@ -266,7 +261,6 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
                 comm->rank() * 10 + dst,
                 comm->rank() * 100 + dst,
                 rapidsmpf::MemoryType::DEVICE,
-                stream,
                 *br
             )
         );
@@ -276,7 +270,7 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
     if (!dsts.empty()) {
         EXPECT_THROW(
             exchange.insert(
-                dsts.front(), make_payload(1, 1, rapidsmpf::MemoryType::HOST, stream, *br)
+                dsts.front(), make_payload(1, 1, rapidsmpf::MemoryType::HOST, *br)
             ),
             std::logic_error
         );
@@ -367,7 +361,6 @@ TEST_F(SparseAlltoallTest, concurrent_insertions) {
                         sequence,
                         comm->rank() * total_messages + sequence,
                         rapidsmpf::MemoryType::HOST,
-                        stream,
                         *br
                     )
                 );
@@ -401,7 +394,7 @@ TEST_F(SparseAlltoallTest, invalid_usage) {
 
     EXPECT_THROW(
         exchange.insert(
-            comm->rank(), make_payload(1, 2, rapidsmpf::MemoryType::DEVICE, stream, *br)
+            comm->rank(), make_payload(1, 2, rapidsmpf::MemoryType::DEVICE, *br)
         ),
         std::logic_error
     );
@@ -431,7 +424,6 @@ TEST_F(SparseAlltoallTest, tag_reuse_after_wait) {
                     iteration,
                     comm->rank() * 1000 + iteration,
                     rapidsmpf::MemoryType::DEVICE,
-                    stream,
                     *br
                 )
             );
@@ -466,7 +458,6 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     100 + i,
                     comm->rank() * 1000 + 100 + i,
                     rapidsmpf::MemoryType::DEVICE,
-                    stream,
                     *br
                 )
             );
@@ -476,7 +467,6 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     200 + i,
                     comm->rank() * 1000 + 200 + i,
                     rapidsmpf::MemoryType::DEVICE,
-                    stream,
                     *br
                 )
             );

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <stdexcept>
 #include <thread>
 #include <tuple>
 #include <utility>
@@ -106,57 +107,39 @@ class SparseAlltoallTest : public ::testing::Test {
     std::unique_ptr<rmm::mr::device_memory_resource> mr;
 };
 
-class SparseAlltoallValidateConstructorTest
-    : public SparseAlltoallTest,
-      public ::testing::WithParamInterface<
-          std::tuple<bool, std::vector<rapidsmpf::Rank>>> {};
-
-auto sparse_alltoall_validate_constructor_name(
-    ::testing::TestParamInfo<std::tuple<bool, std::vector<rapidsmpf::Rank>>> const& info
-) -> std::string {
-    auto const [invalid_srcs, invalid_peers] = info.param;
-    auto const which = invalid_srcs ? "srcs" : "dsts";
-    auto const peer = invalid_peers.front();
-    auto const shape = invalid_peers.size() > 1 ? "duplicate"
-                       : peer < 0               ? "negative"
-                       : peer == 0              ? "self"
-                                                : "out_of_range";
-    return std::string{which} + "_" + shape;
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    SparseAlltoall,
-    SparseAlltoallValidateConstructorTest,
-    ::testing::Values(
-        std::make_tuple(true, std::vector<rapidsmpf::Rank>{0}),
-        std::make_tuple(false, std::vector<rapidsmpf::Rank>{0}),
-        std::make_tuple(true, std::vector<rapidsmpf::Rank>{0, 0}),
-        std::make_tuple(false, std::vector<rapidsmpf::Rank>{0, 0}),
-        std::make_tuple(true, std::vector<rapidsmpf::Rank>{-1}),
-        std::make_tuple(false, std::vector<rapidsmpf::Rank>{-1}),
-        std::make_tuple(true, std::vector<rapidsmpf::Rank>{1 << 20}),
-        std::make_tuple(false, std::vector<rapidsmpf::Rank>{1 << 20})
-    ),
-    sparse_alltoall_validate_constructor_name
-);
-
-TEST_P(SparseAlltoallValidateConstructorTest, validate_constructor) {
+TEST_F(SparseAlltoallTest, validate_constructor) {
     auto const& comm = GlobalEnvironment->comm_;
-    auto const [invalid_srcs, invalid_peers] = GetParam();
     auto const self = comm->rank();
-    auto invalid = invalid_peers;
-    if (invalid.size() == 1 && invalid.front() == 0) {
-        invalid.front() = self;
-    }
-    auto const valid_other = (self + 1) % comm->nranks();
-    auto const valid = self == valid_other ? std::vector<rapidsmpf::Rank>{}
-                                           : std::vector<rapidsmpf::Rank>{valid_other};
-    auto const srcs = invalid_srcs ? invalid : valid;
-    auto const dsts = invalid_srcs ? valid : invalid;
+    auto const size = comm->nranks();
     EXPECT_THROW(
-        std::ignore = rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), srcs, dsts),
-        std::logic_error
+        std::ignore = rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), {self}, {}),
+        std::out_of_range
     );
+    EXPECT_THROW(
+        std::ignore = rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), {size}, {}),
+        std::out_of_range
+    );
+    EXPECT_THROW(
+        std::ignore = rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), {}, {self}),
+        std::out_of_range
+    );
+    EXPECT_THROW(
+        std::ignore = rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), {}, {size}),
+        std::out_of_range
+    );
+    if (comm->nranks() > 1) {
+        auto peer = (self + 1) % size;
+        EXPECT_THROW(
+            std::ignore =
+                rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), {peer, peer}, {}),
+            std::invalid_argument
+        );
+        EXPECT_THROW(
+            std::ignore =
+                rapidsmpf::coll::SparseAlltoall(comm, 0, br.get(), {}, {peer, peer}),
+            std::invalid_argument
+        );
+    }
 }
 
 class SparseAlltoallMemoryTest
@@ -230,7 +213,6 @@ TEST_F(SparseAlltoallTest, zero_message_edge_and_callback) {
         cv.notify_one();
     });
     exchange.insert_finished();
-
     {
         std::unique_lock lk{mutex};
         cv.wait_for(lk, std::chrono::seconds{30}, [&]() { return callback_count > 0; });
@@ -284,6 +266,14 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
     }
 
     exchange.insert_finished();
+    if (!dsts.empty()) {
+        EXPECT_THROW(
+            exchange.insert(
+                dsts.front(), make_payload(1, 1, rapidsmpf::MemoryType::HOST, stream, *br)
+            ),
+            std::logic_error
+        );
+    }
     exchange.wait(std::chrono::seconds{30});
 
     for (auto src : srcs) {
@@ -292,6 +282,7 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
         EXPECT_EQ(decode_metadata(received.front()), src * 10 + comm->rank());
         EXPECT_EQ(decode_payload(received.front()), src * 100 + comm->rank());
     }
+    EXPECT_THROW(std::ignore = exchange.extract(comm->rank()), std::logic_error);
 }
 
 TEST_F(SparseAlltoallTest, ordered_by_sender_insertion_with_stream_reordering) {

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -21,6 +21,7 @@
 #include <rapidsmpf/coll/sparse_alltoall.hpp>
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
+#include <rapidsmpf/memory/cuda_memcpy_async.hpp>
 #include <rapidsmpf/memory/packed_data.hpp>
 
 #include "environment.hpp"
@@ -62,9 +63,11 @@ rapidsmpf::PackedData make_payload(
     auto data = br.allocate(stream, br.reserve_or_fail(sizeof(int), mem_type));
     data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
         if (mem_type == rapidsmpf::MemoryType::DEVICE) {
-            RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
-                ptr, &payload_value, sizeof(payload_value), cudaMemcpyDefault, op_stream
-            ));
+            RAPIDSMPF_CUDA_TRY(
+                rapidsmpf::cuda_memcpy_async(
+                    ptr, &payload_value, sizeof(payload_value), op_stream
+                )
+            );
         } else {
             std::memcpy(ptr, &payload_value, sizeof(payload_value));
         }
@@ -81,13 +84,14 @@ int decode_metadata(rapidsmpf::PackedData const& packed_data) {
 int decode_payload(rapidsmpf::PackedData const& packed_data) {
     int result = -1;
     if (packed_data.data->mem_type() == rapidsmpf::MemoryType::DEVICE) {
-        RAPIDSMPF_CUDA_TRY(cudaMemcpyAsync(
-            &result,
-            packed_data.data->data(),
-            sizeof(result),
-            cudaMemcpyDefault,
-            packed_data.data->stream()
-        ));
+        RAPIDSMPF_CUDA_TRY(
+            rapidsmpf::cuda_memcpy_async(
+                &result,
+                packed_data.data->data(),
+                sizeof(result),
+                packed_data.data->stream()
+            )
+        );
         packed_data.data->stream().synchronize();
     } else {
         std::memcpy(&result, packed_data.data->data(), sizeof(result));

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <cstring>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
 #include <tuple>
@@ -331,6 +334,60 @@ TEST_F(SparseAlltoallTest, ordered_by_sender_insertion_with_stream_reordering) {
     EXPECT_EQ(decode_payload(received[0]), src * 100);
     EXPECT_EQ(decode_metadata(received[1]), src * 10 + 1);
     EXPECT_EQ(decode_payload(received[1]), src * 100 + 1);
+}
+
+TEST_F(SparseAlltoallTest, concurrent_insertions) {
+    auto const& comm = GlobalEnvironment->comm_;
+    if (comm->nranks() < 2) {
+        GTEST_SKIP() << "requires at least 2 ranks";
+    }
+
+    auto [srcs, dsts] = ring_peers(comm);
+    rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts);
+
+    constexpr int num_threads = 4;
+    constexpr int messages_per_thread = 16;
+    constexpr int total_messages = num_threads * messages_per_thread;
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    auto const dst = dsts.front();
+    for (int thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+        threads.emplace_back([&, thread_idx]() {
+            for (int i = 0; i < messages_per_thread; ++i) {
+                auto const sequence = thread_idx * messages_per_thread + i;
+                exchange.insert(
+                    dst,
+                    make_payload(
+                        sequence,
+                        comm->rank() * total_messages + sequence,
+                        rapidsmpf::MemoryType::HOST,
+                        stream,
+                        *br
+                    )
+                );
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    exchange.insert_finished();
+    exchange.wait(std::chrono::seconds{30});
+
+    auto received = exchange.extract(srcs.front());
+    ASSERT_EQ(received.size(), total_messages);
+
+    std::ranges::sort(received, std::less{}, &decode_metadata);
+
+    auto const src = srcs.front();
+    for (int i = 0; i < total_messages; ++i) {
+        EXPECT_EQ(decode_metadata(received[i]), i);
+        EXPECT_EQ(decode_payload(received[i]), src * total_messages + i);
+    }
 }
 
 TEST_F(SparseAlltoallTest, invalid_usage) {

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -55,12 +55,12 @@ rapidsmpf::PackedData make_payload(
     int metadata_value,
     int payload_value,
     rapidsmpf::MemoryType mem_type,
-    rapidsmpf::BufferResource& br
+    rapidsmpf::BufferResource& br,
+    rmm::cuda_stream_view stream
 ) {
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
     std::memcpy(metadata->data(), &metadata_value, sizeof(int));
 
-    auto const stream = br.stream_pool().get_stream();
     auto data = br.allocate(stream, br.reserve_or_fail(sizeof(int), mem_type));
     data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
         if (mem_type == rapidsmpf::MemoryType::DEVICE) {
@@ -179,7 +179,13 @@ TEST_P(SparseAlltoallMemoryTest, basic_ring_exchange) {
         for (int i = 0; i < 3; ++i) {
             exchange.insert(
                 dst,
-                make_payload(comm->rank() * 10 + i, comm->rank() * 100 + i, mem_type, *br)
+                make_payload(
+                    comm->rank() * 10 + i,
+                    comm->rank() * 100 + i,
+                    mem_type,
+                    *br,
+                    br->stream_pool().get_stream()
+                )
             );
         }
     }
@@ -261,7 +267,8 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
                 comm->rank() * 10 + dst,
                 comm->rank() * 100 + dst,
                 rapidsmpf::MemoryType::DEVICE,
-                *br
+                *br,
+                br->stream_pool().get_stream()
             )
         );
     }
@@ -270,7 +277,10 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
     if (!dsts.empty()) {
         EXPECT_THROW(
             exchange.insert(
-                dsts.front(), make_payload(1, 1, rapidsmpf::MemoryType::HOST, *br)
+                dsts.front(),
+                make_payload(
+                    1, 1, rapidsmpf::MemoryType::HOST, *br, br->stream_pool().get_stream()
+                )
             ),
             std::logic_error
         );
@@ -307,8 +317,8 @@ TEST_F(SparseAlltoallTest, ordered_by_sender_insertion_with_stream_reordering) {
             comm->rank() * 10,
             comm->rank() * 100,
             rapidsmpf::MemoryType::DEVICE,
-            delayed_stream,
-            *br
+            *br,
+            delayed_stream
         )
     );
     exchange.insert(
@@ -317,8 +327,8 @@ TEST_F(SparseAlltoallTest, ordered_by_sender_insertion_with_stream_reordering) {
             comm->rank() * 10 + 1,
             comm->rank() * 100 + 1,
             rapidsmpf::MemoryType::DEVICE,
-            fast_stream,
-            *br
+            *br,
+            fast_stream
         )
     );
 
@@ -361,7 +371,8 @@ TEST_F(SparseAlltoallTest, concurrent_insertions) {
                         sequence,
                         comm->rank() * total_messages + sequence,
                         rapidsmpf::MemoryType::HOST,
-                        *br
+                        *br,
+                        br->stream_pool().get_stream()
                     )
                 );
             }
@@ -394,7 +405,10 @@ TEST_F(SparseAlltoallTest, invalid_usage) {
 
     EXPECT_THROW(
         exchange.insert(
-            comm->rank(), make_payload(1, 2, rapidsmpf::MemoryType::DEVICE, *br)
+            comm->rank(),
+            make_payload(
+                1, 2, rapidsmpf::MemoryType::DEVICE, *br, br->stream_pool().get_stream()
+            )
         ),
         std::logic_error
     );
@@ -424,7 +438,8 @@ TEST_F(SparseAlltoallTest, tag_reuse_after_wait) {
                     iteration,
                     comm->rank() * 1000 + iteration,
                     rapidsmpf::MemoryType::DEVICE,
-                    *br
+                    *br,
+                    br->stream_pool().get_stream()
                 )
             );
         }
@@ -458,7 +473,8 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     100 + i,
                     comm->rank() * 1000 + 100 + i,
                     rapidsmpf::MemoryType::DEVICE,
-                    *br
+                    *br,
+                    br->stream_pool().get_stream()
                 )
             );
             exchange1.insert(
@@ -467,7 +483,8 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     200 + i,
                     comm->rank() * 1000 + 200 + i,
                     rapidsmpf::MemoryType::DEVICE,
-                    *br
+                    *br,
+                    br->stream_pool().get_stream()
                 )
             );
         }

--- a/python/rapidsmpf/rapidsmpf/coll/CMakeLists.txt
+++ b/python/rapidsmpf/rapidsmpf/coll/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake-format: on
 # =================================================================================
 
-set(cython_modules allgather.pyx)
+set(cython_modules allgather.pyx sparse_alltoall.pyx)
 
 rapids_cython_create_modules(
   CXX

--- a/python/rapidsmpf/rapidsmpf/coll/__init__.py
+++ b/python/rapidsmpf/rapidsmpf/coll/__init__.py
@@ -5,5 +5,6 @@
 from __future__ import annotations
 
 from rapidsmpf.coll.allgather import AllGather
+from rapidsmpf.coll.sparse_alltoall import SparseAlltoall
 
-__all__ = ["AllGather"]
+__all__ = ["AllGather", "SparseAlltoall"]

--- a/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pxd
+++ b/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pxd
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from libc.stdint cimport int32_t, int64_t, uint64_t
+from libcpp cimport bool
+from libcpp.memory cimport shared_ptr, unique_ptr
+from libcpp.vector cimport vector
+from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+from rmm.pylibrmm.stream cimport Stream
+
+from rapidsmpf._detail.exception_handling cimport ex_handler
+from rapidsmpf.communicator.communicator cimport (Communicator, Rank,
+                                                  cpp_Communicator)
+from rapidsmpf.memory.buffer_resource cimport (BufferResource,
+                                               cpp_BufferResource)
+from rapidsmpf.memory.packed_data cimport cpp_PackedData
+from rapidsmpf.progress_thread cimport cpp_ProgressThread
+
+
+cdef extern from "<rapidsmpf/coll/sparse_alltoall.hpp>" nogil:
+    ctypedef int64_t milliseconds_t "std::chrono::milliseconds"
+
+    cdef cppclass cpp_SparseAlltoall "rapidsmpf::coll::SparseAlltoall":
+        cpp_SparseAlltoall(
+            shared_ptr[cpp_Communicator] comm,
+            int32_t op_id,
+            cpp_BufferResource *br,
+            vector[Rank] srcs,
+            vector[Rank] dsts
+        ) except +ex_handler
+        void insert(Rank dst, cpp_PackedData packed_data) \
+            except +ex_handler
+        void insert_finished() except +ex_handler
+        const shared_ptr[cpp_Communicator]& comm() except +ex_handler
+        void wait(
+            milliseconds_t timeout
+        ) except +ex_handler
+        vector[cpp_PackedData] extract(Rank src) except +ex_handler
+
+
+cdef class SparseAlltoall:
+    cdef unique_ptr[cpp_SparseAlltoall] _handle
+    cdef BufferResource _br
+    cdef Communicator _comm

--- a/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pyi
+++ b/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pyi
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from rapidsmpf.communicator.communicator import Communicator
+from rapidsmpf.memory.buffer_resource import BufferResource
+from rapidsmpf.memory.packed_data import PackedData
+
+class SparseAlltoall:
+    def __init__(
+        self,
+        comm: Communicator,
+        op_id: int,
+        br: BufferResource,
+        srcs: Iterable[int],
+        dsts: Iterable[int],
+    ) -> None: ...
+    @property
+    def comm(self) -> Communicator: ...
+    def insert(self, dst: int, packed_data: PackedData) -> None: ...
+    def insert_finished(self) -> None: ...
+    def wait(self, timeout_ms: int = -1) -> None: ...
+    def extract(self, src: int) -> list[PackedData]: ...

--- a/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pyx
+++ b/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pyx
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Sparse alltoall interface for RapidsMPF."""
+
+from cython.operator cimport dereference as deref
+from libc.stdint cimport int32_t
+from libcpp.memory cimport make_unique
+from libcpp.utility cimport move
+from libcpp.vector cimport vector
+
+from rapidsmpf.coll.sparse_alltoall cimport cpp_SparseAlltoall, milliseconds_t
+from rapidsmpf.communicator.communicator cimport Communicator, Rank
+from rapidsmpf.memory.buffer_resource cimport (BufferResource,
+                                               cpp_BufferResource)
+from rapidsmpf.memory.packed_data cimport (PackedData, cpp_PackedData,
+                                           packed_data_vector_to_list)
+
+
+cdef class SparseAlltoall:
+    """
+    Sparse all-to-all collective over explicit source and destination peer sets.
+
+    Each rank may send zero or more messages to ranks listed in `dsts` and
+    receives zero or more messages from ranks listed in `srcs`. Sender
+    order is defined by the local order of calls to `insert(dst, ...)` for
+    each destination rank.
+
+    This object is logically collective over the communicator and
+    identified by `op_id`. Local extraction is only valid after `wait()`
+    has completed.
+
+    Parameters
+    ----------
+    comm
+        The communicator for communication between ranks.
+    op_id
+        Unique operation identifier for this collective. Must have a value
+        between 0 and 2^20 - 1.
+    br
+        Buffer resource for memory allocation.
+    srcs
+        Sources to receive from
+    dsts
+        Destinations to send to
+
+    Notes
+    -----
+    The caller promises that inserted buffers are stream-ordered with respect to
+    their own stream, and extracted buffers are likewise guaranteed to be stream-
+    ordered with respect to their own stream.
+    """
+
+    def __init__(
+        self,
+        Communicator comm not None,
+        int32_t op_id,
+        BufferResource br not None,
+        srcs,
+        dsts
+    ):
+        self._br = br
+        self._comm = comm
+        cdef cpp_BufferResource* br_ = br.ptr()
+        cdef vector[Rank] c_srcs = list(srcs)
+        cdef vector[Rank] c_dsts = list(dsts)
+        with nogil:
+            self._handle = make_unique[cpp_SparseAlltoall](
+                comm._handle,
+                op_id,
+                br_,
+                move(c_srcs),
+                move(c_dsts),
+            )
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()
+
+    @property
+    def comm(self):
+        """
+        Get the communicator used by the alltoall.
+
+        Returns
+        -------
+        The communicator.
+        """
+        return self._comm
+
+    def insert(self, Rank dst, PackedData packed_data):
+        """
+        Insert packed data into the collective (non-blocking).
+
+        Parameters
+        ----------
+        dst
+            The destination rank for the data.
+        packed_data
+            The data to contribute.
+        """
+        if not packed_data.c_obj:
+            raise ValueError("PackedData was empty")
+
+        with nogil:
+            deref(self._handle).insert(dst, move(deref(packed_data.c_obj)))
+
+    def insert_finished(self):
+        """
+        Mark that this rank has finished contributing data.
+
+        Notes
+        -----
+        This method signals that no more data will be inserted by this rank.
+        All ranks must call this method for the collective to complete.
+        """
+        with nogil:
+            deref(self._handle).insert_finished()
+
+    def wait(self, int timeout_ms = -1):
+        """
+        Wait for completion.
+
+        Parameters
+        ----------
+        timeout_ms
+            Maximum duration to wait in milliseconds. Negative values mean no timeout.
+
+        Raises
+        ------
+        RuntimeError
+            If the timeout is reached.
+        """
+        cdef milliseconds_t _timeout_ms = <milliseconds_t>timeout_ms
+
+        with nogil:
+            deref(self._handle).wait(_timeout_ms)
+
+    def extract(self, Rank src):
+        """
+        Extract data from given source.
+
+        Parameters
+        ----------
+        src
+            Source to extract data from.
+
+        Returns
+        -------
+        list[PackedData]
+            List of the messages received from src.
+
+        Notes
+        -----
+        `wait` must have successfully returned before you call this function.
+        """
+        cdef vector[cpp_PackedData] c_ret
+        with nogil:
+            c_ret = deref(self._handle).extract(src)
+        return packed_data_vector_to_list(move(c_ret))

--- a/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pyx
+++ b/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pyx
@@ -156,4 +156,4 @@ cdef class SparseAlltoall:
         cdef vector[cpp_PackedData] c_ret
         with nogil:
             c_ret = deref(self._handle).extract(src)
-        return packed_data_vector_to_list(move(c_ret))
+        return packed_data_vector_to_list(move(c_ret), self._br)

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/CMakeLists.txt
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/CMakeLists.txt
@@ -1,11 +1,11 @@
 # =================================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =================================================================================
 
-set(cython_modules allgather.pyx shuffler.pyx)
+set(cython_modules allgather.pyx shuffler.pyx sparse_alltoall.pyx)
 
 rapids_cython_create_modules(
   CXX

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pxd
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from libc.stdint cimport int32_t
+from libcpp.memory cimport shared_ptr, unique_ptr
+from libcpp.vector cimport vector
+
+from rapidsmpf._detail.exception_handling cimport ex_handler
+from rapidsmpf.communicator.communicator cimport (Communicator, Rank,
+                                                  cpp_Communicator)
+from rapidsmpf.memory.packed_data cimport cpp_PackedData
+from rapidsmpf.streaming.core.context cimport cpp_Context
+
+
+cdef extern from "<rapidsmpf/streaming/coll/sparse_alltoall.hpp>" nogil:
+    cdef cppclass cpp_SparseAlltoall "rapidsmpf::streaming::SparseAlltoall":
+        cpp_SparseAlltoall(
+            shared_ptr[cpp_Context] ctx,
+            shared_ptr[cpp_Communicator] comm,
+            int32_t op_id,
+            vector[Rank] srcs,
+            vector[Rank] dsts,
+        ) except +ex_handler
+        void insert(Rank dst, cpp_PackedData) except +ex_handler
+        const shared_ptr[cpp_Communicator]& comm() except +ex_handler
+        vector[cpp_PackedData] extract(Rank src) except +ex_handler
+
+
+cdef class SparseAlltoall:
+    cdef unique_ptr[cpp_SparseAlltoall] _handle
+    cdef Communicator _comm

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pxd
@@ -8,6 +8,7 @@ from libcpp.vector cimport vector
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.communicator.communicator cimport (Communicator, Rank,
                                                   cpp_Communicator)
+from rapidsmpf.memory.buffer_resource cimport BufferResource
 from rapidsmpf.memory.packed_data cimport cpp_PackedData
 from rapidsmpf.streaming.core.context cimport cpp_Context
 
@@ -23,9 +24,11 @@ cdef extern from "<rapidsmpf/streaming/coll/sparse_alltoall.hpp>" nogil:
         ) except +ex_handler
         void insert(Rank dst, cpp_PackedData) except +ex_handler
         const shared_ptr[cpp_Communicator]& comm() except +ex_handler
+        const shared_ptr[cpp_Context]& ctx() except +ex_handler
         vector[cpp_PackedData] extract(Rank src) except +ex_handler
 
 
 cdef class SparseAlltoall:
     cdef unique_ptr[cpp_SparseAlltoall] _handle
+    cdef BufferResource _br
     cdef Communicator _comm

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pyi
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable
+
+from rapidsmpf.communicator.communicator import Communicator
+from rapidsmpf.memory.packed_data import PackedData
+from rapidsmpf.streaming.core.context import Context
+
+class SparseAlltoall:
+    def __init__(
+        self,
+        ctx: Context,
+        comm: Communicator,
+        op_id: int,
+        srcs: Iterable[int],
+        dsts: Iterable[int],
+    ) -> None: ...
+    @property
+    def comm(self) -> Communicator: ...
+    def insert(self, dst: int, packed_data: PackedData) -> None: ...
+    async def insert_finished(self, ctx: Context) -> None: ...
+    def extract(self, src: int) -> list[PackedData]: ...

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pyx
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from cpython.object cimport PyObject
+from cpython.ref cimport Py_INCREF
+from cython.operator cimport dereference as deref
+from libc.stdint cimport int32_t
+from libcpp.memory cimport make_unique, shared_ptr
+from libcpp.utility cimport move
+from libcpp.vector cimport vector
+
+from rapidsmpf._detail.exception_handling cimport ex_handler
+from rapidsmpf.communicator.communicator cimport Communicator, Rank
+from rapidsmpf.memory.packed_data cimport (PackedData, cpp_PackedData,
+                                           packed_data_vector_to_list)
+from rapidsmpf.owning_wrapper cimport cpp_OwningWrapper
+from rapidsmpf.streaming._detail.libcoro_spawn_task cimport cpp_set_py_future
+from rapidsmpf.streaming.chunks.utils cimport py_deleter
+from rapidsmpf.streaming.coll.sparse_alltoall cimport cpp_SparseAlltoall
+from rapidsmpf.streaming.core.context cimport Context, cpp_Context
+
+import asyncio
+
+
+cdef extern from * nogil:
+    """
+    namespace {
+    coro::task<void> insert_finished_task(
+        rapidsmpf::streaming::SparseAlltoall *exchange
+    ) {
+        co_await exchange->insert_finished();
+    }
+
+    void cpp_insert_finished(
+        std::shared_ptr<rapidsmpf::streaming::Context> ctx,
+        rapidsmpf::streaming::SparseAlltoall *exchange,
+        void (*cpp_set_py_future)(void*, const char *),
+        rapidsmpf::OwningWrapper py_future
+    ) {
+        RAPIDSMPF_EXPECTS(
+            ctx->executor()->spawn_detached(
+                cython_libcoro_task_wrapper(
+                    cpp_set_py_future,
+                    std::move(py_future),
+                    insert_finished_task(exchange)
+                )
+            ),
+            "libcoro's spawn_detached() failed to spawn task"
+        );
+    }
+    }  // namespace
+    """
+    void cpp_insert_finished(
+        shared_ptr[cpp_Context] ctx,
+        cpp_SparseAlltoall *exchange,
+        void (*cpp_set_py_future)(void*, const char *),
+        cpp_OwningWrapper py_future
+    ) except +ex_handler
+
+
+cdef class SparseAlltoall:
+    """
+    An asynchronous sparse all-to-all.
+
+    Parameters
+    ----------
+    ctx
+        Streaming context.
+    comm
+        The communicator the collective is over.
+    op_id
+        Operation id identifying this sparse all-to-all. Must not be reused while
+        this object is still live.
+    srcs
+        Source ranks this rank receives from.
+    dsts
+        Destination ranks this rank sends to.
+    """
+    def __init__(
+        self,
+        Context ctx not None,
+        Communicator comm not None,
+        int32_t op_id,
+        srcs,
+        dsts,
+    ):
+        self._comm = comm
+        cdef vector[Rank] c_srcs = list(srcs)
+        cdef vector[Rank] c_dsts = list(dsts)
+        with nogil:
+            self._handle = make_unique[cpp_SparseAlltoall](
+                ctx._handle,
+                comm._handle,
+                op_id,
+                move(c_srcs),
+                move(c_dsts),
+            )
+
+    def __dealloc__(self):
+        with nogil:
+            self._handle.reset()
+
+    @property
+    def comm(self):
+        """
+        Get the communicator used by the sparse all-to-all.
+
+        Returns
+        -------
+        The communicator.
+        """
+        return self._comm
+
+    def insert(self, Rank dst, PackedData packed_data not None):
+        """
+        Insert data into the sparse all-to-all.
+
+        Parameters
+        ----------
+        dst
+            Destination rank to send to.
+        packed_data
+            The data to insert.
+        """
+        if not packed_data.c_obj:
+            raise ValueError("PackedData was empty")
+        with nogil:
+            deref(self._handle).insert(dst, move(deref(packed_data.c_obj)))
+
+    async def insert_finished(self, Context ctx not None):
+        """
+        Insert the finished marker and await local completion.
+
+        Notes
+        -----
+        This must be awaited before extraction can occur.
+        """
+        ret = asyncio.get_running_loop().create_future()
+        Py_INCREF(ret)
+        with nogil:
+            cpp_insert_finished(
+                ctx._handle,
+                self._handle.get(),
+                cpp_set_py_future,
+                move(cpp_OwningWrapper(<void*><PyObject*>ret, py_deleter))
+            )
+        await ret
+
+    def extract(self, Rank src):
+        """
+        Extract all data received from the specified source rank.
+
+        Must only be called after awaiting :meth:`insert_finished`.
+
+        Parameters
+        ----------
+        src
+            Source rank to extract from.
+
+        Returns
+        -------
+        list[PackedData]
+            The PackedData messages received from the source.
+        """
+        cdef vector[cpp_PackedData] c_ret
+        with nogil:
+            c_ret = deref(self._handle).extract(src)
+        return packed_data_vector_to_list(move(c_ret))

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/sparse_alltoall.pyx
@@ -85,6 +85,7 @@ cdef class SparseAlltoall:
         dsts,
     ):
         self._comm = comm
+        self._br = ctx.br()
         cdef vector[Rank] c_srcs = list(srcs)
         cdef vector[Rank] c_dsts = list(dsts)
         with nogil:
@@ -165,4 +166,4 @@ cdef class SparseAlltoall:
         cdef vector[cpp_PackedData] c_ret
         with nogil:
             c_ret = deref(self._handle).extract(src)
-        return packed_data_vector_to_list(move(c_ret))
+        return packed_data_vector_to_list(move(c_ret), self._br)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/conftest.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/conftest.py
@@ -9,12 +9,8 @@ import pytest
 
 import rmm.mr
 
-from rapidsmpf.communicator.single import (
-    new_communicator as single_process_comm,
-)
 from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.memory.buffer_resource import BufferResource
-from rapidsmpf.progress_thread import ProgressThread
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.streaming.core.context import Context
 
@@ -22,12 +18,6 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from rapidsmpf.communicator.communicator import Communicator
-
-
-@pytest.fixture(scope="session")
-def comm() -> Communicator:
-    options = Options(get_environment_variables())
-    return single_process_comm(options, ProgressThread())
 
 
 @pytest.fixture

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_allgather.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_allgather.py
@@ -142,6 +142,9 @@ async def allgather_and_concat(
 def test_allgather_object_interface(
     context: Context, comm: Communicator, py_executor: ThreadPoolExecutor
 ) -> None:
+    if comm.nranks != 1:
+        pytest.skip("Only support single-rank runs")
+
     ch_in: Channel[PackedDataChunk] = context.create_channel()
     ch_out: Channel[TableChunk] = context.create_channel()
     actors: list[CppActor | Awaitable[None]] = []

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_read_parquet.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_read_parquet.py
@@ -117,6 +117,9 @@ def test_read_parquet(
     num_rows: int | Literal["all"],
     use_filter: bool,  # noqa: FBT001
 ) -> None:
+    if comm.nranks != 1:
+        pytest.skip("Only support single-rank runs")
+
     ch: Channel[TableChunk] = context.create_channel()
 
     options = plc.io.parquet.ParquetReaderOptions.builder(source).build()

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
@@ -196,6 +196,9 @@ def test_shuffler_runtime_obeys_contiguous_assignment(
     py_executor: ThreadPoolExecutor,
     num_partitions: int,
 ) -> None:
+    if comm.nranks != 1:
+        pytest.skip("Only support single-rank runs")
+
     actors: list[CppActor | Awaitable[None]] = []
 
     num_rows = 200
@@ -239,6 +242,8 @@ def test_shuffler_object_interface(
     comm: Communicator,
     py_executor: ThreadPoolExecutor,
 ) -> None:
+    if comm.nranks != 1:
+        pytest.skip("Only support single-rank runs")
     actors: list[CppActor | Awaitable[None]] = []
 
     num_partitions = 5

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+import pylibcudf as plc
+import rmm.mr
+
+from rapidsmpf.communicator import COMMUNICATORS
+from rapidsmpf.config import Options, get_environment_variables
+from rapidsmpf.integrations.cudf.partition import unpack_and_concat
+from rapidsmpf.memory.buffer_resource import BufferResource
+from rapidsmpf.memory.packed_data import PackedData
+from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
+from rapidsmpf.streaming.coll.sparse_alltoall import SparseAlltoall
+from rapidsmpf.streaming.core.context import Context
+from rapidsmpf.testing import assert_eq
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from rapidsmpf.communicator.communicator import Communicator
+
+
+@pytest.fixture(params=["mpi", "ucxx"], scope="module")
+def distributed_comm(
+    request: pytest.FixtureRequest,
+) -> Generator[Communicator, None, None]:
+    comm_name = request.param
+
+    if "mpi" not in COMMUNICATORS:
+        if comm_name == "mpi":
+            pytest.skip("RapidsMPF not built with MPI support")
+        pytest.skip(
+            "RapidsMPF not built with MPI support, which is used to bootstrap UCXX"
+        )
+    if comm_name == "ucxx" and "ucxx" not in COMMUNICATORS:
+        pytest.skip("RapidsMPF not built with UCXX support")
+
+    from mpi4py import MPI
+
+    MPI.COMM_WORLD.barrier()
+    yield request.getfixturevalue(f"_{comm_name}_comm")
+    MPI.COMM_WORLD.barrier()
+
+
+@pytest.fixture(scope="module")
+def distributed_context(
+    distributed_comm: Communicator,
+) -> Generator[Context, None, None]:
+    options = Options(get_environment_variables())
+    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
+    br = BufferResource(mr)
+
+    with Context(distributed_comm.logger, br, options) as ctx:
+        yield ctx
+
+
+def make_packed_data(context: Context, values: np.ndarray) -> PackedData:
+    stream = context.get_stream_from_pool()
+    table = plc.Table([plc.Column.from_array(values, stream=stream)])
+    return PackedData.from_cudf_packed_columns(
+        plc.contiguous_split.pack(table, stream=stream),
+        stream,
+        context.br(),
+    )
+
+
+def unpack_table(context: Context, packed_data: PackedData) -> plc.Table:
+    stream = context.get_stream_from_pool()
+    return unpack_and_concat([packed_data], stream, context.br())
+
+
+def require_multiple_ranks(comm: Communicator) -> None:
+    if comm.nranks == 1:
+        pytest.skip("Need at least two ranks")
+
+
+def test_sparse_alltoall_non_participating_ranks(
+    distributed_context: Context,
+    distributed_comm: Communicator,
+) -> None:
+    require_multiple_ranks(distributed_comm)
+
+    if distributed_comm.rank == 0:
+        srcs = []
+        dsts = [1]
+    elif distributed_comm.rank == 1:
+        srcs = [0]
+        dsts = []
+    else:
+        srcs = []
+        dsts = []
+
+    exchange = SparseAlltoall(
+        distributed_context,
+        distributed_comm,
+        0,
+        srcs,
+        dsts,
+    )
+
+    if distributed_comm.rank == 0:
+        exchange.insert(
+            1, make_packed_data(distributed_context, np.array([11], dtype=np.int32))
+        )
+        exchange.insert(
+            1, make_packed_data(distributed_context, np.array([29], dtype=np.int32))
+        )
+
+    asyncio.run(exchange.insert_finished(distributed_context))
+
+    if distributed_comm.rank == 1:
+        results = exchange.extract(0)
+        assert len(results) == 2
+        stream = distributed_context.get_stream_from_pool()
+        assert_eq(
+            unpack_table(distributed_context, results[0]),
+            plc.Table(
+                [plc.Column.from_array(np.array([11], dtype=np.int32), stream=stream)]
+            ),
+        )
+        assert_eq(
+            unpack_table(distributed_context, results[1]),
+            plc.Table(
+                [plc.Column.from_array(np.array([29], dtype=np.int32), stream=stream)]
+            ),
+        )
+
+
+@pytest.mark.parametrize("invalid_srcs", [True, False])
+def test_sparse_alltoall_invalid_constructor(
+    distributed_context: Context,
+    distributed_comm: Communicator,
+    invalid_srcs: bool,  # noqa: FBT001
+) -> None:
+    require_multiple_ranks(distributed_comm)
+
+    valid_other = (distributed_comm.rank + 1) % distributed_comm.nranks
+    valid_peers = [] if valid_other == distributed_comm.rank else [valid_other]
+    invalid_peers = [distributed_comm.rank]
+    srcs = invalid_peers if invalid_srcs else valid_peers
+    dsts = valid_peers if invalid_srcs else invalid_peers
+
+    with pytest.raises(
+        RuntimeError, match=r"SparseAlltoall invalid (source|destination) rank"
+    ):
+        SparseAlltoall(distributed_context, distributed_comm, 1, srcs, dsts)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
@@ -10,56 +10,15 @@ import numpy as np
 import pytest
 
 import pylibcudf as plc
-import rmm.mr
 
-from rapidsmpf.communicator import COMMUNICATORS
-from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.integrations.cudf.partition import unpack_and_concat
-from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.memory.packed_data import PackedData
-from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.streaming.coll.sparse_alltoall import SparseAlltoall
-from rapidsmpf.streaming.core.context import Context
 from rapidsmpf.testing import assert_eq
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
     from rapidsmpf.communicator.communicator import Communicator
-
-
-@pytest.fixture(params=["mpi", "ucxx"], scope="module")
-def distributed_comm(
-    request: pytest.FixtureRequest,
-) -> Generator[Communicator, None, None]:
-    comm_name = request.param
-
-    if "mpi" not in COMMUNICATORS:
-        if comm_name == "mpi":
-            pytest.skip("RapidsMPF not built with MPI support")
-        pytest.skip(
-            "RapidsMPF not built with MPI support, which is used to bootstrap UCXX"
-        )
-    if comm_name == "ucxx" and "ucxx" not in COMMUNICATORS:
-        pytest.skip("RapidsMPF not built with UCXX support")
-
-    from mpi4py import MPI
-
-    MPI.COMM_WORLD.barrier()
-    yield request.getfixturevalue(f"_{comm_name}_comm")
-    MPI.COMM_WORLD.barrier()
-
-
-@pytest.fixture(scope="module")
-def distributed_context(
-    distributed_comm: Communicator,
-) -> Generator[Context, None, None]:
-    options = Options(get_environment_variables())
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(mr)
-
-    with Context(distributed_comm.logger, br, options) as ctx:
-        yield ctx
+    from rapidsmpf.streaming.core.context import Context
 
 
 def make_packed_data(context: Context, values: np.ndarray) -> PackedData:
@@ -77,21 +36,16 @@ def unpack_table(context: Context, packed_data: PackedData) -> plc.Table:
     return unpack_and_concat([packed_data], stream, context.br())
 
 
-def require_multiple_ranks(comm: Communicator) -> None:
-    if comm.nranks == 1:
-        pytest.skip("Need at least two ranks")
-
-
 def test_sparse_alltoall_non_participating_ranks(
-    distributed_context: Context,
-    distributed_comm: Communicator,
+    context: Context,
+    comm: Communicator,
 ) -> None:
-    require_multiple_ranks(distributed_comm)
-
-    if distributed_comm.rank == 0:
+    if comm.nranks == 0:
+        pytest.skip("Need at least two ranks")
+    if comm.rank == 0:
         srcs = []
         dsts = [1]
-    elif distributed_comm.rank == 1:
+    elif comm.rank == 1:
         srcs = [0]
         dsts = []
     else:
@@ -99,56 +53,51 @@ def test_sparse_alltoall_non_participating_ranks(
         dsts = []
 
     exchange = SparseAlltoall(
-        distributed_context,
-        distributed_comm,
+        context,
+        comm,
         0,
         srcs,
         dsts,
     )
 
-    if distributed_comm.rank == 0:
-        exchange.insert(
-            1, make_packed_data(distributed_context, np.array([11], dtype=np.int32))
-        )
-        exchange.insert(
-            1, make_packed_data(distributed_context, np.array([29], dtype=np.int32))
-        )
+    if comm.rank == 0:
+        exchange.insert(1, make_packed_data(context, np.array([11], dtype=np.int32)))
+        exchange.insert(1, make_packed_data(context, np.array([29], dtype=np.int32)))
 
-    asyncio.run(exchange.insert_finished(distributed_context))
+    asyncio.run(exchange.insert_finished(context))
 
-    if distributed_comm.rank == 1:
+    if comm.rank == 1:
         results = exchange.extract(0)
         assert len(results) == 2
-        stream = distributed_context.get_stream_from_pool()
+        stream = context.get_stream_from_pool()
         assert_eq(
-            unpack_table(distributed_context, results[0]),
+            unpack_table(context, results[0]),
             plc.Table(
                 [plc.Column.from_array(np.array([11], dtype=np.int32), stream=stream)]
             ),
         )
         assert_eq(
-            unpack_table(distributed_context, results[1]),
+            unpack_table(context, results[1]),
             plc.Table(
                 [plc.Column.from_array(np.array([29], dtype=np.int32), stream=stream)]
             ),
         )
 
 
-@pytest.mark.parametrize("invalid_srcs", [True, False])
 def test_sparse_alltoall_invalid_constructor(
-    distributed_context: Context,
-    distributed_comm: Communicator,
-    invalid_srcs: bool,  # noqa: FBT001
+    context: Context, comm: Communicator
 ) -> None:
-    require_multiple_ranks(distributed_comm)
-
-    valid_other = (distributed_comm.rank + 1) % distributed_comm.nranks
-    valid_peers = [] if valid_other == distributed_comm.rank else [valid_other]
-    invalid_peers = [distributed_comm.rank]
-    srcs = invalid_peers if invalid_srcs else valid_peers
-    dsts = valid_peers if invalid_srcs else invalid_peers
-
-    with pytest.raises(
-        RuntimeError, match=r"SparseAlltoall invalid (source|destination) rank"
-    ):
-        SparseAlltoall(distributed_context, distributed_comm, 1, srcs, dsts)
+    rank = comm.rank
+    size = comm.nranks
+    for src, dst in [([], [rank]), ([rank], []), ([], [size]), ([size], [])]:
+        with pytest.raises(
+            RuntimeError, match=r"SparseAlltoall invalid (source|destination) rank"
+        ):
+            SparseAlltoall(context, comm, 1, src, dst)
+    if size > 1:
+        for src, dst in [([], [(rank + 1) % size]), ([(rank + 1) % size], [])]:
+            with pytest.raises(
+                RuntimeError,
+                match=r"SparseAlltoall (source|destination) rank list must be unique",
+            ):
+                SparseAlltoall(context, comm, 1, src, dst)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
@@ -82,22 +82,3 @@ def test_sparse_alltoall_non_participating_ranks(
                 [plc.Column.from_array(np.array([29], dtype=np.int32), stream=stream)]
             ),
         )
-
-
-def test_sparse_alltoall_invalid_constructor(
-    context: Context, comm: Communicator
-) -> None:
-    rank = comm.rank
-    size = comm.nranks
-    for src, dst in [([], [rank]), ([rank], []), ([], [size]), ([size], [])]:
-        with pytest.raises(
-            RuntimeError, match=r"SparseAlltoall invalid (source|destination) rank"
-        ):
-            SparseAlltoall(context, comm, 1, src, dst)
-    if size > 1:
-        for src, dst in [([], [(rank + 1) % size]), ([(rank + 1) % size], [])]:
-            with pytest.raises(
-                RuntimeError,
-                match=r"SparseAlltoall (source|destination) rank list must be unique",
-            ):
-                SparseAlltoall(context, comm, 1, src, dst)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_sparse_alltoall.py
@@ -40,7 +40,7 @@ def test_sparse_alltoall_non_participating_ranks(
     context: Context,
     comm: Communicator,
 ) -> None:
-    if comm.nranks == 0:
+    if comm.nranks < 2:
         pytest.skip("Need at least two ranks")
     if comm.rank == 0:
         srcs = []

--- a/python/rapidsmpf/rapidsmpf/tests/test_sparse_alltoall.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_sparse_alltoall.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SparseAlltoall functionality."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+import pylibcudf as plc
+
+from rapidsmpf.coll.sparse_alltoall import SparseAlltoall
+from rapidsmpf.integrations.cudf.partition import unpack_and_concat
+from rapidsmpf.memory.buffer_resource import BufferResource
+from rapidsmpf.memory.packed_data import PackedData
+from rapidsmpf.testing import assert_eq
+
+if TYPE_CHECKING:
+    import rmm.mr
+    from rmm.pylibrmm.stream import Stream
+
+    from rapidsmpf.communicator.communicator import Communicator
+
+
+def generate_packed_data(
+    n_elements: int, offset: int, stream: Stream, br: BufferResource
+) -> PackedData:
+    """Generate packed integer data with a predictable payload."""
+    values = np.arange(offset, offset + n_elements, dtype=np.int32)
+    table = plc.Table([plc.Column.from_array(values, stream=stream)])
+    packed_columns = plc.contiguous_split.pack(table, stream=stream)
+    return PackedData.from_cudf_packed_columns(packed_columns, stream, br)
+
+
+def unpack_table(
+    packed_data: PackedData,
+    stream: Stream,
+    br: BufferResource,
+) -> plc.Table:
+    """Unpack a PackedData payload into a single-column table."""
+    return unpack_and_concat([packed_data], stream, br)
+
+
+def expected_peers(comm: Communicator) -> tuple[list[int], list[int]]:
+    """Return the immediate non-self neighbors in the communicator."""
+    peers = []
+    if comm.rank > 0:
+        peers.append(comm.rank - 1)
+    if comm.rank + 1 < comm.nranks:
+        peers.append(comm.rank + 1)
+    return peers, peers
+
+
+def make_offset(src: int, dst: int, ordinal: int) -> int:
+    """Encode the sender, receiver, and per-destination ordinal into payload data."""
+    return src * 1000 + dst * 100 + ordinal * 10
+
+
+@pytest.mark.parametrize("n_inserts", [0, 1, 3])
+def test_basic(
+    comm: Communicator,
+    device_mr: rmm.mr.CudaMemoryResource,
+    stream: Stream,
+    n_inserts: int,
+) -> None:
+    """
+    Test a simple sparse exchange with immediate neighbors.
+
+    Each rank sends `n_inserts` messages to each adjacent rank and then checks
+    that extraction by source returns the expected number of payloads.
+    """
+    br = BufferResource(device_mr)
+    srcs, dsts = expected_peers(comm)
+    sparse_alltoall = SparseAlltoall(
+        comm=comm,
+        op_id=0,
+        br=br,
+        srcs=srcs,
+        dsts=dsts,
+    )
+
+    for dst in dsts:
+        for ordinal in range(n_inserts):
+            sparse_alltoall.insert(
+                dst,
+                generate_packed_data(
+                    n_elements=4,
+                    offset=make_offset(comm.rank, dst, ordinal),
+                    stream=stream,
+                    br=br,
+                ),
+            )
+
+    sparse_alltoall.insert_finished()
+    sparse_alltoall.wait()
+
+    for src in srcs:
+        results = sparse_alltoall.extract(src)
+        assert len(results) == n_inserts
+        for ordinal, result in enumerate(results):
+            expected = plc.Table(
+                [
+                    plc.Column.from_array(
+                        np.arange(
+                            make_offset(src, comm.rank, ordinal),
+                            make_offset(src, comm.rank, ordinal) + 4,
+                            dtype=np.int32,
+                        ),
+                        stream=stream,
+                    )
+                ]
+            )
+            assert_eq(unpack_table(result, stream, br), expected)
+
+
+def test_non_participating_ranks(
+    comm: Communicator,
+    device_mr: rmm.mr.CudaMemoryResource,
+    stream: Stream,
+) -> None:
+    if comm.nranks < 2:
+        pytest.skip("Need at least two ranks")
+
+    br = BufferResource(device_mr)
+
+    if comm.rank == 0:
+        srcs = []
+        dsts = [1]
+    elif comm.rank == 1:
+        srcs = [0]
+        dsts = []
+    else:
+        srcs = []
+        dsts = []
+
+    sparse_alltoall = SparseAlltoall(
+        comm=comm,
+        op_id=1,
+        br=br,
+        srcs=srcs,
+        dsts=dsts,
+    )
+
+    if comm.rank == 0:
+        sparse_alltoall.insert(1, generate_packed_data(1, 11, stream, br))
+        sparse_alltoall.insert(1, generate_packed_data(1, 29, stream, br))
+
+    sparse_alltoall.insert_finished()
+    sparse_alltoall.wait()
+
+    if comm.rank == 1:
+        results = sparse_alltoall.extract(0)
+        assert len(results) == 2
+        assert_eq(
+            unpack_table(results[0], stream, br),
+            plc.Table(
+                [plc.Column.from_array(np.array([11], dtype=np.int32), stream=stream)]
+            ),
+        )
+        assert_eq(
+            unpack_table(results[1], stream, br),
+            plc.Table(
+                [plc.Column.from_array(np.array([29], dtype=np.int32), stream=stream)]
+            ),
+        )
+
+
+@pytest.mark.parametrize("invalid_srcs", [True, False])
+def test_invalid_peers_raise(
+    comm: Communicator,
+    device_mr: rmm.mr.CudaMemoryResource,
+    invalid_srcs: bool,  # noqa: FBT001
+) -> None:
+    br = BufferResource(device_mr)
+    valid_other = (comm.rank + 1) % comm.nranks
+    valid_peers = [] if valid_other == comm.rank else [valid_other]
+    invalid_peers = [comm.rank]
+    srcs = invalid_peers if invalid_srcs else valid_peers
+    dsts = valid_peers if invalid_srcs else invalid_peers
+
+    with pytest.raises(
+        RuntimeError, match=r"SparseAlltoall invalid (source|destination) rank"
+    ):
+        SparseAlltoall(
+            comm=comm,
+            op_id=2,
+            br=br,
+            srcs=srcs,
+            dsts=dsts,
+        )

--- a/python/rapidsmpf/rapidsmpf/tests/test_sparse_alltoall.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_sparse_alltoall.py
@@ -167,26 +167,23 @@ def test_non_participating_ranks(
         )
 
 
-@pytest.mark.parametrize("invalid_srcs", [True, False])
 def test_invalid_peers_raise(
     comm: Communicator,
     device_mr: rmm.mr.CudaMemoryResource,
-    invalid_srcs: bool,  # noqa: FBT001
 ) -> None:
+    rank = comm.rank
+    size = comm.nranks
     br = BufferResource(device_mr)
-    valid_other = (comm.rank + 1) % comm.nranks
-    valid_peers = [] if valid_other == comm.rank else [valid_other]
-    invalid_peers = [comm.rank]
-    srcs = invalid_peers if invalid_srcs else valid_peers
-    dsts = valid_peers if invalid_srcs else invalid_peers
-
-    with pytest.raises(
-        RuntimeError, match=r"SparseAlltoall invalid (source|destination) rank"
-    ):
-        SparseAlltoall(
-            comm=comm,
-            op_id=2,
-            br=br,
-            srcs=srcs,
-            dsts=dsts,
-        )
+    for src, dst in [([], [rank]), ([rank], []), ([], [size]), ([size], [])]:
+        with pytest.raises(
+            IndexError, match=r"SparseAlltoall invalid (source|destination) rank"
+        ):
+            SparseAlltoall(comm, 1, br=br, srcs=src, dsts=dst)
+    if size > 1:
+        peer = (rank + 1) % size
+        for src, dst in [([], [peer, peer]), ([peer, peer], [])]:
+            with pytest.raises(
+                ValueError,
+                match=r"SparseAlltoall (source|destination) rank list must be unique",
+            ):
+                SparseAlltoall(comm, 1, br=br, srcs=src, dsts=dst)


### PR DESCRIPTION
In this collective every rank advertises the destination ranks it will send
to and the source ranks it will receive from (these have to match up
collective, no error is provided). The caller can then insert messages to
particular ranks, followed by a final insert_finished() call.

On the receive side, after waiting for completion, we can extract received
messages by rank. The receive side message order is defined by the
insertion order on the send side. That is, if rank-A inserts messages in
order [A0, A1, A2] to rank-B, then when rank-B calls `extract(rank-A)` it
will see the same order (even if the messages were sent in a different order).