### PR TITLE
Remove unnecessary include from `slurm_backend.cpp`

### DIFF
--- a/cpp/src/bootstrap/slurm_backend.cpp
+++ b/cpp/src/bootstrap/slurm_backend.cpp
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rapidsmpf/config.hpp>
-
 #ifdef RAPIDSMPF_HAVE_SLURM
 
 #include <chrono>


### PR DESCRIPTION
Remove `rapidsmpf/config.hpp` include which is unnecessary and introduces a CUDA dependency which is not supposed to exist in the bootstrapping code.