### PR TITLE
Enable adding setup statistics 

### DIFF
--- a/cpp/benchmarks/streaming/ndsh/utils.cpp
+++ b/cpp/benchmarks/streaming/ndsh/utils.cpp
@@ -156,10 +156,19 @@ create_context(ProgramOptions& arguments, RmmResourceAdaptor* mr) {
         std::invalid_argument
     );
 
+    std::shared_ptr<PinnedMemoryResource> pinned_mr = PinnedMemoryResource::Disabled;
+    if (!arguments.no_pinned_host_memory) {
+        auto const setup_stat = Clock::now();
+        pinned_mr = std::make_shared<PinnedMemoryResource>();
+        auto setup_time = Clock::now() - setup_stat;
+        statistics->record_setup_stat(
+            "pinned-pool-setup", pinned_mr->current_allocated(), setup_time
+        );
+    }
+
     auto br = std::make_shared<BufferResource>(
         mr,
-        arguments.no_pinned_host_memory ? PinnedMemoryResource::Disabled
-                                        : std::make_shared<PinnedMemoryResource>(),
+        std::move(pinned_mr),
         std::move(memory_available),
         arguments.periodic_spill,
         std::make_shared<rmm::cuda_stream_pool>(

--- a/cpp/include/rapidsmpf/statistics.hpp
+++ b/cpp/include/rapidsmpf/statistics.hpp
@@ -394,6 +394,14 @@ class Statistics {
     Stat get_stat(std::string const& name) const;
 
     /**
+     * @brief Retrieves all statistics by prefix.
+     *
+     * @param prefix The prefix to filter statistics by.
+     * @return A vector of statistics matching the prefix.
+     */
+    std::unordered_map<std::string, Stat> get_stats(std::string const& prefix) const;
+
+    /**
      * @brief Adds a numeric value to the named statistic.
      *
      * Creates the statistic if it doesn't exist.
@@ -519,6 +527,22 @@ class Statistics {
     );
 
     /**
+     * @brief Record setup statistics for a given prefix.
+     *
+     * @param prefix The prefix to use for the setup statistics.
+     * @param nbytes The number of bytes to record.
+     * @param duration The duration to record.
+     */
+    void record_setup_stat(std::string prefix, std::size_t nbytes, Duration duration);
+
+    /**
+     * @brief Get the prefixes of all setup statistics.
+     *
+     * @return A reference to the set of setup statistics prefixes.
+     */
+    std::unordered_set<std::string> const& get_setup_stats_prefixes() const;
+
+    /**
      * @brief Get the names of all statistics.
      *
      * @return A vector of all statistic names.
@@ -622,6 +646,7 @@ class Statistics {
     RmmResourceAdaptor* mr_;
     std::shared_ptr<PinnedMemoryResource>
         pinned_mr_;  ///< optional; not used by MemoryRecorder
+    std::unordered_set<std::string> setup_stats_prefixes_;
 };
 
 /**

--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -56,14 +56,25 @@ BufferResource::BufferResource(
 std::shared_ptr<BufferResource> BufferResource::from_options(
     RmmResourceAdaptor* mr, config::Options options
 ) {
+    // TODO: currently statistics requires pinned mr/ mr to be passed in the constructor.
+    // But this is not really required. After the RMM refactor, we can make statistics
+    // object independent from memory resources. Its not possible now because we dont have
+    // a way to convert rmm::device_async_resource_ref to RmmResourceAdaptor.
+    // Because of this, pinned pool setup time is only recorded during from_options
+    // method.
+    auto const setup_stat = Clock::now();
     auto pinned_mr = PinnedMemoryResource::from_options(options);
     auto mem_available = memory_available_from_options(mr, options);
 
     if (pinned_mr != PinnedMemoryResource::Disabled) {
         mem_available[MemoryType::PINNED_HOST] = pinned_mr->get_memory_available_cb();
     }
+    auto setup_time = Clock::now() - setup_stat;
 
     auto statistics = Statistics::from_options(mr, options, pinned_mr);
+    statistics->record_setup_stat(
+        "pinned-pool-setup", pinned_mr->current_allocated(), setup_time
+    );
     return std::make_shared<BufferResource>(
         mr,
         std::move(pinned_mr),

--- a/cpp/src/statistics.cpp
+++ b/cpp/src/statistics.cpp
@@ -138,13 +138,25 @@ Statistics::Stat Statistics::get_stat(std::string const& name) const {
     return stats_.at(name);
 }
 
+std::unordered_map<std::string, Statistics::Stat> Statistics::get_stats(
+    std::string const& prefix
+) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::unordered_map<std::string, Stat> ret;
+    for (auto const& [name, stat] : stats_) {
+        if (name.starts_with(prefix)) {
+            ret[name] = stat;
+        }
+    }
+    return ret;
+}
+
 void Statistics::add_stat(std::string const& name, double value) {
     if (!enabled()) {
         return;
     }
     std::lock_guard<std::mutex> lock(mutex_);
-    auto [it, _] = stats_.try_emplace(name);
-    it->second.add(value);
+    stats_[name].add(value);
 }
 
 bool Statistics::exist_report_entry_name(std::string const& name) const {
@@ -535,6 +547,7 @@ std::shared_ptr<Statistics> Statistics::merge(
     auto ret = std::make_shared<Statistics>(enabled_.load(std::memory_order_acquire));
     ret->stats_ = stats_;
     ret->formatters_ = formatters_;
+    ret->setup_stats_prefixes_ = setup_stats_prefixes_;
 
     for (auto const& [name, stat] : other->stats_) {
         auto [it, inserted] = ret->stats_.try_emplace(name, stat);
@@ -542,6 +555,14 @@ std::shared_ptr<Statistics> Statistics::merge(
             it->second = it->second.merge(stat);
         }
     }
+
+    // update the missing formatters
+    ret->formatters_.insert(other->formatters_.begin(), other->formatters_.end());
+
+    // update the missing setup stats prefixes
+    ret->setup_stats_prefixes_.insert(
+        other->setup_stats_prefixes_.begin(), other->setup_stats_prefixes_.end()
+    );
     return ret;
 }
 
@@ -659,6 +680,34 @@ void Statistics::record_alloc(
                   );
         }
     );
+}
+
+void Statistics::record_setup_stat(
+    std::string prefix, std::size_t nbytes, Duration duration
+) {
+    RAPIDSMPF_EXPECTS(
+        setup_stats_prefixes_.emplace(prefix).second,
+        "setup stat prefix already exists: " + prefix
+    );
+
+    const std::vector<std::string> stat_names{
+        prefix + "-time",
+        prefix + "-bytes",
+    };
+    add_stat(stat_names[0], duration.count());
+    add_stat(stat_names[1], nbytes);
+
+    register_formatter(
+        prefix, stat_names, [](std::ostream& os, std::vector<Stat> const& stats) {
+            auto const time = stats.at(0);
+            auto const bytes = stats.at(1);
+            os << format_duration(time.value()) << " | " << format_nbytes(bytes.value());
+        }
+    );
+}
+
+std::unordered_set<std::string> const& Statistics::get_setup_stats_prefixes() const {
+    return setup_stats_prefixes_;
 }
 
 }  // namespace rapidsmpf

--- a/cpp/tests/test_statistics.cpp
+++ b/cpp/tests/test_statistics.cpp
@@ -529,7 +529,7 @@ TEST_F(StatisticsTest, MergeEmpty) {
     EXPECT_EQ(merged2->list_stat_names().size(), 1);
 }
 
-TEST_F(StatisticsTest, MergeUsesThisFormatters) {
+TEST_F(StatisticsTest, MergeFormatters) {
     auto a = std::make_shared<rapidsmpf::Statistics>();
     a->register_formatter(
         "x", [](std::ostream& os, std::vector<rapidsmpf::Statistics::Stat> const& s) {
@@ -545,9 +545,27 @@ TEST_F(StatisticsTest, MergeUsesThisFormatters) {
     auto merged = a->merge(b);
     EXPECT_THAT(merged->report(), ::testing::HasSubstr("custom:15"));
 
-    // Merging b (no formatter) with a: result does not have the formatter.
+    // Merging b (no formatter for "x") with a (has formatter for "x"): a's formatter
+    // propagates into the result since b has no conflicting formatter for "x".
     auto merged2 = b->merge(a);
-    EXPECT_THAT(merged2->report(), ::testing::Not(::testing::HasSubstr("custom:")));
+    EXPECT_THAT(merged2->report(), ::testing::HasSubstr("custom:15"));
+
+    // When both sides have a formatter for the same key, "this" (b) takes precedence.
+    b->register_formatter(
+        "y", [](std::ostream& os, std::vector<rapidsmpf::Statistics::Stat> const& s) {
+            os << "b-custom:" << s[0].value();
+        }
+    );
+    a->register_formatter(
+        "y", [](std::ostream& os, std::vector<rapidsmpf::Statistics::Stat> const& s) {
+            os << "a-custom:" << s[0].value();
+        }
+    );
+    b->add_stat("y", 3.0);
+    a->add_stat("y", 7.0);
+    auto merged3 = b->merge(a);
+    EXPECT_THAT(merged3->report(), ::testing::HasSubstr("b-custom:10"));
+    EXPECT_THAT(merged3->report(), ::testing::Not(::testing::HasSubstr("a-custom:")));
 }
 
 TEST_F(StatisticsTest, MergeSpan) {
@@ -566,4 +584,60 @@ TEST_F(StatisticsTest, MergeSpan) {
     EXPECT_EQ(merged->list_stat_names().size(), 2);
     EXPECT_EQ(merged->get_stat("x").value(), 3.0);
     EXPECT_EQ(merged->get_stat("y").value(), 10.0);
+}
+
+TEST_F(StatisticsTest, RecordSetupStat) {
+    rapidsmpf::Statistics stats;
+
+    stats.record_setup_stat("setup-a", 100, Duration{1.0});
+    stats.record_setup_stat("setup-b", 200, Duration{0.5});
+
+    // The underlying time and bytes stats are accessible by their full names.
+    EXPECT_DOUBLE_EQ(stats.get_stat("setup-a-time").value(), 1.0);
+    EXPECT_DOUBLE_EQ(stats.get_stat("setup-a-bytes").value(), 100.0);
+    EXPECT_DOUBLE_EQ(stats.get_stat("setup-b-time").value(), 0.5);
+    EXPECT_DOUBLE_EQ(stats.get_stat("setup-b-bytes").value(), static_cast<double>(200));
+
+    // Both prefixes are tracked.
+    auto const& prefixes = stats.get_setup_stats_prefixes();
+    EXPECT_EQ(prefixes.size(), 2);
+    EXPECT_EQ(prefixes.count("setup-a"), 1);
+    EXPECT_EQ(prefixes.count("setup-b"), 1);
+
+    // A report-entry formatter is registered under each prefix name.
+    EXPECT_TRUE(stats.exist_report_entry_name("setup-a"));
+    EXPECT_TRUE(stats.exist_report_entry_name("setup-b"));
+
+    // The report shows prefix labels but not the individual sub-stat names.
+    auto report = stats.report();
+    EXPECT_THAT(report, ::testing::HasSubstr("setup-a"));
+    EXPECT_THAT(report, ::testing::HasSubstr("setup-b"));
+    EXPECT_THAT(report, ::testing::Not(::testing::HasSubstr("setup-a-time")));
+    EXPECT_THAT(report, ::testing::Not(::testing::HasSubstr("setup-a-bytes")));
+    EXPECT_THAT(report, ::testing::Not(::testing::HasSubstr("setup-b-time")));
+    EXPECT_THAT(report, ::testing::Not(::testing::HasSubstr("setup-b-bytes")));
+
+    // Duplicate prefix throws.
+    EXPECT_THROW(
+        stats.record_setup_stat("setup-a", 256, Duration{0.2}), std::logic_error
+    );
+}
+
+TEST_F(StatisticsTest, MergeSetupStatPrefixes) {
+    auto a = std::make_shared<rapidsmpf::Statistics>();
+    a->record_setup_stat("setup-a", 100, Duration{1.0});
+
+    auto b = std::make_shared<rapidsmpf::Statistics>();
+    b->record_setup_stat("setup-b", 200, Duration{2.0});
+
+    auto merged = a->merge(b);
+
+    // Both prefixes must be present in the merged result.
+    auto const& prefixes = merged->get_setup_stats_prefixes();
+    EXPECT_EQ(prefixes.count("setup-a"), 1);
+    EXPECT_EQ(prefixes.count("setup-b"), 1);
+
+    // Stats from both sides should be merged.
+    EXPECT_DOUBLE_EQ(merged->get_stat("setup-a-bytes").value(), 100.0);
+    EXPECT_DOUBLE_EQ(merged->get_stat("setup-b-bytes").value(), 200.0);
 }


### PR DESCRIPTION
This PR enables adding setup stats. Main usecase is to record pinned pool creation time. But we can add more stats later if needed 