### PR TITLE
Remove py_executor from run_actor_network

### DIFF
--- a/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
+++ b/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 import cudf
@@ -47,9 +46,6 @@ def main() -> int:
         br=BufferResource(RmmResourceAdaptor(rmm.mr.get_current_device_resource())),
         options=options,
     )
-
-    # Executor for Python actors (asyncio coroutines).
-    py_executor = ThreadPoolExecutor(max_workers=1)
 
     # Create some pylibcudf tables as input to the streaming graph.
     tables = [
@@ -120,12 +116,12 @@ def main() -> int:
 
     # Run all actors. This blocks until every actor has completed.
     run_actor_network(
+        ctx,
         actors=(
             actor1,
             actor2,
             actor3,
         ),
-        py_executor=py_executor,
     )
 
     # Collect and verify results.

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pxd
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pxd
@@ -2,18 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp.memory cimport unique_ptr
-from libcpp.vector cimport vector
-
-from rapidsmpf._detail.exception_handling cimport ex_handler
 
 
 cdef extern from "<rapidsmpf/streaming/core/actor.hpp>" nogil:
     cdef cppclass cpp_Actor "rapidsmpf::streaming::Actor":
         pass
-
-    cdef void cpp_run_actor_network \
-        "rapidsmpf::streaming::run_actor_network"(vector[cpp_Actor]) \
-        except +ex_handler
 
 
 cdef class CppActor:

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyi
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Collection
-from concurrent.futures import ThreadPoolExecutor
 from typing import Concatenate, ParamSpec
 
 from rapidsmpf.streaming.core.channel import Channel
@@ -22,7 +21,5 @@ def define_actor(
     Callable[Concatenate[Context, P], Awaitable[None]],
 ]: ...
 def run_actor_network(
-    *,
-    actors: Collection[CppActor | Awaitable[None]],
-    py_executor: ThreadPoolExecutor | None = None,
+    ctx: Context, *, actors: Collection[CppActor | Awaitable[None]]
 ) -> None: ...

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
@@ -1,20 +1,64 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
+from cpython.object cimport PyObject
+from cpython.ref cimport Py_INCREF
 from cython.operator cimport dereference as deref
-from libcpp.memory cimport unique_ptr
+from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.utility cimport move
 
 import asyncio
 import inspect
 from collections.abc import Iterable, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial, wraps
+
+from rapidsmpf._detail.exception_handling cimport ex_handler
+from rapidsmpf.owning_wrapper cimport cpp_OwningWrapper
+from rapidsmpf.streaming._detail.libcoro_spawn_task cimport cpp_set_py_future
+from rapidsmpf.streaming.chunks.utils cimport py_deleter
+from rapidsmpf.streaming.core.context cimport Context, cpp_Context
 
 from rapidsmpf.streaming.core.channel import Channel
 from rapidsmpf.streaming.core.context import Context
 
 from rapidsmpf.streaming.core.context cimport Context
 
+
+cdef extern from * nogil:
+    """
+    namespace {
+    coro::task<void> cpp_when_all_task(
+        std::vector<rapidsmpf::streaming::Actor> actors
+    ) {
+        rapidsmpf::streaming::coro_results(co_await coro::when_all(std::move(actors)));
+    }
+
+    void cpp_when_all(
+        std::shared_ptr<rapidsmpf::streaming::Context> ctx,
+        std::vector<rapidsmpf::streaming::Actor> actors,
+        void (*cpp_set_py_future)(void *, const char *),
+        rapidsmpf::OwningWrapper py_future
+    ) {
+        RAPIDSMPF_EXPECTS(
+            ctx->executor()->spawn_detached(
+                cython_libcoro_task_wrapper(
+                    cpp_set_py_future,
+                    std::move(py_future),
+                    cpp_when_all_task(std::move(actors))
+                )
+            ),
+            "libcoro's spawn_detached() failed to spawn task"
+        );
+    }
+    }
+    """
+    void cpp_when_all(
+        shared_ptr[cpp_Context],
+        vector[cpp_Actor],
+        void (*cpp_set_py_future)(void*, const char *),
+        cpp_OwningWrapper py_future
+    ) except +ex_handler
 
 cdef class CppActor:
     """
@@ -179,22 +223,59 @@ def define_actor(*, extra_channels=()):
     return partial(decorate_actor, extra_channels)
 
 
-def run_actor_network(*, actors, py_executor = None):
+def sync_wait(fn):
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(fn)
+    finally:
+        loop.close()
+
+
+async def when_all(Context ctx not None, list cpp_actors):
+    """
+    Asynchronously run C++ actors.
+
+    Parameters
+    ----------
+    ctx
+        Streaming context for execution.
+    cpp_actors
+        List of CppActor nodes
+
+    Warnings
+    --------
+    The C++ actor handles are released and must not be used after this call.
+    """
+    cdef vector[cpp_Actor] cpp_handles
+    for actor in cpp_actors:
+        cpp_handles.push_back(move(deref((<CppActor?>actor).release_handle())))
+    ret = asyncio.get_running_loop().create_future()
+    Py_INCREF(ret)
+    with nogil:
+        cpp_when_all(
+            ctx._handle,
+            move(cpp_handles),
+            cpp_set_py_future,
+            move(cpp_OwningWrapper(<void*><PyObject*>ret, py_deleter))
+        )
+    await ret
+
+
+def run_actor_network(Context ctx not None, *, actors):
     """
     Run streaming actors to completion (blocking).
 
     Accepts a collection of actors. Native C++ actors are moved into the C++ network
     and executed with minimal Python overhead, while Python actors are gathered and
-    executed on a dedicated event loop in the provided executor.
+    executed on a dedicated event loop.
 
     Parameters
     ----------
+    ctx
+        Streaming context for execution.
     actors
         Iterable of actors. Each element is either a native C++ actor or a Python
         awaitable representing an actor.
-    py_executor
-        Executor used to run Python actors (required if any Python actors are present).
-        If no Python actors are provided, this is ignored.
 
     Warnings
     --------
@@ -202,8 +283,6 @@ def run_actor_network(*, actors, py_executor = None):
 
     Raises
     ------
-    ValueError
-        If Python actors are present but no executor is provided.
     Exception
         Any unhandled exception from an actor is re-raised after execution. If multiple
         actors raise exceptions, only one is re-raised, and it is unspecified which one.
@@ -225,8 +304,8 @@ def run_actor_network(*, actors, py_executor = None):
     ...     await ch_out.drain(context)
     ...
     >>> run_actor_network(
-    ...     actors=[cpp_actor, python_actor(context, ch_out=ch)],
-    ...     py_executor=ThreadPoolExecutor(max_workers=1),
+    ...     context,
+    ...     actors=[cpp_actor, python_actor(context, ch_out=ch)]
     ... )
     >>> results = output.release()
     >>> tbl = TableChunk.from_message(results[0])
@@ -234,24 +313,16 @@ def run_actor_network(*, actors, py_executor = None):
     42
     """
 
-    # Split actors into C++ actors and Python actors.
-    cdef vector[cpp_Actor] cpp_actors
     cdef list py_actors = []
+    cdef list cpp_actors = []
     for actor in actors:
         if isinstance(actor, CppActor):
-            cpp_actors.push_back(move(deref((<CppActor>actor).release_handle())))
+            cpp_actors.append(actor)
         else:
             py_actors.append(actor)
 
-    if len(py_actors) > 0:
-        if py_executor is None:
-            raise ValueError("must provide a py_executor to run Python actors.")
-        py_future = py_executor.submit(asyncio.run, run_py_actors(py_actors))
-
-    try:
-        if cpp_actors.size() > 0:
-            with nogil:
-                cpp_run_actor_network(move(cpp_actors))
-    finally:
-        if len(py_actors) > 0:
-            py_future.result()  # This will raise any unhandled exception.
+    py_actors = [when_all(ctx, cpp_actors), *py_actors]
+    # Need to run in a separate thread in case the cluster runtime already
+    # has an async event loop.
+    executor = ThreadPoolExecutor(max_workers=1)
+    executor.submit(sync_wait, run_py_actors(py_actors)).result()

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
@@ -6,6 +6,7 @@ from cpython.ref cimport Py_INCREF
 from cython.operator cimport dereference as deref
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.utility cimport move
+from libcpp.vector cimport vector
 
 import asyncio
 import inspect
@@ -21,8 +22,6 @@ from rapidsmpf.streaming.core.context cimport Context, cpp_Context
 
 from rapidsmpf.streaming.core.channel import Channel
 from rapidsmpf.streaming.core.context import Context
-
-from rapidsmpf.streaming.core.context cimport Context
 
 
 cdef extern from * nogil:
@@ -223,12 +222,21 @@ def define_actor(*, extra_channels=()):
     return partial(decorate_actor, extra_channels)
 
 
-def sync_wait(fn):
-    loop = asyncio.new_event_loop()
-    try:
-        loop.run_until_complete(fn)
-    finally:
-        loop.close()
+def sync_wait(coro):
+    """
+    Run, and wait for completion of, a coroutine.
+
+    This builds a new event loop with :class:`asyncio.Runner` and runs the
+    coroutine to completion in that event loop, shutting the loop down
+    afterwards.
+
+    Notes
+    -----
+    This should always be called from a thread we control to ensure no live
+    event loop is running.
+    """
+    with asyncio.Runner() as runner:
+        runner.run(coro)
 
 
 async def when_all(Context ctx not None, list cpp_actors):

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
@@ -26,6 +26,8 @@ from rapidsmpf.streaming.core.context import Context
 
 cdef extern from * nogil:
     """
+    #include <rapidsmpf/streaming/core/coro_utils.hpp>
+
     namespace {
     coro::task<void> cpp_when_all_task(
         std::vector<rapidsmpf::streaming::Actor> actors
@@ -266,7 +268,21 @@ async def when_all(Context ctx not None, list cpp_actors):
             cpp_set_py_future,
             move(cpp_OwningWrapper(<void*><PyObject*>ret, py_deleter))
         )
-    await ret
+    try:
+        # This shield makes sure that if a cancellation is raised, the
+        # future is not cancelled.
+        await asyncio.shield(ret)
+    except asyncio.CancelledError as cancel:
+        # The outer awaitable was cancelled, but we must still ensure the
+        # C++ future still runs to completion.
+        try:
+            # This could still fail so we catch and reraise the
+            # cancellation but recording the C++ exception as well.
+            await asyncio.shield(ret)
+        except Exception as cpp_except:
+            raise cancel from cpp_except
+        # Otherwise just reraise the cancellation
+        raise cancel
 
 
 def run_actor_network(Context ctx not None, *, actors):

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
@@ -348,5 +348,5 @@ def run_actor_network(Context ctx not None, *, actors):
     py_actors = [when_all(ctx, cpp_actors), *py_actors]
     # Need to run in a separate thread in case the cluster runtime already
     # has an async event loop.
-    executor = ThreadPoolExecutor(max_workers=1)
-    executor.submit(sync_wait, run_py_actors(py_actors)).result()
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(sync_wait, run_py_actors(py_actors)).result()

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/conftest.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/conftest.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 import pytest
@@ -31,11 +30,3 @@ def context(comm: Communicator) -> Generator[Context, None, None]:
 
     with Context(comm.logger, br, options) as ctx:
         yield ctx
-
-
-@pytest.fixture(scope="session")
-def py_executor() -> ThreadPoolExecutor:
-    """
-    Fixture to get a streaming context.
-    """
-    return ThreadPoolExecutor(max_workers=1)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_allgather.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_allgather.py
@@ -22,7 +22,6 @@ from rapidsmpf.testing import assert_eq
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-    from concurrent.futures import ThreadPoolExecutor
 
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.actor import CppActor
@@ -72,7 +71,7 @@ def test_allgather_actor(context: Context, comm: Communicator) -> None:
 
     actor, deferred = pull_from_channel(context, ch2)
     actors.append(actor)
-    run_actor_network(actors=actors)
+    run_actor_network(context, actors=actors)
 
     result = unpack_and_concat(
         (
@@ -139,9 +138,7 @@ async def allgather_and_concat(
     await ch_out.drain(context)
 
 
-def test_allgather_object_interface(
-    context: Context, comm: Communicator, py_executor: ThreadPoolExecutor
-) -> None:
+def test_allgather_object_interface(context: Context, comm: Communicator) -> None:
     if comm.nranks != 1:
         pytest.skip("Only support single-rank runs")
 
@@ -157,7 +154,7 @@ def test_allgather_object_interface(
     actor, deferred = pull_from_channel(context, ch_out)
     actors.append(actor)
 
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
     (result_msg,) = deferred.release()
     result = TableChunk.from_message(result_msg, br=context.br())
     expect = plc.Table(

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_arbitrary_chunk.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_arbitrary_chunk.py
@@ -13,7 +13,6 @@ from rapidsmpf.streaming.core.message import Message
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-    from concurrent.futures import ThreadPoolExecutor
     from typing import Any
 
     from rapidsmpf.streaming.core.actor import CppActor
@@ -107,7 +106,7 @@ def test_gc_after_chunk_release() -> None:
     assert not finalizer.alive
 
 
-def test_with_channel(context: Context, py_executor: ThreadPoolExecutor) -> None:
+def test_with_channel(context: Context) -> None:
     ch_in: Channel[ArbitraryChunk[int]] = context.create_channel()
     ch_out: Channel[ArbitraryChunk[int]] = context.create_channel()
 
@@ -135,7 +134,7 @@ def test_with_channel(context: Context, py_executor: ThreadPoolExecutor) -> None
     actor, deferred_messages = pull_from_channel(context, ch_out)
     actors.append(actor)
 
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
 
     results = deferred_messages.release()
     for seq, msg in enumerate(results):

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_bloom_filter.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_bloom_filter.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -117,7 +116,7 @@ def run_bloom_filter_pipeline(
     ]
     pull_actor, deferred = pull_from_channel(context, ch_out)
     actors.append(pull_actor)
-    run_actor_network(actors=actors, py_executor=ThreadPoolExecutor(max_workers=1))
+    run_actor_network(context, actors=actors)
     return deferred.release()
 
 

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_channel.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_channel.py
@@ -13,7 +13,6 @@ from rapidsmpf.streaming.core.message import Message
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-    from concurrent.futures import ThreadPoolExecutor
 
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
@@ -90,9 +89,7 @@ async def consume_metadata_then_data(
         data_out.append(ArbitraryChunk.from_message(msg).release())
 
 
-def test_data_roundtrip_without_metadata(
-    context: Context, py_executor: ThreadPoolExecutor
-) -> None:
+def test_data_roundtrip_without_metadata(context: Context) -> None:
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     outputs: list[int] = []
     actors: list[Awaitable[None]] = [
@@ -107,14 +104,12 @@ def test_data_roundtrip_without_metadata(
             outputs.append(ArbitraryChunk.from_message(msg).release())
 
     actors.append(consume_only_data(context, ch))
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
 
     assert outputs == [0, 1, 2]
 
 
-def test_metadata_then_data_roundtrip(
-    context: Context, py_executor: ThreadPoolExecutor
-) -> None:
+def test_metadata_then_data_roundtrip(context: Context) -> None:
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     metadata_out: list[int] = []
     data_out: list[int] = []
@@ -123,15 +118,13 @@ def test_metadata_then_data_roundtrip(
         send_metadata_then_data(context, ch, [10, 20], 0, 2),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
 
     assert metadata_out == [10, 20]
     assert data_out == [0, 1]
 
 
-def test_data_only_with_metadata_shutdown(
-    context: Context, py_executor: ThreadPoolExecutor
-) -> None:
+def test_data_only_with_metadata_shutdown(context: Context) -> None:
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     metadata_out: list[int] = []
     data_out: list[int] = []
@@ -139,15 +132,13 @@ def test_data_only_with_metadata_shutdown(
         send_data_only_with_metadata_shutdown(context, ch, 5, 2),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
 
     assert metadata_out == []
     assert data_out == [5, 6]
 
 
-def test_metadata_only_with_data_shutdown(
-    context: Context, py_executor: ThreadPoolExecutor
-) -> None:
+def test_metadata_only_with_data_shutdown(context: Context) -> None:
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     metadata_out: list[int] = []
     data_out: list[int] = []
@@ -155,15 +146,13 @@ def test_metadata_only_with_data_shutdown(
         send_metadata_only(context, ch, [30, 31]),
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
 
     assert metadata_out == [30, 31]
     assert data_out == []
 
 
-def test_producer_raises_after_metadata(
-    context: Context, py_executor: ThreadPoolExecutor
-) -> None:
+def test_producer_raises_after_metadata(context: Context) -> None:
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
     metadata_out: list[int] = []
     data_out: list[int] = []
@@ -180,12 +169,10 @@ def test_producer_raises_after_metadata(
         consume_metadata_then_data(context, ch, metadata_out, data_out),
     ]
     with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="producer failed")):
-        run_actor_network(actors=actors, py_executor=py_executor)
+        run_actor_network(context, actors=actors)
 
 
-def test_consumer_raises_with_metadata(
-    context: Context, py_executor: ThreadPoolExecutor
-) -> None:
+def test_consumer_raises_with_metadata(context: Context) -> None:
     ch: Channel[ArbitraryChunk[int]] = context.create_channel()
 
     @define_actor()
@@ -199,4 +186,4 @@ def test_consumer_raises_with_metadata(
         throwing_consumer(context, ch),
     ]
     with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="consumer failed")):
-        run_actor_network(actors=actors, py_executor=py_executor)
+        run_actor_network(context, actors=actors)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_define_actor.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_define_actor.py
@@ -18,17 +18,13 @@ from rapidsmpf.testing import assert_eq
 from rapidsmpf.utils.cudf import cudf_to_pylibcudf_table
 
 if TYPE_CHECKING:
-    from concurrent.futures import ThreadPoolExecutor
-
     from rmm.pylibrmm.stream import Stream
 
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
 
 
-def test_send_table_chunks(
-    context: Context, stream: Stream, py_executor: ThreadPoolExecutor
-) -> None:
+def test_send_table_chunks(context: Context, stream: Stream) -> None:
     expects = [
         cudf_to_pylibcudf_table(cudf.DataFrame({"a": [1 * seq, 2 * seq, 3 * seq]}))
         for seq in range(10)
@@ -57,11 +53,11 @@ def test_send_table_chunks(
     actor2, output = pull_from_channel(context, ch_in=ch1)
 
     run_actor_network(
+        context,
         actors=[
             actor1(context, ch_out=ch1),
             actor2,
         ],
-        py_executor=py_executor,
     )
 
     results = output.release()
@@ -71,7 +67,7 @@ def test_send_table_chunks(
         assert_eq(tbl.table_view(), expect)
 
 
-def test_shutdown(context: Context, py_executor: ThreadPoolExecutor) -> None:
+def test_shutdown(context: Context) -> None:
     @define_actor()
     async def actor1(ctx: Context, ch_out: Channel[TableChunk]) -> None:
         await ch_out.shutdown(ctx)
@@ -82,17 +78,17 @@ def test_shutdown(context: Context, py_executor: ThreadPoolExecutor) -> None:
     actor2, output = pull_from_channel(context, ch_in=ch1)
 
     run_actor_network(
+        context,
         actors=[
             actor1(context, ch_out=ch1),
             actor2,
         ],
-        py_executor=py_executor,
     )
 
     assert output.release() == []
 
 
-def test_send_error(context: Context, py_executor: ThreadPoolExecutor) -> None:
+def test_send_error(context: Context) -> None:
     @define_actor()
     async def actor1(ctx: Context, ch_out: Channel[TableChunk]) -> None:
         raise RuntimeError("MyError")
@@ -107,19 +103,17 @@ def test_send_error(context: Context, py_executor: ThreadPoolExecutor) -> None:
         )
     ):
         run_actor_network(
+            context,
             actors=[
                 actor1(context, ch_out=ch1),
                 actor2,
             ],
-            py_executor=py_executor,
         )
 
     assert output.release() == []
 
 
-def test_recv_table_chunks(
-    context: Context, stream: Stream, py_executor: ThreadPoolExecutor
-) -> None:
+def test_recv_table_chunks(context: Context, stream: Stream) -> None:
     expects = [
         cudf_to_pylibcudf_table(cudf.DataFrame({"a": [1 * seq, 2 * seq, 3 * seq]}))
         for seq in range(10)
@@ -147,11 +141,11 @@ def test_recv_table_chunks(
     ch1: Channel[TableChunk] = context.create_channel()
 
     run_actor_network(
+        context,
         actors=[
             push_to_channel(context, ch_out=ch1, messages=table_chunks),
             actor1(context, ch_in=ch1),
         ],
-        py_executor=py_executor,
     )
 
     for seq, (result, expect) in enumerate(zip(results, expects, strict=True)):

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_exceptions.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_exceptions.py
@@ -12,7 +12,6 @@ from rapidsmpf.streaming.core.leaf_actor import pull_from_channel
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-    from concurrent.futures import ThreadPoolExecutor
 
     from rapidsmpf.streaming.core.actor import CppActor
     from rapidsmpf.streaming.core.channel import Channel
@@ -31,7 +30,7 @@ async def task_that_spins(ctx: Context, ch_in: Channel) -> None:
         pass
 
 
-def test_task_exceptions(context: Context, py_executor: ThreadPoolExecutor) -> None:
+def test_task_exceptions(context: Context) -> None:
     ch1: Channel[Payload] = context.create_channel()
     ch2: Channel[Payload] = context.create_channel()
     ch3: Channel[Payload] = context.create_channel()
@@ -45,7 +44,7 @@ def test_task_exceptions(context: Context, py_executor: ThreadPoolExecutor) -> N
     ]
 
     with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="Throwing in task")):
-        run_actor_network(actors=actors, py_executor=py_executor)
+        run_actor_network(context, actors=actors)
 
     messages = deferred.release()
     assert len(messages) == 0

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_fanout.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_fanout.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 import pytest
@@ -53,11 +52,10 @@ def test_fanout_basic(context: Context, stream: Stream, policy: FanoutPolicy) ->
     pull_actor2, output2 = pull_from_channel(context, ch_out2)
 
     # Run pipeline
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        run_actor_network(
-            actors=[push_actor, fanout_actor, pull_actor1, pull_actor2],
-            py_executor=executor,
-        )
+    run_actor_network(
+        context,
+        actors=[push_actor, fanout_actor, pull_actor1, pull_actor2],
+    )
 
     # Verify results
     results1 = output1.release()
@@ -122,11 +120,10 @@ def test_fanout_multiple_outputs(
         outputs.append(output)
 
     # Run pipeline
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        run_actor_network(
-            actors=[push_actor, fanout_actor, *pull_actors],
-            py_executor=executor,
-        )
+    run_actor_network(
+        context,
+        actors=[push_actor, fanout_actor, *pull_actors],
+    )
 
     # Verify all outputs received the messages
     for output_idx, output in enumerate(outputs):

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_leaf_actor.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_leaf_actor.py
@@ -38,7 +38,7 @@ def test_roundtrip(context: Context, stream: Stream) -> None:
     ch1: Channel[TableChunk] = context.create_channel()
     actor1 = push_to_channel(context, ch_out=ch1, messages=table_chunks)
     actor2, output = pull_from_channel(context, ch_in=ch1)
-    run_actor_network(actors=(actor1, actor2))
+    run_actor_network(context, actors=(actor1, actor2))
 
     results = output.release()
     for seq, (result, expect) in enumerate(zip(results, expects, strict=True)):

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_memory_reserve_or_wait.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_memory_reserve_or_wait.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -26,9 +25,6 @@ from rapidsmpf.streaming.core.memory_reserve_or_wait import (
     reserve_memory,
 )
 
-if TYPE_CHECKING:
-    from concurrent.futures import ThreadPoolExecutor
-
 
 def make_context(
     *, dev_limit: int, overwrite_options: dict[str, str] | None = None
@@ -46,7 +42,7 @@ def make_context(
     return Context(comm.logger, br, options)
 
 
-def test_memory_is_available(py_executor: ThreadPoolExecutor) -> None:
+def test_memory_is_available() -> None:
     with make_context(dev_limit=1024) as context:
         mrow = MemoryReserveOrWait(context.options(), MemoryType.DEVICE, context)
 
@@ -56,13 +52,10 @@ def test_memory_is_available(py_executor: ThreadPoolExecutor) -> None:
             assert res.mem_type == MemoryType.DEVICE
             assert res.size == 1024
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
 
-def test_reserve_zero_is_always_available(py_executor: ThreadPoolExecutor) -> None:
+def test_reserve_zero_is_always_available() -> None:
     with make_context(dev_limit=0) as context:
         mrow = MemoryReserveOrWait(
             Options({"memory_reserve_timeout": "10m"}), MemoryType.DEVICE, context
@@ -76,13 +69,10 @@ def test_reserve_zero_is_always_available(py_executor: ThreadPoolExecutor) -> No
             assert res.mem_type == MemoryType.DEVICE
             assert res.size == 0
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
 
-def test_timeout(py_executor: ThreadPoolExecutor) -> None:
+def test_timeout() -> None:
     with make_context(dev_limit=1024) as context:
         mrow = MemoryReserveOrWait(
             Options({"memory_reserve_timeout": "1ms"}), MemoryType.DEVICE, context
@@ -94,13 +84,10 @@ def test_timeout(py_executor: ThreadPoolExecutor) -> None:
             assert res.mem_type == MemoryType.DEVICE
             assert res.size == 0
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
 
-def test_shutdown(py_executor: ThreadPoolExecutor) -> None:
+def test_shutdown() -> None:
     with make_context(dev_limit=1024) as context:
         mrow = MemoryReserveOrWait(
             Options({"memory_reserve_timeouts": "10m"}), MemoryType.DEVICE, context
@@ -118,13 +105,10 @@ def test_shutdown(py_executor: ThreadPoolExecutor) -> None:
                 await asyncio.sleep(0)
             await mrow.shutdown()
 
-        run_actor_network(
-            actors=[actor1(context), actor2(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor1(context), actor2(context)])
 
 
-def test_context_memory_returns_handle(py_executor: ThreadPoolExecutor) -> None:
+def test_context_memory_returns_handle() -> None:
     with make_context(dev_limit=1024) as context:
         mrow = context.memory(MemoryType.DEVICE)
         assert isinstance(mrow, MemoryReserveOrWait)
@@ -136,13 +120,10 @@ def test_context_memory_returns_handle(py_executor: ThreadPoolExecutor) -> None:
             assert res.mem_type == MemoryType.DEVICE
             assert res.size == 512
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
 
-def test_reserve_or_wait_or_overbook(py_executor: ThreadPoolExecutor) -> None:
+def test_reserve_or_wait_or_overbook() -> None:
     with make_context(dev_limit=2048) as context:
         mrow = MemoryReserveOrWait(
             Options({"memory_reserve_timeout": "1ms"}), MemoryType.DEVICE, context
@@ -166,13 +147,10 @@ def test_reserve_or_wait_or_overbook(py_executor: ThreadPoolExecutor) -> None:
             assert res.size == 2048
             assert overbooked == 1024
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
 
-def test_reserve_or_wait_or_fail(py_executor: ThreadPoolExecutor) -> None:
+def test_reserve_or_wait_or_fail() -> None:
     with make_context(dev_limit=1024) as context:
         mrow = MemoryReserveOrWait(
             Options({"memory_reserve_timeout": "1ms"}), MemoryType.DEVICE, context
@@ -184,13 +162,10 @@ def test_reserve_or_wait_or_fail(py_executor: ThreadPoolExecutor) -> None:
             with pytest.raises(RuntimeError):
                 await mrow.reserve_or_wait_or_fail(size=2048, net_memory_delta=0)
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
 
-def test_reserve_memory_helper(py_executor: ThreadPoolExecutor) -> None:
+def test_reserve_memory_helper() -> None:
     with make_context(
         dev_limit=1024, overwrite_options={"memory_reserve_timeout": "1ms"}
     ) as context:
@@ -229,15 +204,10 @@ def test_reserve_memory_helper(py_executor: ThreadPoolExecutor) -> None:
                     allow_overbooking=False,
                 )
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
 
-def test_reserve_memory_helper_allow_overbooking_by_default(
-    py_executor: ThreadPoolExecutor,
-) -> None:
+def test_reserve_memory_helper_allow_overbooking_by_default() -> None:
     # Option enabled, should overbook and succeed.
     with make_context(
         dev_limit=1024,
@@ -259,10 +229,7 @@ def test_reserve_memory_helper_allow_overbooking_by_default(
             assert res.mem_type == MemoryType.DEVICE
             assert res.size == 2048
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])
 
     # Option disabled, should fail when no progress is possible.
     with make_context(
@@ -284,7 +251,4 @@ def test_reserve_memory_helper_allow_overbooking_by_default(
                     allow_overbooking=None,
                 )
 
-        run_actor_network(
-            actors=[actor(context)],
-            py_executor=py_executor,
-        )
+        run_actor_network(context, actors=[actor(context)])

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_partition.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_partition.py
@@ -62,7 +62,7 @@ def test_partition_and_pack_unpack(
     )
 
     actor4, output = pull_from_channel(context, ch_in=ch3)
-    run_actor_network(actors=(actor1, actor2, actor3, actor4))
+    run_actor_network(context, actors=(actor1, actor2, actor3, actor4))
 
     results = output.release()
     for seq, (result, expect) in enumerate(zip(results, expects, strict=True)):

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_read_parquet.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_read_parquet.py
@@ -133,7 +133,7 @@ def test_read_parquet(
 
     consumer, deferred_messages = pull_from_channel(context, ch)
 
-    run_actor_network(actors=[producer, consumer])
+    run_actor_network(context, actors=[producer, consumer])
 
     messages = deferred_messages.release()
     assert all(

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
@@ -31,7 +31,6 @@ from rapidsmpf.utils.cudf import cudf_to_pylibcudf_table, pylibcudf_to_cudf_data
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-    from concurrent.futures import ThreadPoolExecutor
 
     from rmm.pylibrmm.stream import Stream
 
@@ -114,7 +113,7 @@ def test_single_rank_shuffler(
     pull_actor, out_messages = pull_from_channel(context, ch_in=ch4)
     actors.append(pull_actor)
 
-    run_actor_network(actors=actors)
+    run_actor_network(context, actors=actors)
 
     output_chunks = [
         TableChunk.from_message(msg, br=context.br()) for msg in out_messages.release()
@@ -193,7 +192,6 @@ async def do_shuffle(
 def test_shuffler_runtime_obeys_contiguous_assignment(
     context: Context,
     comm: Communicator,
-    py_executor: ThreadPoolExecutor,
     num_partitions: int,
 ) -> None:
     if comm.nranks != 1:
@@ -221,7 +219,7 @@ def test_shuffler_runtime_obeys_contiguous_assignment(
     actor, deferred = pull_from_channel(context, ch_shuffled)
     actors.append(actor)
 
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
     messages = deferred.release()
     received_pids = [msg.sequence_number for msg in messages]
 
@@ -240,7 +238,6 @@ def test_shuffler_runtime_obeys_contiguous_assignment(
 def test_shuffler_object_interface(
     context: Context,
     comm: Communicator,
-    py_executor: ThreadPoolExecutor,
 ) -> None:
     if comm.nranks != 1:
         pytest.skip("Only support single-rank runs")
@@ -266,7 +263,7 @@ def test_shuffler_object_interface(
     actor, deferred = pull_from_channel(context, ch_shuffled)
     actors.append(actor)
 
-    run_actor_network(actors=actors, py_executor=py_executor)
+    run_actor_network(context, actors=actors)
     messages = deferred.release()
     # TODO: single rank only assertions
     assert len(messages) == 5

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_table_chunk.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_table_chunk.py
@@ -26,8 +26,6 @@ from rapidsmpf.testing import assert_eq
 from rapidsmpf.utils.cudf import cudf_to_pylibcudf_table
 
 if TYPE_CHECKING:
-    from concurrent.futures import ThreadPoolExecutor
-
     from rmm.pylibrmm.stream import Stream
 
     from rapidsmpf.streaming.core.context import Context
@@ -280,7 +278,7 @@ def test_spillable_messages_by_context(context: Context, stream: Stream) -> None
 
 
 def test_make_available_or_wait_already_available(
-    context: Context, stream: Stream, py_executor: ThreadPoolExecutor
+    context: Context, stream: Stream
 ) -> None:
     expect = random_table(1024)
     chunk = TableChunk.from_pylibcudf_table(
@@ -293,7 +291,7 @@ def test_make_available_or_wait_already_available(
         result = await chunk.make_available_or_wait(ctx, net_memory_delta=0)
         result_holder.append(result)
 
-    run_actor_network(actors=[test_actor(context)], py_executor=py_executor)
+    run_actor_network(context, actors=[test_actor(context)])
     assert_eq(expect, result_holder[0].table_view())
 
 
@@ -301,7 +299,6 @@ def test_make_available_or_wait_already_available(
 def test_make_available_or_wait_from_host(
     context: Context,
     stream: Stream,
-    py_executor: ThreadPoolExecutor,
     *,
     net_memory_delta: int,
 ) -> None:
@@ -324,7 +321,7 @@ def test_make_available_or_wait_from_host(
         )
         result_holder.append(result)
 
-    run_actor_network(actors=[test_actor(context)], py_executor=py_executor)
+    run_actor_network(context, actors=[test_actor(context)])
     assert_eq(expect, result_holder[0].table_view())
 
 
@@ -448,7 +445,6 @@ def test_into_packed_data(context: Context, stream: Stream, from_pack: bool) -> 
 def test_make_table_chunks_available_or_wait_single_chunk(
     context: Context,
     stream: Stream,
-    py_executor: ThreadPoolExecutor,
     *,
     chunk_location: str,
 ) -> None:
@@ -476,7 +472,7 @@ def test_make_table_chunks_available_or_wait_single_chunk(
         )
         result_holder.append((result_chunk, res))
 
-    run_actor_network(actors=[test_actor(context)], py_executor=py_executor)
+    run_actor_network(context, actors=[test_actor(context)])
     chunk, res = result_holder[0]
     assert chunk.is_available()
     assert_eq(expect, chunk.table_view())
@@ -488,7 +484,6 @@ def test_make_table_chunks_available_or_wait_single_chunk(
 def test_make_table_chunks_available_or_wait_multiple_chunks(
     context: Context,
     stream: Stream,
-    py_executor: ThreadPoolExecutor,
     *,
     num_chunks: int,
 ) -> None:
@@ -525,7 +520,7 @@ def test_make_table_chunks_available_or_wait_multiple_chunks(
         )
         result_holder.append((chunks, res))
 
-    run_actor_network(actors=[test_actor(context)], py_executor=py_executor)
+    run_actor_network(context, actors=[test_actor(context)])
     chunks, res = result_holder[0]
     assert len(chunks) == num_chunks
     assert all(chunk.is_available() for chunk in chunks)
@@ -554,7 +549,6 @@ def test_make_table_chunks_available_or_wait_multiple_chunks(
 def test_make_table_chunks_available_or_wait(
     context: Context,
     stream: Stream,
-    py_executor: ThreadPoolExecutor,
     *,
     reserve_extra: int,
     net_memory_delta: int,
@@ -583,7 +577,7 @@ def test_make_table_chunks_available_or_wait(
         )
         result_holder.append((chunk, res))
 
-    run_actor_network(actors=[test_actor(context)], py_executor=py_executor)
+    run_actor_network(context, actors=[test_actor(context)])
     chunk, res = result_holder[0]
     assert chunk.is_available()
     assert_eq(expect, chunk.table_view())
@@ -592,7 +586,7 @@ def test_make_table_chunks_available_or_wait(
 
 
 def test_make_table_chunks_available_or_wait_mixed_availability(
-    context: Context, stream: Stream, py_executor: ThreadPoolExecutor
+    context: Context, stream: Stream
 ) -> None:
     expect1 = random_table(1024)
     expect2 = random_table(2048)
@@ -624,7 +618,7 @@ def test_make_table_chunks_available_or_wait_mixed_availability(
         )
         result_holder.append((chunks, res))
 
-    run_actor_network(actors=[test_actor(context)], py_executor=py_executor)
+    run_actor_network(context, actors=[test_actor(context)])
     chunks, res = result_holder[0]
     assert len(chunks) == 2
     assert all(chunk.is_available() for chunk in chunks)


### PR DESCRIPTION
This, despite its name, was only ever used to offload the top-level asyncio.run to a thread so that it could run concurrently with the C++ actors. The multi-threading should belong in the application that chooses to offload work.

To facilitate this, make an awaitable version of when_all to wait for a list of C++ actors. We still need a single thread to run the resulting awaitable tasks because we do so in a fresh event loop which conflicts with any event loop that the cluster manager might have.

- Closes #855