### PR TITLE
Use non-deprecated `cudf::filtered_join` constructor

### DIFF
--- a/cpp/benchmarks/streaming/ndsh/join.cpp
+++ b/cpp/benchmarks/streaming/ndsh/join.cpp
@@ -179,7 +179,6 @@ streaming::Message semi_join_chunk(
     auto joiner = cudf::filtered_join(
         right_chunk.table_view().select(right_on),
         cudf::null_equality::UNEQUAL,
-        cudf::set_as_build_table::RIGHT,
         chunk_stream
     );
 


### PR DESCRIPTION
The `cudf::filtered_join` API now always treats the first argument as the build (right/filter) table, making the `set_as_build_table` parameter unnecessary and deprecated.