### PR TITLE
Pin cuCascade for 26.06 release

### DIFF
--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -15,7 +15,7 @@ function(find_and_configure_cucascade)
     CPM_ARGS
     GIT_REPOSITORY https://github.com/NVIDIA/cuCascade.git
     GIT_TAG e6dcdd37763e5018666b8b57e3a73a4c701d9c4e
-    GIT_SHALLOW TRUE
+    GIT_SHALLOW FALSE
     OPTIONS "CUCASCADE_BUILD_TESTS OFF"
             "CUCASCADE_BUILD_BENCHMARKS OFF"
             "CUCASCADE_BUILD_SHARED_LIBS OFF"

--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -14,7 +14,7 @@ function(find_and_configure_cucascade)
     GLOBAL_TARGETS cuCascade::cucascade cuCascade::cucascade_topology_discovery
     CPM_ARGS
     GIT_REPOSITORY https://github.com/NVIDIA/cuCascade.git
-    GIT_TAG main
+    GIT_TAG e6dcdd37763e5018666b8b57e3a73a4c701d9c4e
     GIT_SHALLOW TRUE
     OPTIONS "CUCASCADE_BUILD_TESTS OFF"
             "CUCASCADE_BUILD_BENCHMARKS OFF"


### PR DESCRIPTION
cuCascade does not currently have a release and versioning process. Prior to a RapidsMPF release it should be pinning to a known working commit.