### PR TITLE
Increase timeout for test_bootstrap_multiple_clients

### DIFF
--- a/python/rapidsmpf/rapidsmpf/tests/test_dask.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_dask.py
@@ -465,7 +465,7 @@ def test_dask_cudf_join(
             dd.assert_eq(joined, expected, check_index=False)
 
 
-@gen_test(timeout=30)
+@gen_test(timeout=60)
 @pytest.mark.filterwarnings("ignore")
 async def test_bootstrap_multiple_clients(
     loop: pytest.FixtureDef,  # noqa: F811
@@ -487,7 +487,9 @@ async def test_bootstrap_multiple_clients(
             args=(cluster.scheduler_address, q),
         )
         p.start()
-        result = q.get(timeout=5)
+        # forkserver subprocess must reimport all modules from scratch,
+        # which can be slow on loaded CI machines.
+        result = q.get(timeout=30)
         p.join()
 
     assert result is True


### PR DESCRIPTION
PR #901 switched the subprocess in this test from `fork` to `forkserver` and simultaneously reduced the `q.get` timeout from 10 s to 5 s. Unlike `fork`, `forkserver` starts a fresh Python interpreter that must reimport all modules, which is likely slower due to the additional import work. On loaded CI machines this can exceed 5 seconds, causing a spurious `_queue.Empty` failure.

Increase the `q.get` timeout to 30 seconds and the `@gen_test` timeout to 60 seconds to give the subprocess enough headroom.