### PR TITLE
Remove cuCascade transitive dependency workarounds

### DIFF
--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -5,34 +5,8 @@
 # cmake-format: on
 # =============================================================================
 
-# This function finds cuCascade and ensures cuDF transitive dependencies are available for linking.
-#
-# NOTE: We explicitly find kvikio and nvcomp here because:
-#
-# 1. cuCascade depends on cuDF, which depends on kvikio and nvcomp
-# 2. cuCascade runs as a CMake subdirectory/subproject and needs GLOBAL targets to see dependencies
-# 3. CMake's transitive dependency handling can fail with mixed static/shared libraries
-# 4. Without explicit transitive linking, the linker cannot find cuDF's dependent libraries when
-#    building tools
-#
 # We build cuCascade as a static library to avoid packaging issues with wheels.
 function(find_and_configure_cucascade)
-  # Find cuDF transitive dependencies that cuCascade's subproject and the tools need.
-  if(NOT TARGET kvikio::kvikio)
-    find_package(kvikio REQUIRED CONFIG)
-  endif()
-  if(NOT TARGET nvcomp::nvcomp)
-    find_package(nvcomp REQUIRED CONFIG)
-  endif()
-
-  # Mark dependencies as GLOBAL so cuCascade's subproject can see them
-  if(TARGET kvikio::kvikio)
-    set_target_properties(kvikio::kvikio PROPERTIES IMPORTED_GLOBAL TRUE)
-  endif()
-  if(TARGET nvcomp::nvcomp)
-    set_target_properties(nvcomp::nvcomp PROPERTIES IMPORTED_GLOBAL TRUE)
-  endif()
-
   rapids_cpm_find(
     cuCascade 0.1.0
     GLOBAL_TARGETS cuCascade::cucascade
@@ -53,12 +27,6 @@ function(find_and_configure_cucascade)
   if(TARGET cuCascade::cucascade AND NOT TARGET rapidsmpf_cucascade_internal)
     add_library(rapidsmpf_cucascade_internal INTERFACE)
     target_link_libraries(rapidsmpf_cucascade_internal INTERFACE cuCascade::cucascade)
-    if(TARGET kvikio::kvikio)
-      target_link_libraries(rapidsmpf_cucascade_internal INTERFACE kvikio::kvikio)
-    endif()
-    if(TARGET nvcomp::nvcomp)
-      target_link_libraries(rapidsmpf_cucascade_internal INTERFACE nvcomp::nvcomp)
-    endif()
     set_target_properties(rapidsmpf_cucascade_internal PROPERTIES EXPORT_NAME "")
   endif()
 endfunction()

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -268,7 +268,7 @@ target_compile_definitions(
 )
 target_link_libraries(
   bootstrap_tests PRIVATE GTest::gmock GTest::gtest $<TARGET_NAME_IF_EXISTS:conda_env> maybe_asan
-                          $<TARGET_NAME_IF_EXISTS:PMIx::PMIx> ${CMAKE_DL_LIBS}
+                          CUDA::cudart_static $<TARGET_NAME_IF_EXISTS:PMIx::PMIx> ${CMAKE_DL_LIBS}
 )
 add_test(NAME bootstrap_tests COMMAND "gtests/bootstrap_tests")
 

--- a/cpp/tests/bootstrap/test_socket_backend.cpp
+++ b/cpp/tests/bootstrap/test_socket_backend.cpp
@@ -91,7 +91,7 @@ int connect_raw(SocketServer const& server) {
 // Send a line (appending '\n') to fd and return the first response line.
 std::string send_recv_line(int fd, std::string const& line) {
     std::string msg = line + "\n";
-    ::write(fd, msg.c_str(), msg.size());
+    EXPECT_EQ(::write(fd, msg.c_str(), msg.size()), static_cast<ssize_t>(msg.size()));
 
     std::string response;
     char ch;

--- a/cpp/tools/CMakeLists.txt
+++ b/cpp/tools/CMakeLists.txt
@@ -34,8 +34,6 @@ target_link_libraries(
   rrun
   PRIVATE Threads::Threads
           cuCascade::cucascade
-          $<$<TARGET_EXISTS:kvikio::kvikio>:kvikio::kvikio>
-          $<$<TARGET_EXISTS:nvcomp::nvcomp>:nvcomp::nvcomp>
           $<TARGET_NAME_IF_EXISTS:conda_env>
           maybe_asan
           $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa>
@@ -62,14 +60,8 @@ target_compile_options(
   topology_discovery PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
 )
 target_link_libraries(
-  topology_discovery
-  PRIVATE cuCascade::cucascade
-          $<$<TARGET_EXISTS:kvikio::kvikio>:kvikio::kvikio>
-          $<$<TARGET_EXISTS:nvcomp::nvcomp>:nvcomp::nvcomp>
-          $<TARGET_NAME_IF_EXISTS:conda_env>
-          $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa>
-          maybe_asan
-          ${CMAKE_DL_LIBS}
+  topology_discovery PRIVATE cuCascade::cucascade $<TARGET_NAME_IF_EXISTS:conda_env>
+                             $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa> maybe_asan ${CMAKE_DL_LIBS}
 )
 install(
   TARGETS topology_discovery
@@ -97,14 +89,8 @@ target_compile_definitions(
   check_resource_binding PRIVATE $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:RAPIDSMPF_HAVE_NUMA>
 )
 target_link_libraries(
-  check_resource_binding
-  PRIVATE cuCascade::cucascade
-          $<$<TARGET_EXISTS:kvikio::kvikio>:kvikio::kvikio>
-          $<$<TARGET_EXISTS:nvcomp::nvcomp>:nvcomp::nvcomp>
-          $<TARGET_NAME_IF_EXISTS:conda_env>
-          maybe_asan
-          $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa>
-          ${CMAKE_DL_LIBS}
+  check_resource_binding PRIVATE cuCascade::cucascade $<TARGET_NAME_IF_EXISTS:conda_env> maybe_asan
+                                 $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa> ${CMAKE_DL_LIBS}
 )
 install(
   TARGETS check_resource_binding


### PR DESCRIPTION
## Summary
- Remove rapidsmpf's explicit KvikIO/nvCOMP handling around cuCascade.
- Remove direct KvikIO/nvCOMP links from rapidsmpf tools.
- Link the standalone bootstrap test target to static cudart.

cuCascade uses cuDF directly. I did not find direct cuCascade source usage of KvikIO or nvCOMP, so rapidsmpf should not link those libraries on cuCascade's behalf.

Depends on NVIDIA/cuCascade#125.

## Testing
- `env CPM_cuCascade_SOURCE="/home/coder/rapidsmpf/cuCascade" build-rapidsmpf-cpp -j0`