### PR TITLE
Fix socket backend test write handling

### DIFF
--- a/cpp/tests/bootstrap/test_socket_backend.cpp
+++ b/cpp/tests/bootstrap/test_socket_backend.cpp
@@ -99,8 +99,9 @@ std::string send_recv_line(int fd, std::string const& line) {
     while (bytes_left > 0) {
         auto written = ::write(fd, ptr, bytes_left);
         if (written < 0) {
-            if (errno == EINTR)
+            if (errno == EINTR) {
                 continue;
+            }
             throw std::runtime_error(
                 "write() failed: " + std::string{std::strerror(errno)}
             );

--- a/cpp/tests/bootstrap/test_socket_backend.cpp
+++ b/cpp/tests/bootstrap/test_socket_backend.cpp
@@ -4,9 +4,12 @@
  */
 
 #include <atomic>
+#include <cerrno>
 #include <chrono>
+#include <cstring>
 #include <exception>
 #include <functional>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -91,7 +94,20 @@ int connect_raw(SocketServer const& server) {
 // Send a line (appending '\n') to fd and return the first response line.
 std::string send_recv_line(int fd, std::string const& line) {
     std::string msg = line + "\n";
-    ::write(fd, msg.c_str(), msg.size());
+    auto bytes_left = msg.size();
+    auto const* ptr = msg.data();
+    while (bytes_left > 0) {
+        auto written = ::write(fd, ptr, bytes_left);
+        if (written < 0) {
+            if (errno == EINTR)
+                continue;
+            throw std::runtime_error(
+                "write() failed: " + std::string{std::strerror(errno)}
+            );
+        }
+        bytes_left -= static_cast<std::size_t>(written);
+        ptr += written;
+    }
 
     std::string response;
     char ch;


### PR DESCRIPTION
## Summary
- Handle the return value from `write()` in the socket backend test helper.
- Retry on `EINTR` and continue until the full request line is sent.

## Raw Error
```text
FAILED: tests/CMakeFiles/bootstrap_tests.dir/bootstrap/test_socket_backend.cpp.o
sccache /usr/bin/g++ -DRAPIDSMPF_HAVE_SLURM -I/home/coder/rapidsmpf/cpp/include -isystem /home/coder/rapidsmpf/cpp/build/pip/cuda-13.1/release/_deps/gtest-src/googlemock/include -isystem /home/coder/rapidsmpf/cpp/build/pip/cuda-13.1/release/_deps/gtest-src/googlemock -isystem /home/coder/rapidsmpf/cpp/build/pip/cuda-13.1/release/_deps/gtest-src/googletest/include -isystem /home/coder/rapidsmpf/cpp/build/pip/cuda-13.1/release/_deps/gtest-src/googletest -O3 -DNDEBUG -std=gnu++20 -Wall -Werror -Wextra -Wsign-conversion -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-error=deprecated-declarations -MD -MT tests/CMakeFiles/bootstrap_tests.dir/bootstrap/test_socket_backend.cpp.o -MF tests/CMakeFiles/bootstrap_tests.dir/bootstrap/test_socket_backend.cpp.o.d -o tests/CMakeFiles/bootstrap_tests.dir/bootstrap/test_socket_backend.cpp.o -c /home/coder/rapidsmpf/cpp/tests/bootstrap/test_socket_backend.cpp
/home/coder/rapidsmpf/cpp/tests/bootstrap/test_socket_backend.cpp: In function 'std::string {anonymous}::send_recv_line(int, const std::string&)':
/home/coder/rapidsmpf/cpp/tests/bootstrap/test_socket_backend.cpp:94:12: error: ignoring return value of 'ssize_t write(int, const void*, size_t)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   94 |     ::write(fd, msg.c_str(), msg.size());
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

## Reproduction Environment
- `g++ (Ubuntu 14.3.0-12ubuntu1~24~ppa1) 14.3.0`
- `cmake version 4.3.2`
- `ninja 1.11.1`
- CUDA compilation tools `release 13.1, V13.1.115`

## Reproduction Flags
The failing compile command used:
```text
-DRAPIDSMPF_HAVE_SLURM -I/home/coder/rapidsmpf/cpp/include -O3 -DNDEBUG -std=gnu++20 -Wall -Werror -Wextra -Wsign-conversion -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-error=deprecated-declarations
```

The warning is promoted to an error by `-Werror`; GCC reports it as `-Werror=unused-result` because glibc declares `write()` with `warn_unused_result`.