### PR TITLE
Remove C language from librapidsmpf wheel builder

### DIFF
--- a/python/librapidsmpf/CMakeLists.txt
+++ b/python/librapidsmpf/CMakeLists.txt
@@ -18,7 +18,7 @@ rapids_cuda_init_architectures(librapidsmpf-python)
 project(
   librapidsmpf-python
   VERSION "${RAPIDS_VERSION}"
-  LANGUAGES C CXX CUDA
+  LANGUAGES CXX CUDA
 )
 
 # For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the


### PR DESCRIPTION
https://github.com/NVIDIA/cuCascade/pull/123 has removed the unused C language from the project, so it is safe for it to be removed here.