### PR TITLE
Harden FileBackend key validation and temp file creation

### DIFF
--- a/cpp/src/bootstrap/file_backend.cpp
+++ b/cpp/src/bootstrap/file_backend.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -224,8 +225,7 @@ void FileBackend::write_file(std::string const& path, std::string_view content) 
         if (written < 0) {
             int err = errno;
             ::close(fd);
-            std::error_code rm_ec;
-            std::filesystem::remove(tmp_path, rm_ec);
+            ::unlink(tmp_path.c_str());
             throw std::runtime_error(
                 "Failed to write to temporary file: " + tmp_path + ": "
                 + std::strerror(err)
@@ -236,14 +236,12 @@ void FileBackend::write_file(std::string const& path, std::string_view content) 
     }
     ::close(fd);
 
-    // Atomic rename
-    std::error_code ec;
-    std::filesystem::rename(tmp_path, path, ec);
-    if (ec) {
-        std::error_code rm_ec;
-        std::filesystem::remove(tmp_path, rm_ec);
+    // POSIX rename(2) guarantees atomic replacement of the destination.
+    if (::rename(tmp_path.c_str(), path.c_str()) != 0) {
+        int err = errno;
+        ::unlink(tmp_path.c_str());
         throw std::runtime_error(
-            "Failed to rename " + tmp_path + " to " + path + ": " + ec.message()
+            "Failed to rename " + tmp_path + " to " + path + ": " + std::strerror(err)
         );
     }
 }

--- a/cpp/src/bootstrap/file_backend.cpp
+++ b/cpp/src/bootstrap/file_backend.cpp
@@ -223,7 +223,7 @@ void FileBackend::write_file(std::string const& path, std::string_view content) 
     while (bytes_left > 0) {
         auto written = ::write(fd, ptr, bytes_left);
         if (written < 0) {
-            if (errno == EINTR)  {
+            if (errno == EINTR) {
                 continue;  // re-try on interrupt
             }
             int err = errno;

--- a/cpp/src/bootstrap/file_backend.cpp
+++ b/cpp/src/bootstrap/file_backend.cpp
@@ -223,6 +223,9 @@ void FileBackend::write_file(std::string const& path, std::string_view content) 
     while (bytes_left > 0) {
         auto written = ::write(fd, ptr, bytes_left);
         if (written < 0) {
+            if (errno == EINTR)  {
+                continue;  // re-try on interrupt
+            }
             int err = errno;
             ::close(fd);
             ::unlink(tmp_path.c_str());

--- a/cpp/src/bootstrap/file_backend.cpp
+++ b/cpp/src/bootstrap/file_backend.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -13,6 +14,8 @@
 #include <string_view>
 #include <system_error>
 #include <thread>
+
+#include <unistd.h>
 
 #include <rapidsmpf/bootstrap/file_backend.hpp>
 #include <rapidsmpf/error.hpp>
@@ -123,6 +126,14 @@ void FileBackend::sync() {
 }
 
 std::string FileBackend::get_kv_path(std::string const& key) const {
+    if (key.empty() || key.find("..") != std::string::npos
+        || key.find('/') != std::string::npos || key.find('\\') != std::string::npos
+        || key.find('\0') != std::string::npos)
+    {
+        throw std::invalid_argument(
+            "Key contains invalid path characters (e.g., '..', '/', '\\'): " + key
+        );
+    }
     return kv_dir_ + "/" + key;
 }
 
@@ -193,22 +204,44 @@ bool FileBackend::wait_for_file(std::string const& path, Duration timeout) {
 }
 
 void FileBackend::write_file(std::string const& path, std::string_view content) {
-    std::string tmp_path = path + ".tmp." + std::to_string(getpid());
+    std::string tmp_path = path + ".tmp.XXXXXX";
 
-    // Write to temporary file
-    std::ofstream ofs(tmp_path, std::ios::binary | std::ios::trunc);
-    if (!ofs) {
-        throw std::runtime_error("Failed to open temporary file: " + tmp_path);
+    // mkstemp requires a mutable char array and atomically creates a unique file,
+    // preventing symlink race conditions on shared filesystems.
+    int fd = mkstemp(tmp_path.data());
+    if (fd == -1) {
+        throw std::runtime_error(
+            "Failed to create temporary file via mkstemp: " + tmp_path + ": "
+            + std::strerror(errno)
+        );
     }
-    ofs.write(content.data(), static_cast<std::streamsize>(content.size()));
-    ofs.close();
+
+    // Write content and close the file descriptor
+    auto bytes_left = content.size();
+    auto const* ptr = content.data();
+    while (bytes_left > 0) {
+        auto written = ::write(fd, ptr, bytes_left);
+        if (written < 0) {
+            int err = errno;
+            ::close(fd);
+            std::error_code rm_ec;
+            std::filesystem::remove(tmp_path, rm_ec);
+            throw std::runtime_error(
+                "Failed to write to temporary file: " + tmp_path + ": "
+                + std::strerror(err)
+            );
+        }
+        bytes_left -= static_cast<std::size_t>(written);
+        ptr += written;
+    }
+    ::close(fd);
 
     // Atomic rename
     std::error_code ec;
     std::filesystem::rename(tmp_path, path, ec);
     if (ec) {
         std::error_code rm_ec;
-        std::filesystem::remove(tmp_path, rm_ec);  // Clean up temp file
+        std::filesystem::remove(tmp_path, rm_ec);
         throw std::runtime_error(
             "Failed to rename " + tmp_path + " to " + path + ": " + ec.message()
         );


### PR DESCRIPTION
Add input validation to `get_kv_path` to reject keys containing path separators (`/`, `\`), parent directory references (`..`), null bytes, or empty strings. This ensures that key-value paths are always confined to the intended coordination directory on shared filesystems.

Replace the predictable PID-based temporary file naming in `write_file` with `mkstemp()`, which atomically creates a uniquely-named file. This strengthens the atomic write pattern against race conditions on shared NFS mounts where multiple processes may operate concurrently. The write loop now also correctly handles partial writes via POSIX `write()`.