### PR TITLE
Change cuCascade GIT_TAG to main

### DIFF
--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -26,14 +26,13 @@ function(find_and_configure_cucascade)
     set_target_properties(kvikio::kvikio PROPERTIES IMPORTED_GLOBAL TRUE)
   endif()
 
-  # We pin to a commit of cuCascade from https://github.com/NVIDIA/cuCascade/pull/98 until the RMM
-  # CCCL memory resource migration is complete.
   rapids_cpm_find(
     cuCascade 0.1.0
     GLOBAL_TARGETS cuCascade::cucascade
     CPM_ARGS
     GIT_REPOSITORY https://github.com/NVIDIA/cuCascade.git
-    GIT_TAG e2fa1cf30ca8ab622b86952d32a80eb69a0a6851
+    GIT_TAG main
+    GIT_SHALLOW TRUE
     OPTIONS "CUCASCADE_BUILD_TESTS OFF"
             "CUCASCADE_BUILD_BENCHMARKS OFF"
             "CUCASCADE_BUILD_SHARED_LIBS OFF"


### PR DESCRIPTION
Updated cuCascade GIT_TAG to use the main branch and enabled shallow cloning.

Cucascade was pinned to RMM refactor PR previously. Its now merged. 
https://github.com/NVIDIA/cuCascade/pull/98