### PR TITLE
Remove unnecessary `$<BUILD_INTERFACE:...>` from CMake targets

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(bench_utils INTERFACE utils/random_data.cu)
 add_executable(bench_shuffle "bench_shuffle.cpp")
 set_target_properties(
   bench_shuffle
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/benchmarks"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              # For std:: support of __int128_t. Can be removed once using cuda::std
@@ -36,7 +36,7 @@ install(
 add_executable(bench_comm "bench_comm.cpp")
 set_target_properties(
   bench_comm
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/benchmarks"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              # For std:: support of __int128_t. Can be removed once using cuda::std
@@ -66,7 +66,7 @@ rapids_cpm_gbench(BUILD_STATIC)
 add_executable(bench_partition "bench_partition.cpp")
 set_target_properties(
   bench_partition
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/benchmarks"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              # For std:: support of __int128_t. Can be removed once using cuda::std
@@ -99,7 +99,7 @@ install(
 add_executable(bench_memory_resources "bench_memory_resources.cpp")
 set_target_properties(
   bench_memory_resources
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/benchmarks"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              CXX_EXTENSIONS ON
@@ -125,7 +125,7 @@ install(
 add_executable(bench_pack "bench_pack.cpp")
 set_target_properties(
   bench_pack
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/benchmarks"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              CXX_EXTENSIONS ON

--- a/cpp/benchmarks/streaming/CMakeLists.txt
+++ b/cpp/benchmarks/streaming/CMakeLists.txt
@@ -8,7 +8,7 @@
 add_executable(bench_streaming_shuffle "bench_streaming_shuffle.cpp")
 set_target_properties(
   bench_streaming_shuffle
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/benchmarks"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              CUDA_STANDARD 20

--- a/cpp/benchmarks/streaming/ndsh/CMakeLists.txt
+++ b/cpp/benchmarks/streaming/ndsh/CMakeLists.txt
@@ -44,7 +44,7 @@ foreach(query IN ITEMS ${RAPIDSMPFNDSH_QUERIES})
   add_executable(${query} "${query}.cpp")
   set_target_properties(
     ${query}
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/benchmarks/ndsh>"
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/benchmarks/ndsh"
                CXX_STANDARD 20
                CXX_STANDARD_REQUIRED ON
                CUDA_STANDARD 20

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -8,7 +8,7 @@
 add_executable(example_shuffle "example_shuffle.cpp" "../benchmarks/utils/random_data.cu")
 set_target_properties(
   example_shuffle
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/examples>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/examples"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              # For std:: support of __int128_t. Can be removed once using cuda::std
@@ -35,7 +35,7 @@ if(RAPIDSMPF_HAVE_CUPTI)
   add_executable(example_cupti_monitor "example_cupti_monitor.cpp")
   set_target_properties(
     example_cupti_monitor
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/examples>"
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/examples"
                CXX_STANDARD 20
                CXX_STANDARD_REQUIRED ON
                CUDA_STANDARD 20

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ set_target_properties(
              CUDA_STANDARD 20
              CUDA_STANDARD_REQUIRED ON
 )
-target_include_directories(test_sources PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(test_sources PRIVATE "${PROJECT_SOURCE_DIR}/include")
 target_compile_options(
   test_sources PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
                        "$<$<COMPILE_LANGUAGE:CUDA>:${RAPIDSMPF_CUDA_FLAGS}>"
@@ -125,7 +125,7 @@ if(RAPIDSMPF_HAVE_MPI)
   add_executable(mpi_tests main/mpi.cpp)
   set_target_properties(
     mpi_tests
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/gtests>"
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/gtests"
                CXX_STANDARD 20
                CXX_STANDARD_REQUIRED ON
                # For std:: support of __int128_t. Can be removed once using cuda::std
@@ -157,7 +157,7 @@ if(RAPIDSMPF_HAVE_MPI)
     add_executable(ucxx_tests main/ucxx.cpp)
     set_target_properties(
       ucxx_tests
-      PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/gtests>"
+      PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/gtests"
                  CXX_STANDARD 20
                  CXX_STANDARD_REQUIRED ON
                  # For std:: support of __int128_t. Can be removed once using cuda::std
@@ -193,7 +193,7 @@ endif()
 add_executable(rrun_tests main/rrun.cpp test_rrun.cpp test_rrun_bind.cpp)
 set_target_properties(
   rrun_tests
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/gtests>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/gtests"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              # For std:: support of __int128_t. Can be removed once using cuda::std
@@ -217,7 +217,7 @@ add_executable(single_tests main/single.cpp)
 
 set_target_properties(
   single_tests
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${RAPIDSMPF_BINARY_DIR}/gtests>"
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/gtests"
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
              # For std:: support of __int128_t. Can be removed once using cuda::std

--- a/cpp/tools/CMakeLists.txt
+++ b/cpp/tools/CMakeLists.txt
@@ -8,10 +8,10 @@
 add_executable(
   rrun
   "rrun.cpp"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/rrun/rrun.cpp>"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/bootstrap/utils.cpp>"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/system_info.cpp>"
-  "$<$<BOOL:${RAPIDSMPF_HAVE_SLURM}>:$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/bootstrap/slurm_backend.cpp>>"
+  "${PROJECT_SOURCE_DIR}/src/rrun/rrun.cpp"
+  "${PROJECT_SOURCE_DIR}/src/bootstrap/utils.cpp"
+  "${PROJECT_SOURCE_DIR}/src/system_info.cpp"
+  "$<$<BOOL:${RAPIDSMPF_HAVE_SLURM}>:${PROJECT_SOURCE_DIR}/src/bootstrap/slurm_backend.cpp>"
 )
 set_target_properties(
   rrun
@@ -19,7 +19,7 @@ set_target_properties(
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
 )
-target_include_directories(rrun PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_include_directories(rrun PRIVATE "${PROJECT_SOURCE_DIR}/include")
 target_compile_options(rrun PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>")
 target_compile_definitions(
   rrun PRIVATE $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:RAPIDSMPF_HAVE_NUMA>
@@ -43,8 +43,7 @@ install(
 )
 
 add_executable(
-  topology_discovery "topology_discovery.cpp"
-                     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/system_info.cpp>"
+  topology_discovery "topology_discovery.cpp" "${PROJECT_SOURCE_DIR}/src/system_info.cpp"
 )
 set_target_properties(
   topology_discovery
@@ -52,9 +51,7 @@ set_target_properties(
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
 )
-target_include_directories(
-  topology_discovery PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
-)
+target_include_directories(topology_discovery PRIVATE "${PROJECT_SOURCE_DIR}/include")
 target_compile_options(
   topology_discovery PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
 )
@@ -76,10 +73,8 @@ install(
 
 add_executable(
   check_resource_binding
-  "check_resource_binding.cpp"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/rrun/rrun.cpp>"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/bootstrap/utils.cpp>"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/system_info.cpp>"
+  "check_resource_binding.cpp" "${PROJECT_SOURCE_DIR}/src/rrun/rrun.cpp"
+  "${PROJECT_SOURCE_DIR}/src/bootstrap/utils.cpp" "${PROJECT_SOURCE_DIR}/src/system_info.cpp"
 )
 set_target_properties(
   check_resource_binding
@@ -87,9 +82,7 @@ set_target_properties(
              CXX_STANDARD 20
              CXX_STANDARD_REQUIRED ON
 )
-target_include_directories(
-  check_resource_binding PRIVATE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
-)
+target_include_directories(check_resource_binding PRIVATE "${PROJECT_SOURCE_DIR}/include")
 target_compile_options(
   check_resource_binding PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
 )


### PR DESCRIPTION
The `$<BUILD_INTERFACE:...>` generator expression only has an effect on `PUBLIC` or `INTERFACE` properties, where it controls what downstream consumers see when they consume the target via `find_package()` or `add_subdirectory()`. It was being used in several places where it served no purpose: on `PRIVATE` source files and include directories (which never propagate), and on `RUNTIME_OUTPUT_DIRECTORY` target properties (which are non-propagating build-time-only properties). This PR removes the redundant wrapping, leaving only the one legitimate usage on the `rapidsmpf` library's `PUBLIC` include directory.