### PR TITLE
Remove CUDA includes from bootstrap sources

### DIFF
--- a/cpp/include/rapidsmpf/bootstrap/slurm_backend.hpp
+++ b/cpp/include/rapidsmpf/bootstrap/slurm_backend.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <rapidsmpf/config.hpp>
-
 #ifdef RAPIDSMPF_HAVE_SLURM
 
 #include <array>

--- a/cpp/src/bootstrap/bootstrap.cpp
+++ b/cpp/src/bootstrap/bootstrap.cpp
@@ -11,7 +11,6 @@
 #include <rapidsmpf/bootstrap/file_backend.hpp>
 #include <rapidsmpf/bootstrap/socket_backend.hpp>
 #include <rapidsmpf/bootstrap/utils.hpp>
-#include <rapidsmpf/config.hpp>
 
 #ifdef RAPIDSMPF_HAVE_SLURM
 #include <rapidsmpf/bootstrap/slurm_backend.hpp>

--- a/cpp/src/bootstrap/file_backend.cpp
+++ b/cpp/src/bootstrap/file_backend.cpp
@@ -22,7 +22,6 @@
 
 #include <rapidsmpf/bootstrap/file_backend.hpp>
 #include <rapidsmpf/bootstrap/utils.hpp>
-#include <rapidsmpf/error.hpp>
 
 // NOTE: Do not use RAPIDSMPF_EXPECTS or RAPIDSMPF_FAIL in this file.
 // Using these macros introduces a CUDA dependency via rapidsmpf/error.hpp.


### PR DESCRIPTION
## Summary
- Remove unused headers that pull CUDA into bootstrap-only sources
- Keep bootstrap_tests independent of CUDA while compiling bootstrap sources directly

## Validation
- git diff --check
- checked bootstrap source/header include paths for cuda_runtime_api.h