### PR TITLE
Rename `BufferResource::{allocate() => make_buffer()}`

### DIFF
--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -219,10 +219,10 @@ Duration run(
         for (Rank rank = 0; rank < comm->nranks(); ++rank) {
             auto [res, _] =
                 br->reserve(MemoryType::DEVICE, args.msg_size * 2, AllowOverbooking::YES);
-            auto buf = br->allocate(args.msg_size, stream, res);
+            auto buf = br->make_buffer(args.msg_size, stream, res);
             random_fill(*buf, br->device_mr());
             send_bufs.push_back(std::move(buf));
-            recv_bufs.push_back(br->allocate(args.msg_size, stream, res));
+            recv_bufs.push_back(br->make_buffer(args.msg_size, stream, res));
         }
     }
 

--- a/cpp/include/rapidsmpf/memory/buffer_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer_resource.hpp
@@ -288,7 +288,7 @@ class BufferResource {
      * @throws std::invalid_argument if the memory type does not match the reservation.
      * @throws rapidsmpf::reservation_error if `size` exceeds the size of the reservation.
      */
-    std::unique_ptr<Buffer> allocate(
+    std::unique_ptr<Buffer> make_buffer(
         std::size_t size, rmm::cuda_stream_view stream, MemoryReservation& reservation
     );
 
@@ -302,7 +302,7 @@ class BufferResource {
      * @param reservation The memory reservation to consume for the allocation.
      * @return A unique pointer to the allocated Buffer.
      */
-    std::unique_ptr<Buffer> allocate(
+    std::unique_ptr<Buffer> make_buffer(
         rmm::cuda_stream_view stream, MemoryReservation&& reservation
     );
 

--- a/cpp/include/rapidsmpf/memory/packed_data.hpp
+++ b/cpp/include/rapidsmpf/memory/packed_data.hpp
@@ -88,7 +88,7 @@ struct PackedData {
      * the data buffer and metadata.
      */
     PackedData copy(MemoryReservation& reservation) const {
-        auto dst = reservation.br()->allocate(data->size, data->stream(), reservation);
+        auto dst = reservation.br()->make_buffer(data->size, data->stream(), reservation);
         buffer_copy(reservation.br()->statistics(), *dst, *data, data->size);
         return PackedData{
             std::make_unique<std::vector<std::uint8_t>>(*metadata), std::move(dst)

--- a/cpp/src/coll/utils.cpp
+++ b/cpp/src/coll/utils.cpp
@@ -145,7 +145,7 @@ std::unique_ptr<Chunk> Chunk::deserialize(
         id,
         Chunk::INVALID_RANK,
         std::move(metadata),
-        br->allocate(
+        br->make_buffer(
             br->stream_pool().get_stream(), br->reserve_or_fail(data_size, MEMORY_TYPES)
         )
     ));

--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -167,7 +167,7 @@ std::size_t BufferResource::release(MemoryReservation& reservation, std::size_t 
     return reservation.size_ -= size;
 }
 
-std::unique_ptr<Buffer> BufferResource::allocate(
+std::unique_ptr<Buffer> BufferResource::make_buffer(
     std::size_t size, rmm::cuda_stream_view stream, MemoryReservation& reservation
 ) {
     auto const mem_type = reservation.mem_type_;
@@ -202,10 +202,10 @@ std::unique_ptr<Buffer> BufferResource::allocate(
     return ret;
 }
 
-std::unique_ptr<Buffer> BufferResource::allocate(
+std::unique_ptr<Buffer> BufferResource::make_buffer(
     rmm::cuda_stream_view stream, MemoryReservation&& reservation
 ) {
-    return allocate(reservation.size(), stream, reservation);
+    return make_buffer(reservation.size(), stream, reservation);
 }
 
 std::unique_ptr<Buffer> BufferResource::move(
@@ -233,7 +233,7 @@ std::unique_ptr<Buffer> BufferResource::move(
 ) {
     if (reservation.mem_type_ != buffer->mem_type()) {
         auto const nbytes = buffer->size;
-        auto ret = allocate(nbytes, buffer->stream(), reservation);
+        auto ret = make_buffer(nbytes, buffer->stream(), reservation);
         buffer_copy(statistics_, *ret, *buffer, nbytes);
         return ret;
     }

--- a/cpp/src/shuffler/chunk.cpp
+++ b/cpp/src/shuffler/chunk.cpp
@@ -95,7 +95,7 @@ Chunk Chunk::deserialize(
         RAPIDSMPF_EXPECTS(
             br != nullptr, "Deserializing non-control Chunk requires a BufferResource"
         );
-        data = br->allocate(
+        data = br->make_buffer(
             br->stream_pool().get_stream(), br->reserve_or_fail(data_size, MEMORY_TYPES)
         );
         if (rapidsmpf::contains(SPILL_TARGET_MEMORY_TYPES, data->mem_type())) {

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -244,7 +244,7 @@ Shuffler::Shuffler(
                     comm_,
                     op_id,
                     [this](std::size_t size) -> std::unique_ptr<Buffer> {
-                        return br_->allocate(
+                        return br_->make_buffer(
                             br_->stream_pool().get_stream(),
                             br_->reserve_or_fail(size, MEMORY_TYPES)
                         );

--- a/cpp/src/streaming/cudf/table_chunk.cpp
+++ b/cpp/src/streaming/cudf/table_chunk.cpp
@@ -253,7 +253,7 @@ TableChunk TableChunk::copy(MemoryReservation& reservation) const {
     // to copy the packed data into the reservation-specified memory type.
     auto const nbytes = packed_data_->data->size;
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(*packed_data_->metadata);
-    auto data = br->allocate(nbytes, packed_data_->stream(), reservation);
+    auto data = br->make_buffer(nbytes, packed_data_->stream(), reservation);
     buffer_copy(br->statistics(), *data, *packed_data_->data, nbytes);
     return TableChunk(std::make_unique<PackedData>(std::move(metadata), std::move(data)));
 }

--- a/cpp/tests/streaming/test_allgather.cpp
+++ b/cpp/tests/streaming/test_allgather.cpp
@@ -72,7 +72,7 @@ TEST_P(StreamingAllGather, basic) {
         }
 
         auto br = ctx->br();
-        auto buf = br->allocate(
+        auto buf = br->make_buffer(
             br->stream_pool().get_stream(),
             br->reserve_or_fail(data.size() * sizeof(int), mem_type)
         );
@@ -143,7 +143,7 @@ TEST_P(StreamingAllGather, streaming_actor) {
         }
 
         auto br = ctx->br();
-        auto buf = br->allocate(
+        auto buf = br->make_buffer(
             br->stream_pool().get_stream(),
             br->reserve_or_fail(data.size() * sizeof(int), mem_type)
         );

--- a/cpp/tests/streaming/test_allreduce.cpp
+++ b/cpp/tests/streaming/test_allreduce.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<Buffer> make_buffer(
     auto const nbytes = count * sizeof(T);
     auto stream = br->stream_pool().get_stream();
     auto reservation = br->reserve_or_fail(nbytes, mem_type);
-    auto buffer = br->allocate(stream, std::move(reservation));
+    auto buffer = br->make_buffer(stream, std::move(reservation));
     buffer->write_access([&](std::byte* buf_data, rmm::cuda_stream_view s) {
         RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(buf_data, data, nbytes, s));
     });
@@ -87,7 +87,7 @@ TEST_F(StreamingAllReduce, basic_sum) {
         auto input =
             make_buffer<int>(ctx->br(), data.data(), data.size(), MemoryType::HOST);
         auto reservation = ctx->br()->reserve_or_fail(input->size, input->mem_type());
-        auto output = ctx->br()->allocate(input->size, input->stream(), reservation);
+        auto output = ctx->br()->make_buffer(input->size, input->stream(), reservation);
 
         auto reduce_op = coll::detail::make_host_reduce_operator<int>(std::plus<int>{});
 
@@ -116,7 +116,7 @@ TEST_F(StreamingAllReduce, empty_buffer) {
         std::vector<int> empty;
         auto input = make_buffer<int>(ctx->br(), empty.data(), 0, MemoryType::HOST);
         auto reservation = ctx->br()->reserve_or_fail(input->size, input->mem_type());
-        auto output = ctx->br()->allocate(input->size, input->stream(), reservation);
+        auto output = ctx->br()->make_buffer(input->size, input->stream(), reservation);
 
         auto reduce_op = coll::detail::make_host_reduce_operator<int>(std::plus<int>{});
 
@@ -148,7 +148,7 @@ TEST_F(StreamingAllReduce, concurrent_allreduces) {
         auto input =
             make_buffer<int>(ctx->br(), data.data(), data.size(), MemoryType::HOST);
         auto reservation = ctx->br()->reserve_or_fail(input->size, input->mem_type());
-        auto output = ctx->br()->allocate(input->size, input->stream(), reservation);
+        auto output = ctx->br()->make_buffer(input->size, input->stream(), reservation);
 
         auto reduce_op = coll::detail::make_host_reduce_operator<int>(std::plus<int>{});
 

--- a/cpp/tests/streaming/test_fanout.cpp
+++ b/cpp/tests/streaming/test_fanout.cpp
@@ -59,7 +59,7 @@ std::vector<Message> make_buffer_inputs(int n, rapidsmpf::BufferResource& br) {
     Message::CopyCallback copy_cb = [&](Message const& msg, MemoryReservation& res) {
         rmm::cuda_stream_view stream = br.stream_pool().get_stream();
         auto const cd = msg.content_description();
-        auto buf_cpy = br.allocate(cd.content_size(), stream, res);
+        auto buf_cpy = br.make_buffer(cd.content_size(), stream, res);
         // cd needs to be updated to reflect the new buffer
         ContentDescription new_cd{
             {{buf_cpy->mem_type(), buf_cpy->size}}, ContentDescription::Spillable::YES

--- a/cpp/tests/streaming/test_message.cpp
+++ b/cpp/tests/streaming/test_message.cpp
@@ -78,7 +78,7 @@ TEST_F(StreamingMessage, ContentSize) {
 TEST_F(StreamingMessage, CopyWithoutCallbacks) {
     Message m{
         0,
-        br->allocate(stream, br->reserve_or_fail(10, MemoryType::HOST)),
+        br->make_buffer(stream, br->reserve_or_fail(10, MemoryType::HOST)),
         ContentDescription{}
     };
     {
@@ -96,7 +96,7 @@ TEST_F(StreamingMessage, CopyWithCallbacks) {
                                        MemoryReservation& reservation) -> Message {
         EXPECT_TRUE(msg.holds<Buffer>());
         auto const& src = msg.get<Buffer>();
-        auto dst = reservation.br()->allocate(src.size, src.stream(), reservation);
+        auto dst = reservation.br()->make_buffer(src.size, src.stream(), reservation);
         buffer_copy(reservation.br()->statistics(), *dst, src, src.size);
         ContentDescription cd{
             {{dst->mem_type(), dst->size}}, ContentDescription::Spillable::YES
@@ -109,7 +109,7 @@ TEST_F(StreamingMessage, CopyWithCallbacks) {
         };
         Message m1{
             42,
-            br->allocate(stream, br->reserve_or_fail(10, MemoryType::HOST)),
+            br->make_buffer(stream, br->reserve_or_fail(10, MemoryType::HOST)),
             cd,
             copy_cb
         };
@@ -126,7 +126,7 @@ TEST_F(StreamingMessage, CopyWithCallbacks) {
         };
         Message m1{
             42,
-            br->allocate(stream, br->reserve_or_fail(10, MemoryType::DEVICE)),
+            br->make_buffer(stream, br->reserve_or_fail(10, MemoryType::DEVICE)),
             cd,
             copy_cb
         };

--- a/cpp/tests/streaming/test_sparse_alltoall.cpp
+++ b/cpp/tests/streaming/test_sparse_alltoall.cpp
@@ -50,7 +50,7 @@ PackedData make_payload(
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
     std::memcpy(metadata->data(), &metadata_value, sizeof(int));
 
-    auto data = br->allocate(stream, br->reserve_or_fail(sizeof(int), mem_type));
+    auto data = br->make_buffer(stream, br->reserve_or_fail(sizeof(int), mem_type));
     data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
         RAPIDSMPF_CUDA_TRY(
             rapidsmpf::cuda_memcpy_async(

--- a/cpp/tests/test_allgather.cpp
+++ b/cpp/tests/test_allgather.cpp
@@ -371,7 +371,7 @@ TEST(PostBox, spill_uses_remaining_amount) {
         auto metadata =
             std::make_unique<std::vector<std::uint8_t>>(std::size_t{1}, std::uint8_t{0});
         auto res = br->reserve_or_fail(size, rapidsmpf::MemoryType::DEVICE);
-        auto data = br->allocate(size, stream, res);
+        auto data = br->make_buffer(size, stream, res);
         return rapidsmpf::coll::detail::Chunk::from_packed_data(
             0,
             0,

--- a/cpp/tests/test_allreduce.cu
+++ b/cpp/tests/test_allreduce.cu
@@ -153,7 +153,7 @@ std::unique_ptr<rapidsmpf::Buffer> make_buffer(
     auto const nbytes = count * sizeof(T);
     auto stream = br->stream_pool().get_stream();
     auto reservation = br->reserve_or_fail(nbytes, mem_type);
-    auto buffer = br->allocate(stream, std::move(reservation));
+    auto buffer = br->make_buffer(stream, std::move(reservation));
 
     RAPIDSMPF_EXPECTS(
         buffer->mem_type() == mem_type, "make_buffer: buffer memory type mismatch"
@@ -228,13 +228,15 @@ TEST_F(BaseAllReduceTest, timeout_interleaved) {
     auto in_buffer1 =
         make_buffer<int>(br.get(), data1.data(), data1.size(), MemoryType::HOST);
     auto reservation = br->reserve_or_fail(in_buffer1->size, in_buffer1->mem_type());
-    auto out_buffer1 = br->allocate(in_buffer1->size, in_buffer1->stream(), reservation);
+    auto out_buffer1 =
+        br->make_buffer(in_buffer1->size, in_buffer1->stream(), reservation);
 
     std::vector<float> data2(1, rank + 7);
     auto in_buffer2 =
         make_buffer<float>(br.get(), data2.data(), data2.size(), MemoryType::DEVICE);
     reservation = br->reserve_or_fail(in_buffer2->size, in_buffer2->mem_type());
-    auto out_buffer2 = br->allocate(in_buffer2->size, in_buffer2->stream(), reservation);
+    auto out_buffer2 =
+        br->make_buffer(in_buffer2->size, in_buffer2->stream(), reservation);
 
     if (rank % 2 == 0) {
         AllReduce allreduce1(
@@ -340,7 +342,7 @@ TEST_P(AllReduceIntSumTest, basic_allreduce_sum_int) {
 
     auto in_buffer = make_buffer<int>(br.get(), data.data(), data.size(), mem_type);
     auto reservation = br->reserve_or_fail(in_buffer->size, in_buffer->mem_type());
-    auto out_buffer = br->allocate(in_buffer->size, in_buffer->stream(), reservation);
+    auto out_buffer = br->make_buffer(in_buffer->size, in_buffer->stream(), reservation);
 
     AllReduce allreduce(
         GlobalEnvironment->comm_,
@@ -446,7 +448,7 @@ TYPED_TEST(AllReduceTypedOpsTest, basic_allreduce) {
     auto in_buffer = make_buffer<T>(this->br.get(), data.data(), data.size(), mem_type);
     auto reservation = this->br->reserve_or_fail(in_buffer->size, in_buffer->mem_type());
     auto out_buffer =
-        this->br->allocate(in_buffer->size, in_buffer->stream(), reservation);
+        this->br->make_buffer(in_buffer->size, in_buffer->stream(), reservation);
 
     AllReduce allreduce(
         GlobalEnvironment->comm_,
@@ -512,7 +514,7 @@ TEST_P(AllReduceCustomTypeTest, custom_struct_allreduce) {
     auto in_buffer =
         make_buffer<CustomValue>(br.get(), data.data(), data.size(), mem_type);
     auto reservation = br->reserve_or_fail(in_buffer->size, in_buffer->mem_type());
-    auto out_buffer = br->allocate(in_buffer->size, in_buffer->stream(), reservation);
+    auto out_buffer = br->make_buffer(in_buffer->size, in_buffer->stream(), reservation);
 
     AllReduce allreduce(
         GlobalEnvironment->comm_,
@@ -574,7 +576,7 @@ TEST_F(AllReduceFinishedCallbackTest, finished_callback_invoked) {
     }
     auto in_buffer = make_buffer(br.get(), data.data(), data.size(), MemoryType::HOST);
     auto reservation = br->reserve_or_fail(in_buffer->size, in_buffer->mem_type());
-    auto out_buffer = br->allocate(in_buffer->size, in_buffer->stream(), reservation);
+    auto out_buffer = br->make_buffer(in_buffer->size, in_buffer->stream(), reservation);
 
     std::mutex m;
     std::condition_variable cv;
@@ -622,7 +624,7 @@ TEST_F(AllReduceFinishedCallbackTest, wait_and_extract_multiple_times) {
     }
     auto in_buffer = make_buffer(br.get(), data.data(), data.size(), MemoryType::DEVICE);
     auto reservation = br->reserve_or_fail(in_buffer->size, in_buffer->mem_type());
-    auto out_buffer = br->allocate(in_buffer->size, in_buffer->stream(), reservation);
+    auto out_buffer = br->make_buffer(in_buffer->size, in_buffer->stream(), reservation);
 
     AllReduce allreduce(
         GlobalEnvironment->comm_,

--- a/cpp/tests/test_buffer.cpp
+++ b/cpp/tests/test_buffer.cpp
@@ -96,7 +96,7 @@ TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
 
     auto [reserve1, overbooking1] =
         br->reserve(mem_type, buffer_size, AllowOverbooking::YES);
-    auto buffer1 = br->allocate(buffer_size, stream1, reserve1);
+    auto buffer1 = br->make_buffer(buffer_size, stream1, reserve1);
     EXPECT_EQ(buffer1->mem_type(), mem_type);
     EXPECT_EQ(buffer1->stream().value(), stream1.value());
 
@@ -115,7 +115,7 @@ TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
 
     auto [reserve2, overbooking2] =
         br->reserve(mem_type, buffer_size, AllowOverbooking::YES);
-    auto buffer2 = br->allocate(buffer_size, stream2, reserve2);
+    auto buffer2 = br->make_buffer(buffer_size, stream2, reserve2);
     EXPECT_EQ(buffer2->mem_type(), mem_type);
     EXPECT_EQ(buffer2->stream().value(), stream2.value());
 
@@ -143,7 +143,7 @@ TEST_P(BufferRebindStreamTest, RebindStreamSynchronizesCorrectly) {
 
     auto [reserve1, overbooking1] =
         br->reserve(mem_type, test_size, AllowOverbooking::YES);
-    auto buffer1 = br->allocate(test_size, stream1, reserve1);
+    auto buffer1 = br->make_buffer(test_size, stream1, reserve1);
     EXPECT_EQ(buffer1->mem_type(), mem_type);
 
     buffer1->write_access([&](std::byte* ptr, rmm::cuda_stream_view stream) {
@@ -179,7 +179,7 @@ TEST_P(BufferRebindStreamTest, MultipleRebinds) {
 
     constexpr std::size_t test_size = 2_MiB;
     auto [reserve, overbooking] = br->reserve(mem_type, test_size, AllowOverbooking::YES);
-    auto buffer = br->allocate(test_size, stream1, reserve);
+    auto buffer = br->make_buffer(test_size, stream1, reserve);
     EXPECT_EQ(buffer->mem_type(), mem_type);
 
     buffer->write_access([&](std::byte* ptr, rmm::cuda_stream_view stream) {
@@ -220,7 +220,7 @@ TEST_P(BufferRebindStreamTest, ThrowsWhenLocked) {
 
     constexpr std::size_t test_size = 1_MiB;
     auto [reserve, overbooking] = br->reserve(mem_type, test_size, AllowOverbooking::YES);
-    auto buffer = br->allocate(test_size, stream1, reserve);
+    auto buffer = br->make_buffer(test_size, stream1, reserve);
     EXPECT_EQ(buffer->mem_type(), mem_type);
 
     auto* ptr = buffer->exclusive_data_access();

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<Buffer> zeros(
     rmm::cuda_stream_view stream,
     MemoryReservation& reservation
 ) {
-    auto ret = br.allocate(size, stream, reservation);
+    auto ret = br.make_buffer(size, stream, reservation);
     if (size > 0) {
         ret->write_access([&](std::byte* ptr, rmm::cuda_stream_view s) {
             RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(ptr, 0, size, s));
@@ -308,22 +308,22 @@ TEST(BufferResource, AllocStatistics) {
     // Allocate device memory twice.
     {
         auto [r, _] = br.reserve(MemoryType::DEVICE, device_size, AllowOverbooking::YES);
-        br.allocate(device_size, stream, r);
+        br.make_buffer(device_size, stream, r);
     }
     {
         auto [r, _] = br.reserve(MemoryType::DEVICE, device_size, AllowOverbooking::YES);
-        br.allocate(device_size, stream, r);
+        br.make_buffer(device_size, stream, r);
     }
     // Allocate pinned_host memory once (if available).
     if (pinned_mr != PinnedMemoryResource::Disabled) {
         auto [r, _] =
             br.reserve(MemoryType::PINNED_HOST, pinned_size, AllowOverbooking::YES);
-        br.allocate(pinned_size, stream, r);
+        br.make_buffer(pinned_size, stream, r);
     }
     // Allocate host memory once.
     {
         auto [r, _] = br.reserve(MemoryType::HOST, host_size, AllowOverbooking::YES);
-        br.allocate(host_size, stream, r);
+        br.make_buffer(host_size, stream, r);
     }
 
     stream.synchronize();
@@ -437,7 +437,7 @@ class BaseBufferResourceCopyTest : public ::testing::Test {
     ) {
         auto [alloc_reserve, alloc_overbooking] =
             br->reserve(mem_type, size, AllowOverbooking::NO);
-        auto buf = br->allocate(size, stream, alloc_reserve);
+        auto buf = br->make_buffer(size, stream, alloc_reserve);
         EXPECT_EQ(buf->mem_type(), mem_type);
         // copy the host pattern to the Buffer
         buf->write_access([&](std::byte* buf_data, rmm::cuda_stream_view stream) {
@@ -474,7 +474,7 @@ class BufferResourceCopySliceTest
         std::size_t const offset,
         std::size_t const length
     ) {
-        auto slice = br->allocate(stream, br->reserve_or_fail(length, dest_type));
+        auto slice = br->make_buffer(stream, br->reserve_or_fail(length, dest_type));
         buffer_copy(
             br->statistics(),
             *slice,
@@ -594,7 +594,7 @@ TEST_P(BufferResourceCopyToTest, CopyTo) {
     auto source = create_and_initialize_buffer(source_type, params.source_size);
     auto [dest_reserve, dest_overbooking] =
         br->reserve(dest_type, buffer_size, AllowOverbooking::NO);
-    auto dest = br->allocate(buffer_size, stream, dest_reserve);
+    auto dest = br->make_buffer(buffer_size, stream, dest_reserve);
     EXPECT_EQ(dest->mem_type(), dest_type);
 
     copy_and_verify(source, dest, params.dest_offset);
@@ -654,7 +654,7 @@ class BufferResourceDifferentResourcesTest : public ::testing::Test {
     std::unique_ptr<Buffer> create_source_buffer() {
         auto [reserv1, ob1] =
             br1->reserve(MemoryType::DEVICE, buffer_size, AllowOverbooking::NO);
-        auto buf1 = br1->allocate(buffer_size, stream, reserv1);
+        auto buf1 = br1->make_buffer(buffer_size, stream, reserv1);
         EXPECT_EQ(reserv1.size(), 0);  // reservation should be consumed
         EXPECT_EQ(buf1->size, buffer_size);
         EXPECT_EQ(buf1->mem_type(), MemoryType::DEVICE);
@@ -696,7 +696,7 @@ TEST_F(BufferResourceDifferentResourcesTest, CopySlice) {
     auto res2 = br2->reserve_or_fail(slice_length, MEMORY_TYPES);
 
     // Create slice of buf1 on br2
-    auto buf2 = br2->allocate(slice_length, stream, res2);
+    auto buf2 = br2->make_buffer(slice_length, stream, res2);
     buffer_copy(
         br2->statistics(),
         *buf2,
@@ -718,7 +718,7 @@ TEST_F(BufferResourceDifferentResourcesTest, Copy) {
     auto buf1 = create_source_buffer();
 
     // Create copy of buf1 on br2
-    auto buf2 = br2->allocate(stream, br2->reserve_or_fail(buffer_size, MEMORY_TYPES));
+    auto buf2 = br2->make_buffer(stream, br2->reserve_or_fail(buffer_size, MEMORY_TYPES));
     buffer_copy(br2->statistics(), *buf2, *buf1, buffer_size);
     EXPECT_EQ(buf2->size, buffer_size);
     buf2->stream().synchronize();
@@ -733,7 +733,7 @@ TEST_F(BufferCopyEdgeCases, IllegalArguments) {
     constexpr std::size_t N = 1024;
 
     auto src = create_and_initialize_buffer(MemoryType::HOST, N);
-    auto dst = br->allocate(stream, br->reserve_or_fail(N, MemoryType::HOST));
+    auto dst = br->make_buffer(stream, br->reserve_or_fail(N, MemoryType::HOST));
 
     // Negative offsets
     EXPECT_THROW(
@@ -776,7 +776,7 @@ TEST_F(BufferCopyEdgeCases, ZeroSizeIsNoOp) {
     constexpr std::size_t N = 128;
 
     auto src = create_and_initialize_buffer(MemoryType::HOST, N);
-    auto dst = br->allocate(stream, br->reserve_or_fail(N, MemoryType::HOST));
+    auto dst = br->make_buffer(stream, br->reserve_or_fail(N, MemoryType::HOST));
 
     // Pre-fill dst with a sentinel pattern
     std::vector<std::uint8_t> sent(N, 0xCD);
@@ -796,7 +796,7 @@ TEST_F(BufferCopyEdgeCases, SameBufferIsDisallowed) {
     // Matches current implementation which rejects &dst == &src.
     constexpr std::size_t N = 64;
 
-    auto buf = br->allocate(stream, br->reserve_or_fail(N, MemoryType::HOST));
+    auto buf = br->make_buffer(stream, br->reserve_or_fail(N, MemoryType::HOST));
 
     EXPECT_THROW(
         buffer_copy(br->statistics(), *buf, *buf, 16, 0, 0), std::invalid_argument

--- a/cpp/tests/test_communicator.cpp
+++ b/cpp/tests/test_communicator.cpp
@@ -79,7 +79,7 @@ TEST_P(BasicCommunicatorTest, SendToSelf) {
     }
     constexpr int nelems{10};
     auto send_data_h = iota_vector<std::uint8_t>(nelems);
-    auto send_buf = br->allocate(stream, br->reserve_or_fail(nelems, memory_type()));
+    auto send_buf = br->make_buffer(stream, br->reserve_or_fail(nelems, memory_type()));
     send_buf->write_access([&](std::byte* send_buf_data, rmm::cuda_stream_view stream) {
         RAPIDSMPF_CUDA_TRY(
             rapidsmpf::cuda_memcpy_async(
@@ -91,7 +91,7 @@ TEST_P(BasicCommunicatorTest, SendToSelf) {
     rapidsmpf::Tag tag{0, 0};
     auto send_fut = comm->send(std::move(send_buf), comm->rank(), tag);
 
-    auto recv_buf = br->allocate(stream, br->reserve_or_fail(nelems, memory_type()));
+    auto recv_buf = br->make_buffer(stream, br->reserve_or_fail(nelems, memory_type()));
     recv_buf->stream().synchronize();
     auto recv_fut = comm->recv(comm->rank(), tag, std::move(recv_buf));
     std::ignore = comm->wait(std::move(send_fut));

--- a/cpp/tests/test_metadata_payload_exchange.cpp
+++ b/cpp/tests/test_metadata_payload_exchange.cpp
@@ -51,8 +51,9 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
     ) {
         std::unique_ptr<Buffer> data_buffer = nullptr;
         if (data_size > 0) {
-            data_buffer =
-                br->allocate(stream, br->reserve_or_fail(data_size, MemoryType::DEVICE));
+            data_buffer = br->make_buffer(
+                stream, br->reserve_or_fail(data_size, MemoryType::DEVICE)
+            );
             // Fill with test data
             data_buffer->write_access(
                 [data_size](std::byte* ptr, rmm::cuda_stream_view stream) {
@@ -72,7 +73,7 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
     }
 
     std::unique_ptr<Buffer> allocate_receive_buffer(std::size_t size) {
-        return br->allocate(stream, br->reserve_or_fail(size, MemoryType::DEVICE));
+        return br->make_buffer(stream, br->reserve_or_fail(size, MemoryType::DEVICE));
     }
 
     void wait_for_communication_complete() {

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -59,7 +59,7 @@ TEST(ReceivedChunks, spill_respects_amount) {
         auto metadata =
             std::make_unique<std::vector<std::uint8_t>>(std::size_t{1}, std::uint8_t{0});
         auto res = br->reserve_or_fail(chunk_size, rapidsmpf::MemoryType::DEVICE);
-        auto data = br->allocate(chunk_size, stream, res);
+        auto data = br->make_buffer(chunk_size, stream, res);
         received.insert(
             rapidsmpf::shuffler::detail::Chunk::from_packed_data(
                 0, pid, rapidsmpf::PackedData{std::move(metadata), std::move(data)}

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -61,7 +61,7 @@ rapidsmpf::PackedData make_payload(
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
     std::memcpy(metadata->data(), &metadata_value, sizeof(int));
 
-    auto data = br.allocate(stream, br.reserve_or_fail(sizeof(int), mem_type));
+    auto data = br.make_buffer(stream, br.reserve_or_fail(sizeof(int), mem_type));
     data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
         if (mem_type == rapidsmpf::MemoryType::DEVICE) {
             RAPIDSMPF_CUDA_TRY(

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
@@ -44,7 +44,7 @@ cdef extern from *:
 
         // Allocate host buffer and copy data into it
         auto reservation = br->reserve_or_fail(size, rapidsmpf::MemoryType::HOST);
-        auto buffer = br->allocate(
+        auto buffer = br->make_buffer(
             rmm::cuda_stream_default, std::move(reservation)
         );
 


### PR DESCRIPTION
To support the upcoming work on #641, this PR renames `allocate()` to `make_buffer()` to avoid shadowing the CCCL device resource `allocate()` method.