### PR TITLE
Disable pinned memory by default

### DIFF
--- a/cpp/include/rapidsmpf/memory/pinned_memory_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/pinned_memory_resource.hpp
@@ -100,6 +100,9 @@ class PinnedMemoryResource final
     /// @brief Sentinel value indicating that pinned host memory is disabled.
     static constexpr std::nullopt_t Disabled = std::nullopt;
 
+    /// @brief Whether pinned host memory is enabled by default.
+    static constexpr bool EnabledByDefault = false;
+
     /**
      * @brief Fraction of total host memory per GPU used as the initial pinned pool size
      *        when no explicit `pinned_initial_pool_size` option is provided.
@@ -107,7 +110,7 @@ class PinnedMemoryResource final
      * Applied as: `initial_pool_size = get_host_memory_per_gpu() *
      * DefaultInitiPoolSizeFactor`.
      */
-    static constexpr std::string_view DefaultInitiPoolSizeFactor = "10%";
+    static constexpr std::string_view DefaultInitiPoolSizeFactor = "0%";
 
     /**
      * @brief Fraction of total host memory per GPU used as the maximum pinned pool size
@@ -138,7 +141,8 @@ class PinnedMemoryResource final
      * @brief Construct from configuration options.
      *
      * Recognized options:
-     * - `pinned_memory` (bool): enables pinned memory; defaults to `true`.
+     * - `pinned_memory` (bool): enables pinned memory; defaults to
+     *   `EnabledByDefault`.
      * - `pinned_initial_pool_size` (nbytes string): initial pool size; defaults to
      *   `get_host_memory_per_gpu() * DefaultInitiPoolSizeFactor`.
      * - `pinned_max_pool_size` (nbytes string or empty): maximum pool size; defaults to

--- a/cpp/src/memory/pinned_memory_resource.cpp
+++ b/cpp/src/memory/pinned_memory_resource.cpp
@@ -74,7 +74,7 @@ std::optional<PinnedMemoryResource> PinnedMemoryResource::from_options(
     config::Options options
 ) {
     bool const pinned_memory = options.get<bool>("pinned_memory", [](auto const& s) {
-        return s.empty() ? true : parse_string<bool>(s);
+        return s.empty() ? EnabledByDefault : parse_string<bool>(s);
     });
 
     if (pinned_memory && is_pinned_memory_resources_supported()) {
@@ -115,3 +115,4 @@ std::function<std::int64_t()> PinnedMemoryResource::get_memory_available_cb() co
 }
 
 }  // namespace rapidsmpf
+1

--- a/cpp/src/memory/pinned_memory_resource.cpp
+++ b/cpp/src/memory/pinned_memory_resource.cpp
@@ -115,4 +115,3 @@ std::function<std::int64_t()> PinnedMemoryResource::get_memory_available_cb() co
 }
 
 }  // namespace rapidsmpf
-1

--- a/cpp/tests/test_config.cpp
+++ b/cpp/tests/test_config.cpp
@@ -504,18 +504,13 @@ TEST(OptionsTest, PinnedMemoryResourceFromOptionsDisabledWhenSetToFalse) {
     EXPECT_FALSE(pmr.has_value());
 }
 
-TEST(OptionsTest, PinnedMemoryResourceFromOptionsEnabledByDefault) {
+TEST(OptionsTest, PinnedMemoryResourceFromOptionsDisabledByDefault) {
     Options opts;  // Empty options
 
     auto pmr = PinnedMemoryResource::from_options(opts);
 
-    if (is_pinned_memory_resources_supported()) {
-        EXPECT_NE(pmr, PinnedMemoryResource::Disabled);
-        EXPECT_TRUE(pmr.has_value());
-    } else {
-        EXPECT_EQ(pmr, PinnedMemoryResource::Disabled);
-        EXPECT_FALSE(pmr.has_value());
-    }
+    EXPECT_EQ(pmr, PinnedMemoryResource::Disabled);
+    EXPECT_FALSE(pmr.has_value());
 }
 
 TEST(OptionsTest, MemoryAvailableFromOptionsCreatesMapWithDeviceLimit) {

--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -96,7 +96,7 @@ rapidsmpf::config::Options options{rapidsmpf::config::get_environment_variables(
 
 - **`pinned_memory`**
   - **Environment Variable**: `RAPIDSMPF_PINNED_MEMORY`
-  - **Default**: `true`
+  - **Default**: `false`
   - **Description**: Enables pinned host memory if it is available on the system.
     Pinned host memory provides higher bandwidth and lower latency for device-to-host
     transfers compared to regular pageable host memory. When enabled, RapidsMPF

--- a/python/rapidsmpf/rapidsmpf/tests/test_config.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_config.py
@@ -410,7 +410,7 @@ def test_statistics_from_options(*, opts: Options, expected_enabled: bool) -> No
     [
         (Options({"pinned_memory": "True"}), True),
         (Options({"pinned_memory": "False"}), False),
-        (Options(), True),  # Default case
+        (Options(), False),  # Default case (disabled by default)
     ],
 )
 def test_pinned_memory_resource_from_options(


### PR DESCRIPTION
As per the discussion today regarding defaults, we will be disabling pinned memory by default. 

This will unblock cudf CI. To be confirmed by this https://github.com/rapidsai/cudf/pull/22425 