### PR TITLE
Make BufferResource parameters required instead of optional

### DIFF
--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pxd
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pxd
@@ -20,9 +20,9 @@ cdef class PackedData:
     cdef BufferResource _br
 
     @staticmethod
-    cdef from_librapidsmpf(unique_ptr[cpp_PackedData] obj, BufferResource br)  # noqa: E704
+    cdef from_librapidsmpf(unique_ptr[cpp_PackedData] obj, BufferResource br)
 
 
 cdef list packed_data_vector_to_list(
     vector[cpp_PackedData] packed_data, BufferResource br
-)  # noqa: E704
+)

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pxd
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pxd
@@ -20,9 +20,9 @@ cdef class PackedData:
     cdef BufferResource _br
 
     @staticmethod
-    cdef from_librapidsmpf(unique_ptr[cpp_PackedData] obj, BufferResource br=*)
+    cdef from_librapidsmpf(unique_ptr[cpp_PackedData] obj, BufferResource br)  # noqa: E704
 
 
 cdef list packed_data_vector_to_list(
-    vector[cpp_PackedData] packed_data, BufferResource br=*
-)
+    vector[cpp_PackedData] packed_data, BufferResource br
+)  # noqa: E704

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
@@ -99,7 +99,7 @@ cdef extern from *:
 
 cdef class PackedData:
     @staticmethod
-    cdef from_librapidsmpf(unique_ptr[cpp_PackedData] obj, BufferResource br=None):
+    cdef from_librapidsmpf(unique_ptr[cpp_PackedData] obj, BufferResource br):
         cdef PackedData self = PackedData.__new__(PackedData)
         self.c_obj = move(obj)
         self._br = br
@@ -224,7 +224,7 @@ cdef class PackedData:
 
 # Convert a vector of `cpp_PackedData` into a list of `PackedData`.
 cdef list packed_data_vector_to_list(
-    vector[cpp_PackedData] packed_data, BufferResource br=None
+    vector[cpp_PackedData] packed_data, BufferResource br
 ):
     cdef list ret = []
     for i in range(packed_data.size()):

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pxd
@@ -16,6 +16,6 @@ cdef class PackedDataChunk:
     @staticmethod
     cdef PackedDataChunk from_handle(
         unique_ptr[cpp_PackedData] handle, BufferResource br
-    )  # noqa: E704
+    )
     cdef const cpp_PackedData* handle_ptr(self)
     cdef unique_ptr[cpp_PackedData] release_handle(self)

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pxd
@@ -15,7 +15,7 @@ cdef class PackedDataChunk:
 
     @staticmethod
     cdef PackedDataChunk from_handle(
-        unique_ptr[cpp_PackedData] handle, BufferResource br=*
-    )
+        unique_ptr[cpp_PackedData] handle, BufferResource br
+    )  # noqa: E704
     cdef const cpp_PackedData* handle_ptr(self)
     cdef unique_ptr[cpp_PackedData] release_handle(self)

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pyi
@@ -2,24 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.memory.packed_data import PackedData
-from rapidsmpf.streaming.core.message import Message, Payload
+from rapidsmpf.streaming.core.message import Message
 
 class PackedDataChunk:
     def to_packed_data(self) -> PackedData: ...
     @staticmethod
-    def from_packed_data(
-        obj: PackedData, br: BufferResource | None = None
-    ) -> PackedDataChunk: ...
+    def from_packed_data(obj: PackedData, br: BufferResource) -> PackedDataChunk: ...
     @classmethod
     def from_message(
-        cls: type[Self], message: Message[Self], br: BufferResource | None = None
+        cls: type[Self], message: Message[Self], br: BufferResource
     ) -> Self: ...
     def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...
-
-if TYPE_CHECKING:
-    t1: PackedDataChunk
-    t2: Payload = t1

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pyx
@@ -48,7 +48,7 @@ cdef class PackedDataChunk:
         return PackedData.from_librapidsmpf(self.release_handle(), self._br)
 
     @staticmethod
-    def from_packed_data(PackedData obj not None, BufferResource br):
+    def from_packed_data(PackedData obj not None, BufferResource br not None):
         """
         Construct a PackedDataChunk from an existing PackedData object.
 
@@ -86,7 +86,7 @@ cdef class PackedDataChunk:
         return ret
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br):
+    def from_message(Message message not None, BufferResource br not None):
         """
         Construct a PackedDataChunk by consuming a Message.
 

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/packed_data.pyx
@@ -48,7 +48,7 @@ cdef class PackedDataChunk:
         return PackedData.from_librapidsmpf(self.release_handle(), self._br)
 
     @staticmethod
-    def from_packed_data(PackedData obj not None, BufferResource br=None):
+    def from_packed_data(PackedData obj not None, BufferResource br):
         """
         Construct a PackedDataChunk from an existing PackedData object.
 
@@ -61,13 +61,11 @@ cdef class PackedDataChunk:
         -------
         A new PackedDataChunk from the given object.
         """
-        if br is None:
-            br = obj._br
         return PackedDataChunk.from_handle(move(obj.c_obj), br)
 
     @staticmethod
     cdef PackedDataChunk from_handle(
-        unique_ptr[cpp_PackedData] handle, BufferResource br=None
+        unique_ptr[cpp_PackedData] handle, BufferResource br
     ):
         """
         Construct a PackedDataChunk from an existing C++ handle.
@@ -88,7 +86,7 @@ cdef class PackedDataChunk:
         return ret
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br=None):
+    def from_message(Message message not None, BufferResource br):
         """
         Construct a PackedDataChunk by consuming a Message.
 

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pxd
@@ -26,8 +26,8 @@ cdef class PartitionMapChunk:
 
     @staticmethod
     cdef PartitionMapChunk from_handle(
-        unique_ptr[cpp_PartitionMapChunk] handle, BufferResource br=*
-    )
+        unique_ptr[cpp_PartitionMapChunk] handle, BufferResource br
+    )  # noqa: E704
     cdef const cpp_PartitionMapChunk* handle_ptr(self)
     cdef unique_ptr[cpp_PartitionMapChunk] release_handle(self)
 
@@ -40,7 +40,7 @@ cdef class PartitionVectorChunk:
 
     @staticmethod
     cdef PartitionVectorChunk from_handle(
-        unique_ptr[cpp_PartitionVectorChunk] handle, BufferResource br=*
-    )
+        unique_ptr[cpp_PartitionVectorChunk] handle, BufferResource br
+    )  # noqa: E704
     cdef const cpp_PartitionVectorChunk* handle_ptr(self)
     cdef unique_ptr[cpp_PartitionVectorChunk] release_handle(self)

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pxd
@@ -27,7 +27,7 @@ cdef class PartitionMapChunk:
     @staticmethod
     cdef PartitionMapChunk from_handle(
         unique_ptr[cpp_PartitionMapChunk] handle, BufferResource br
-    )  # noqa: E704
+    )
     cdef const cpp_PartitionMapChunk* handle_ptr(self)
     cdef unique_ptr[cpp_PartitionMapChunk] release_handle(self)
 
@@ -41,6 +41,6 @@ cdef class PartitionVectorChunk:
     @staticmethod
     cdef PartitionVectorChunk from_handle(
         unique_ptr[cpp_PartitionVectorChunk] handle, BufferResource br
-    )  # noqa: E704
+    )
     cdef const cpp_PartitionVectorChunk* handle_ptr(self)
     cdef unique_ptr[cpp_PartitionVectorChunk] release_handle(self)

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyi
@@ -2,25 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
-from rapidsmpf.streaming.core.message import Message, Payload
+from rapidsmpf.memory.buffer_resource import BufferResource
+from rapidsmpf.streaming.core.message import Message
 
 class PartitionMapChunk:
     @classmethod
-    def from_message(cls: type[Self], message: Message[Self]) -> Self: ...
+    def from_message(
+        cls: type[Self], message: Message[Self], br: BufferResource
+    ) -> Self: ...
     def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...
 
 class PartitionVectorChunk:
     @classmethod
-    def from_message(cls: type[Self], message: Message[Self]) -> Self: ...
+    def from_message(
+        cls: type[Self], message: Message[Self], br: BufferResource
+    ) -> Self: ...
     def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...
-
-if TYPE_CHECKING:
-    # Check that PartitionMapChunk implements Payload.
-    t1: PartitionMapChunk
-    t2: Payload = t1
-
-    # Check that PartitionVectorChunk implements Payload.
-    t3: PartitionVectorChunk
-    t4: Payload = t3

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
@@ -29,7 +29,7 @@ cdef class PartitionMapChunk:
 
     @staticmethod
     cdef PartitionMapChunk from_handle(
-        unique_ptr[cpp_PartitionMapChunk] handle, BufferResource br=None
+        unique_ptr[cpp_PartitionMapChunk] handle, BufferResource br
     ):
         """
         Construct a PartitionMapChunk from an existing C++ handle.
@@ -50,7 +50,7 @@ cdef class PartitionMapChunk:
         return ret
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br=None):
+    def from_message(Message message not None, BufferResource br):
         """
         Construct a PartitionMapChunk by consuming a Message.
 
@@ -149,7 +149,7 @@ cdef class PartitionVectorChunk:
 
     @staticmethod
     cdef PartitionVectorChunk from_handle(
-        unique_ptr[cpp_PartitionVectorChunk] handle, BufferResource br=None
+        unique_ptr[cpp_PartitionVectorChunk] handle, BufferResource br
     ):
         """
         Construct a PartitionVectorChunk from an existing C++ handle.
@@ -171,7 +171,7 @@ cdef class PartitionVectorChunk:
         return ret
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br=None):
+    def from_message(Message message not None, BufferResource br):
         """
         Construct a PartitionVectorChunk by consuming a Message.
 

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
@@ -50,7 +50,7 @@ cdef class PartitionMapChunk:
         return ret
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br):
+    def from_message(Message message not None, BufferResource br not None):
         """
         Construct a PartitionMapChunk by consuming a Message.
 
@@ -171,7 +171,7 @@ cdef class PartitionVectorChunk:
         return ret
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br):
+    def from_message(Message message not None, BufferResource br not None):
         """
         Construct a PartitionVectorChunk by consuming a Message.
 

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/allgather.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/allgather.pyx
@@ -151,7 +151,7 @@ cdef class AllGather:
                 move(cpp_OwningWrapper(<void*><PyObject*>ret, py_deleter))
             )
         await ret
-        return packed_data_vector_to_list(move(deref(c_ret)))
+        return packed_data_vector_to_list(move(deref(c_ret)), ctx.br())
 
 
 def allgather(

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/shuffler.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/shuffler.pxd
@@ -9,6 +9,7 @@ from libcpp.vector cimport vector
 
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.communicator.communicator cimport Communicator, cpp_Communicator
+from rapidsmpf.memory.buffer_resource cimport BufferResource
 from rapidsmpf.memory.packed_data cimport cpp_PackedData
 from rapidsmpf.shuffler cimport cpp_PartitionOwner
 from rapidsmpf.streaming.core.actor cimport cpp_Actor
@@ -45,3 +46,4 @@ cdef extern from "<rapidsmpf/streaming/coll/shuffler.hpp>" nogil:
 cdef class ShufflerAsync:
     cdef unique_ptr[cpp_ShufflerAsync] _handle
     cdef Communicator _comm
+    cdef BufferResource _br

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/shuffler.pyx
@@ -13,6 +13,7 @@ from libcpp.vector cimport vector
 
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.communicator.communicator cimport Communicator
+# Need the header include for inline C++ code
 from rapidsmpf.memory.buffer_resource cimport BufferResource  # no-cython-lint
 from rapidsmpf.memory.packed_data cimport (PackedData, cpp_PackedData,
                                            packed_data_vector_to_list)

--- a/python/rapidsmpf/rapidsmpf/streaming/coll/shuffler.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/coll/shuffler.pyx
@@ -13,6 +13,7 @@ from libcpp.vector cimport vector
 
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.communicator.communicator cimport Communicator
+from rapidsmpf.memory.buffer_resource cimport BufferResource  # no-cython-lint
 from rapidsmpf.memory.packed_data cimport (PackedData, cpp_PackedData,
                                            packed_data_vector_to_list)
 from rapidsmpf.owning_wrapper cimport cpp_OwningWrapper
@@ -156,6 +157,7 @@ cdef class ShufflerAsync:
         PartitionAssignment partition_assignment = PartitionAssignment.ROUND_ROBIN,
     ):
         self._comm = comm
+        self._br = ctx.br()
         with nogil:
             self._handle = make_unique[cpp_ShufflerAsync](
                 ctx._handle, comm._handle, op_id, total_num_partitions,
@@ -238,7 +240,7 @@ cdef class ShufflerAsync:
         cdef vector[cpp_PackedData] c_ret
         with nogil:
             c_ret = deref(self._handle).extract(pid)
-        return packed_data_vector_to_list(move(c_ret))
+        return packed_data_vector_to_list(move(c_ret), self._br)
 
     def local_partitions(self):
         """

--- a/python/rapidsmpf/rapidsmpf/streaming/core/message.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/message.pyi
@@ -8,7 +8,7 @@ from typing import Generic, Protocol, Self, TypeVar
 from rapidsmpf.memory.content_description import ContentDescription
 from rapidsmpf.memory.memory_reservation import MemoryReservation
 
-PayloadT = TypeVar("PayloadT", bound="Payload")
+PayloadT = TypeVar("PayloadT")
 
 class Payload(Protocol):
     """

--- a/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pxd
@@ -37,6 +37,6 @@ cdef class TableChunk:
     cdef BufferResource _br
 
     @staticmethod
-    cdef TableChunk from_handle(unique_ptr[cpp_TableChunk] handle, BufferResource br=*)
+    cdef TableChunk from_handle(unique_ptr[cpp_TableChunk] handle, BufferResource br)  # noqa: E704
     cdef const cpp_TableChunk* handle_ptr(self)
     cdef unique_ptr[cpp_TableChunk] release_handle(self)

--- a/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pxd
@@ -37,6 +37,6 @@ cdef class TableChunk:
     cdef BufferResource _br
 
     @staticmethod
-    cdef TableChunk from_handle(unique_ptr[cpp_TableChunk] handle, BufferResource br)  # noqa: E704
+    cdef TableChunk from_handle(unique_ptr[cpp_TableChunk] handle, BufferResource br)
     cdef const cpp_TableChunk* handle_ptr(self)
     cdef unique_ptr[cpp_TableChunk] release_handle(self)

--- a/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyi
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Self, overload
+from typing import Self, overload
 
 from pylibcudf.table import Table
 from rmm.pylibrmm.stream import Stream
@@ -13,7 +13,7 @@ from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.memory.memory_reservation import MemoryReservation
 from rapidsmpf.memory.packed_data import PackedData
 from rapidsmpf.streaming.core.context import Context
-from rapidsmpf.streaming.core.message import Message, Payload
+from rapidsmpf.streaming.core.message import Message
 
 class TableChunk:
     @staticmethod
@@ -22,15 +22,13 @@ class TableChunk:
         stream: Stream,
         *,
         exclusive_view: bool,
-        br: BufferResource | None = None,
+        br: BufferResource,
     ) -> TableChunk: ...
     @staticmethod
-    def from_packed_data(
-        pd: PackedData, br: BufferResource | None = None
-    ) -> TableChunk: ...
+    def from_packed_data(pd: PackedData, br: BufferResource) -> TableChunk: ...
     @classmethod
     def from_message(
-        cls: type[Self], message: Message[Self], br: BufferResource | None = None
+        cls: type[Self], message: Message[Self], br: BufferResource
     ) -> Self: ...
     def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...
     @property
@@ -69,8 +67,3 @@ async def make_table_chunks_available_or_wait(
     net_memory_delta: int,
     allow_overbooking: bool | None = None,
 ) -> tuple[list[TableChunk], MemoryReservation]: ...
-
-if TYPE_CHECKING:
-    # Check that TableChunk implements Payload.
-    tc: TableChunk
-    p: Payload = tc

--- a/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
@@ -144,7 +144,7 @@ cdef class TableChunk:
         Stream stream not None,
         *,
         bool_t exclusive_view,
-        BufferResource br,
+        BufferResource br not None,
     ):
         """
         Construct a TableChunk from a pylibcudf Table.
@@ -194,7 +194,7 @@ cdef class TableChunk:
         )
 
     @staticmethod
-    def from_packed_data(PackedData pd not None, BufferResource br):
+    def from_packed_data(PackedData pd not None, BufferResource br not None):
         """
         Construct a TableChunk from packed data.
 
@@ -214,7 +214,7 @@ cdef class TableChunk:
         return TableChunk.from_handle(make_unique[cpp_TableChunk](move(pd.c_obj)), br)
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br):
+    def from_message(Message message not None, BufferResource br not None):
         """
         Construct a TableChunk by consuming a Message.
 

--- a/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/cudf/table_chunk.pyx
@@ -117,7 +117,7 @@ cdef class TableChunk:
 
     @staticmethod
     cdef TableChunk from_handle(
-        unique_ptr[cpp_TableChunk] handle, BufferResource br=None,
+        unique_ptr[cpp_TableChunk] handle, BufferResource br,
     ):
         """
         Construct a TableChunk from an existing C++ handle.
@@ -144,7 +144,7 @@ cdef class TableChunk:
         Stream stream not None,
         *,
         bool_t exclusive_view,
-        BufferResource br=None,
+        BufferResource br,
     ):
         """
         Construct a TableChunk from a pylibcudf Table.
@@ -194,7 +194,7 @@ cdef class TableChunk:
         )
 
     @staticmethod
-    def from_packed_data(PackedData pd not None, BufferResource br=None):
+    def from_packed_data(PackedData pd not None, BufferResource br):
         """
         Construct a TableChunk from packed data.
 
@@ -211,12 +211,10 @@ cdef class TableChunk:
         -----
         This takes ownership of the data in the PackedData object, which is left empty.
         """
-        if br is None:
-            br = pd._br
         return TableChunk.from_handle(make_unique[cpp_TableChunk](move(pd.c_obj)), br)
 
     @staticmethod
-    def from_message(Message message not None, BufferResource br=None):
+    def from_message(Message message not None, BufferResource br):
         """
         Construct a TableChunk by consuming a Message.
 

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_bloom_filter.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_bloom_filter.py
@@ -26,15 +26,16 @@ if TYPE_CHECKING:
     from rmm.pylibrmm.stream import Stream
 
     from rapidsmpf.communicator.communicator import Communicator
+    from rapidsmpf.memory.buffer_resource import BufferResource
     from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
     from rapidsmpf.streaming.cudf.bloom_filter import BloomFilterChunk
 
 
-def make_table(values: np.ndarray, stream: Stream) -> TableChunk:
+def make_table(values: np.ndarray, stream: Stream, br: BufferResource) -> TableChunk:
     table = plc.Table([plc.Column.from_array(values, stream=stream)])
-    return TableChunk.from_pylibcudf_table(table, stream, exclusive_view=True)
+    return TableChunk.from_pylibcudf_table(table, stream, exclusive_view=True, br=br)
 
 
 @define_actor()
@@ -126,8 +127,8 @@ def test_bloom_filter_roundtrip(context: Context, comm: Communicator) -> None:
 
     stream = context.get_stream_from_pool()
     values = np.arange(10, dtype=np.int32)
-    build_table = make_table(values, stream=stream)
-    probe_table = make_table(values, stream=stream)
+    build_table = make_table(values, stream=stream, br=context.br())
+    probe_table = make_table(values, stream=stream, br=context.br())
     messages = run_bloom_filter_pipeline(context, comm, build_table, probe_table)
     assert len(messages) == 1
 
@@ -144,8 +145,12 @@ def test_bloom_filter_empty_build_filters_all(
         pytest.skip("Only support single-rank runs")
 
     stream = context.get_stream_from_pool()
-    build_table = make_table(np.array([], dtype=np.int32), stream=stream)
-    probe_table = make_table(np.arange(5, dtype=np.int32), stream=stream)
+    build_table = make_table(
+        np.array([], dtype=np.int32), stream=stream, br=context.br()
+    )
+    probe_table = make_table(
+        np.arange(5, dtype=np.int32), stream=stream, br=context.br()
+    )
     messages = run_bloom_filter_pipeline(context, comm, build_table, probe_table)
     assert len(messages) == 1
 


### PR DESCRIPTION
## Summary

Follow-up to #960 which added `BufferResource` lifetime tracking to Python wrapper classes. This PR makes all of those `br` parameters **required** instead of optional (removes `=None`/`=*` defaults), so callers are forced to pass a `BufferResource` and cannot accidentally omit it.

## Changes

- Removed `=None`/`=*` defaults from `br` parameters in:
  - `PackedData.from_librapidsmpf`, `packed_data_vector_to_list`
  - `PackedDataChunk.from_handle`, `from_packed_data`, `from_message`
  - `PartitionMapChunk` and `PartitionVectorChunk`: `from_handle`, `from_message`
  - `TableChunk.from_handle`, `from_pylibcudf_table`, `from_packed_data`, `from_message`
- Removed `if br is None: br = obj._br` fallback logic in `PackedDataChunk` and `TableChunk`
- `ShufflerAsync` now stores `ctx.br()` as `self._br` and passes it to `packed_data_vector_to_list` in `extract()`
- `AllGather.extract_all` now passes `ctx.br()` to `packed_data_vector_to_list`
- Updated `.pyi` stubs and `Payload` protocol (`PayloadT` TypeVar bound relaxed to allow types with extended `from_message` signatures)
- Updated `test_bloom_filter.py` to pass `br` to `make_table` and `TableChunk.from_pylibcudf_table`