### PR TITLE
Remove custom `MemoryAvailable` functions

### DIFF
--- a/cpp/benchmarks/bench_shuffle.cpp
+++ b/cpp/benchmarks/bench_shuffle.cpp
@@ -538,12 +538,9 @@ int main(int argc, char** argv) {
     set_current_rmm_resource(args.rmm_mr);
     rapidsmpf::RmmResourceAdaptor stat_enabled_mr = set_device_mem_resource_with_stats();
 
-    std::unordered_map<rapidsmpf::MemoryType, rapidsmpf::BufferResource::MemoryAvailable>
-        memory_available{};
+    std::unordered_map<rapidsmpf::MemoryType, std::int64_t> memory_limits{};
     if (args.device_mem_limit_mb >= 0) {
-        memory_available[rapidsmpf::MemoryType::DEVICE] = rapidsmpf::LimitAvailableMemory{
-            stat_enabled_mr, args.device_mem_limit_mb << 20
-        };
+        memory_limits[rapidsmpf::MemoryType::DEVICE] = args.device_mem_limit_mb << 20;
     }
 
     auto stats = std::make_shared<rapidsmpf::Statistics>(/* enable = */ true);
@@ -554,7 +551,7 @@ int main(int argc, char** argv) {
         stat_enabled_mr,
         args.pinned_mem_disable ? rapidsmpf::PinnedMemoryResource::Disabled
                                 : rapidsmpf::PinnedMemoryResource::make_if_available(),
-        std::move(memory_available),
+        std::move(memory_limits),
         std::chrono::milliseconds{1},
         std::make_shared<rmm::cuda_stream_pool>(
             16, rmm::cuda_stream::flags::non_blocking

--- a/cpp/benchmarks/streaming/bench_streaming_shuffle.cpp
+++ b/cpp/benchmarks/streaming/bench_streaming_shuffle.cpp
@@ -359,12 +359,9 @@ int main(int argc, char** argv) {
 
     set_current_rmm_resource(args.rmm_mr);
     auto stat_enabled_mr = set_device_mem_resource_with_stats();
-    std::unordered_map<rapidsmpf::MemoryType, rapidsmpf::BufferResource::MemoryAvailable>
-        memory_available{};
+    std::unordered_map<rapidsmpf::MemoryType, std::int64_t> memory_limits{};
     if (args.device_mem_limit_mb >= 0) {
-        memory_available[rapidsmpf::MemoryType::DEVICE] = rapidsmpf::LimitAvailableMemory{
-            stat_enabled_mr, args.device_mem_limit_mb << 20
-        };
+        memory_limits[rapidsmpf::MemoryType::DEVICE] = args.device_mem_limit_mb << 20;
     }
 
     auto stats = std::make_shared<rapidsmpf::Statistics>(/* enable = */ true);
@@ -375,7 +372,7 @@ int main(int argc, char** argv) {
     auto br = std::make_shared<rapidsmpf::BufferResource>(
         stat_enabled_mr,
         pinned_mr,
-        std::move(memory_available),
+        std::move(memory_limits),
         std::nullopt,
         std::make_shared<rmm::cuda_stream_pool>(
             16, rmm::cuda_stream::flags::non_blocking

--- a/cpp/benchmarks/streaming/ndsh/bench_read.cpp
+++ b/cpp/benchmarks/streaming/ndsh/bench_read.cpp
@@ -365,7 +365,6 @@ int main(int argc, char** argv) {
     // work around https://github.com/rapidsai/cudf/issues/20849
     cudf::initialize();
     auto mr = rmm::mr::cuda_async_memory_resource{};
-    auto stats_wrapper = rapidsmpf::RmmResourceAdaptor(mr);
     auto arguments = parse_arguments(argc, argv);
     rapidsmpf::ndsh::ProgramOptions ctx_arguments{
         .num_streaming_threads = arguments.num_streaming_threads,
@@ -377,8 +376,7 @@ int main(int argc, char** argv) {
         .input_directory = arguments.input_directory
     };
 
-    auto [ctx, comm] =
-        rapidsmpf::ndsh::create_context(ctx_arguments, std::move(stats_wrapper));
+    auto [ctx, comm] = rapidsmpf::ndsh::create_context(ctx_arguments, std::move(mr));
     std::vector<double> timings;
     for (int i = 0; i < arguments.num_iterations; i++) {
         std::vector<rapidsmpf::streaming::Actor> actors;

--- a/cpp/benchmarks/streaming/ndsh/q01.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q01.cpp
@@ -302,10 +302,8 @@ int main(int argc, char** argv) {
     // work around https://github.com/rapidsai/cudf/issues/20849
     cudf::initialize();
     auto mr = rmm::mr::cuda_async_memory_resource{};
-    auto stats_wrapper = rapidsmpf::RmmResourceAdaptor(mr);
     auto arguments = rapidsmpf::ndsh::parse_arguments(argc, argv);
-    auto [ctx, comm] =
-        rapidsmpf::ndsh::create_context(arguments, std::move(stats_wrapper));
+    auto [ctx, comm] = rapidsmpf::ndsh::create_context(arguments, std::move(mr));
     std::string output_path = arguments.output_file;
 
     // Detect date column type from parquet metadata before timed section

--- a/cpp/benchmarks/streaming/ndsh/q03.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q03.cpp
@@ -453,10 +453,8 @@ int main(int argc, char** argv) {
     // work around https://github.com/rapidsai/cudf/issues/20849
     cudf::initialize();
     auto mr = rmm::mr::cuda_async_memory_resource{};
-    auto stats_wrapper = rapidsmpf::RmmResourceAdaptor(mr);
     auto arguments = rapidsmpf::ndsh::parse_arguments(argc, argv);
-    auto [ctx, comm] =
-        rapidsmpf::ndsh::create_context(arguments, std::move(stats_wrapper));
+    auto [ctx, comm] = rapidsmpf::ndsh::create_context(arguments, std::move(mr));
     std::string output_path = arguments.output_file;
 
     // Detect date column types from parquet metadata before timed section

--- a/cpp/benchmarks/streaming/ndsh/q04.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q04.cpp
@@ -294,10 +294,8 @@ int main(int argc, char** argv) {
     // work around https://github.com/rapidsai/cudf/issues/20849
     cudf::initialize();
     auto mr = rmm::mr::cuda_async_memory_resource{};
-    auto stats_wrapper = rapidsmpf::RmmResourceAdaptor(mr);
     auto arguments = rapidsmpf::ndsh::parse_arguments(argc, argv);
-    auto [ctx, comm] =
-        rapidsmpf::ndsh::create_context(arguments, std::move(stats_wrapper));
+    auto [ctx, comm] = rapidsmpf::ndsh::create_context(arguments, std::move(mr));
     std::string output_path = arguments.output_file;
     std::vector<double> timings;
 

--- a/cpp/benchmarks/streaming/ndsh/q09.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q09.cpp
@@ -377,10 +377,8 @@ int main(int argc, char** argv) {
     // work around https://github.com/rapidsai/cudf/issues/20849
     cudf::initialize();
     auto mr = rmm::mr::cuda_async_memory_resource{};
-    auto stats_wrapper = rapidsmpf::RmmResourceAdaptor(mr);
     auto arguments = rapidsmpf::ndsh::parse_arguments(argc, argv);
-    auto [ctx, comm] =
-        rapidsmpf::ndsh::create_context(arguments, std::move(stats_wrapper));
+    auto [ctx, comm] = rapidsmpf::ndsh::create_context(arguments, std::move(mr));
     std::string output_path = arguments.output_file;
     std::vector<double> timings;
     for (int i = 0; i < arguments.num_iterations; i++) {

--- a/cpp/benchmarks/streaming/ndsh/q21.cpp
+++ b/cpp/benchmarks/streaming/ndsh/q21.cpp
@@ -648,10 +648,8 @@ int main(int argc, char** argv) {
     cudaFree(nullptr);
     cudf::initialize();
     auto mr = rmm::mr::cuda_async_memory_resource{};
-    auto stats_wrapper = rapidsmpf::RmmResourceAdaptor(mr);
     auto arguments = rapidsmpf::ndsh::parse_arguments(argc, argv);
-    auto [ctx, comm] =
-        rapidsmpf::ndsh::create_context(arguments, std::move(stats_wrapper));
+    auto [ctx, comm] = rapidsmpf::ndsh::create_context(arguments, std::move(mr));
     std::string output_path = arguments.output_file;
     std::vector<double> timings;
     int l2size;

--- a/cpp/benchmarks/streaming/ndsh/utils.cpp
+++ b/cpp/benchmarks/streaming/ndsh/utils.cpp
@@ -129,9 +129,11 @@ streaming::Actor consume_channel(
 }
 
 std::pair<std::shared_ptr<streaming::Context>, std::shared_ptr<Communicator>>
-create_context(ProgramOptions& arguments, RmmResourceAdaptor&& mr) {
+create_context(
+    ProgramOptions& arguments, cuda::mr::any_resource<cuda::mr::device_accessible> mr
+) {
     rmm::mr::set_current_device_resource(mr);
-    std::unordered_map<MemoryType, BufferResource::MemoryAvailable> memory_available{};
+    std::unordered_map<MemoryType, std::int64_t> memory_limits{};
     if (arguments.spill_device_limit.has_value()) {
         auto limit_size = rmm::align_down(
             (rmm::available_device_memory().second
@@ -140,8 +142,7 @@ create_context(ProgramOptions& arguments, RmmResourceAdaptor&& mr) {
             rmm::CUDA_ALLOCATION_ALIGNMENT
         );
 
-        memory_available[MemoryType::DEVICE] =
-            LimitAvailableMemory{mr, static_cast<std::int64_t>(limit_size)};
+        memory_limits[MemoryType::DEVICE] = static_cast<std::int64_t>(limit_size);
     }
     auto statistics = std::make_shared<Statistics>(/* enable = */ true);
 
@@ -159,7 +160,7 @@ create_context(ProgramOptions& arguments, RmmResourceAdaptor&& mr) {
         std::move(mr),
         arguments.no_pinned_host_memory ? PinnedMemoryResource::Disabled
                                         : PinnedMemoryResource::make_if_available(),
-        std::move(memory_available),
+        std::move(memory_limits),
         arguments.periodic_spill,
         std::make_shared<rmm::cuda_stream_pool>(
             arguments.num_streams, rmm::cuda_stream::flags::non_blocking

--- a/cpp/benchmarks/streaming/ndsh/utils.hpp
+++ b/cpp/benchmarks/streaming/ndsh/utils.hpp
@@ -14,6 +14,8 @@
 
 #include <mpi.h>
 
+#include <cuda/memory_resource>
+
 #include <cudf/ast/expressions.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/types.hpp>
@@ -295,12 +297,14 @@ ProgramOptions parse_arguments(int argc, char** argv);
  * @brief Create a streaming execution context and communicator for a query.
  *
  * @param arguments Arguments to configure the context
- * @param mr The RMM resource adaptor to use for all allocations.
+ * @param mr The device memory resource to use for all allocations.
  *
  * @return Pair of shared pointer to new streaming context and communicator.
  */
 std::pair<std::shared_ptr<streaming::Context>, std::shared_ptr<Communicator>>
-create_context(ProgramOptions& arguments, RmmResourceAdaptor&& mr);
+create_context(
+    ProgramOptions& arguments, cuda::mr::any_resource<cuda::mr::device_accessible> mr
+);
 
 /**
  * @brief Finalize MPI when going out of scope.

--- a/cpp/include/rapidsmpf/memory/buffer_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer_resource.hpp
@@ -6,6 +6,8 @@
 #pragma once
 
 #include <array>
+#include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -55,42 +57,35 @@ enum class AllowOverbooking : bool {
 class BufferResource {
   public:
     /**
-     * @brief Callback function to determine available memory.
-     *
-     * The function should return the current available memory of a specific type and
-     * must be thread-safe iff used by multiple `BufferResource` instances concurrently.
-     *
-     * @warning Calling any `BufferResource` instance methods in the function might result
-     * in a deadlock. This is because the buffer resource is locked when the function is
-     * called.
-     */
-    using MemoryAvailable = std::function<std::int64_t()>;
-
-    /**
      * @brief Constructs a buffer resource.
      *
+     * Memory availability is computed per `MemoryType` as `limit - allocated`.
+     *
+     * Device and pinned-host allocations routed through this BufferResource are tracked
+     * automatically. Host memory allocations are not tracked, so the available memory
+     * always equals the configured limit.
+     *
+     * If pinned-host memory is disabled, available pinned-host memory is always reported
+     * as zero regardless of the configured limit.
+     *
      * @param device_mr The RMM device memory resource used for device allocations.
-     * Ownership is transferred to the BufferResource.
      * @param pinned_mr The pinned host memory resource used for `MemoryType::PINNED_HOST`
-     * allocations. If null, pinned host allocations are disabled. In that case, any
-     * attempt to allocate pinned memory will fail regardless of what @p memory_available
-     * reports.
-     * @param memory_available Optional functions that report available memory for each
-     * memory type. If a memory type is not present in this map, it is treated as having
-     * unlimited available memory. The only exception is `MemoryType::PINNED_HOST`, which
-     * is always assigned a zero-capacity function when `pinned_mr` is disabled.
+     * allocations. If disabled, pinned host allocations are unavailable regardless of
+     * @p memory_limits.
+     * @param memory_limits Maximum bytes per memory type before overbooking or spilling.
+     * Missing entries default to unlimited.
      * @param periodic_spill_check Enable periodic spill checks. A dedicated thread
-     * continuously checks and perform spilling based on the memory availability
-     * functions. The value of `periodic_spill_check` is used as the pause between checks.
-     * If `std::nullopt`, no periodic spill check is performed.
-     * @param stream_pool Pool of CUDA streams. Used throughout RapidsMPF for operations
+     * continuously checks and performs spilling based on memory availability. The value
+     * of `periodic_spill_check` controls the pause between checks. If `std::nullopt`, no
+     * periodic spill checking is performed.
+     * @param stream_pool Pool of CUDA streams used throughout RapidsMPF for operations
      * that do not take an explicit CUDA stream.
      * @param statistics The statistics instance to use (disabled by default).
      */
     BufferResource(
         cuda::mr::any_resource<cuda::mr::device_accessible> device_mr,
         std::optional<PinnedMemoryResource> pinned_mr = PinnedMemoryResource::Disabled,
-        std::unordered_map<MemoryType, MemoryAvailable> memory_available = {},
+        std::unordered_map<MemoryType, std::int64_t> memory_limits = {},
         std::optional<Duration> periodic_spill_check = std::chrono::milliseconds{1},
         std::shared_ptr<rmm::cuda_stream_pool> stream_pool = std::make_shared<
             rmm::cuda_stream_pool>(16, rmm::cuda_stream::flags::non_blocking),
@@ -101,16 +96,17 @@ class BufferResource {
      * @brief Construct a BufferResource from configuration options.
      *
      * This factory method creates a BufferResource using configuration options to
-     * initialize all components.
+     * initialize all components. The supplied device memory resource is wrapped in
+     * an internal `RmmResourceAdaptor` for allocation tracking.
      *
-     * @param mr The RMM resource adaptor.
+     * @param mr A device-accessible RMM memory resource.
      * @param options Configuration options.
      *
      * @return A shared pointer to a BufferResource instance configured according to the
      * options.
      */
     static std::shared_ptr<BufferResource> from_options(
-        RmmResourceAdaptor mr, config::Options options
+        cuda::mr::any_resource<cuda::mr::device_accessible> mr, config::Options options
     );
 
     ~BufferResource() noexcept = default;
@@ -146,17 +142,33 @@ class BufferResource {
     [[nodiscard]] std::optional<any_host_device_resource> try_pinned_mr() const noexcept;
 
     /**
-     * @brief Retrieves the memory availability function for a given memory type.
+     * @brief Returns the currently available memory for a given memory type, in bytes.
      *
-     * This function returns the callback function used to determine the available memory
-     * for the specified memory type.
+     * Computed as `limit - allocated`, where `allocated` is reported by the
+     * memory type's allocation counter (see the constructor documentation for
+     * how each memory type is tracked). The value may be negative when
+     * allocations exceed the configured limit.
      *
-     * @param mem_type The type of memory whose availability function is requested.
-     * @return Reference to the memory availability function associated with `mem_type`.
+     * @param mem_type The memory type to query.
+     * @return The available memory in bytes.
      */
-    [[nodiscard]] MemoryAvailable const& memory_available(MemoryType mem_type) const {
-        return memory_available_.at(mem_type);
-    }
+    [[nodiscard]] std::int64_t memory_available(MemoryType mem_type) const noexcept;
+
+    /**
+     * @brief Updates the memory limit for a given memory type at runtime.
+     *
+     * The store is atomic, but readers (e.g. `memory_available()` and `reserve()`)
+     * observe the limit and the allocation count independently. A concurrent
+     * `set_memory_limit()` call can change the limit between a caller's read of
+     * `memory_available()` and a subsequent allocation decision; callers that need
+     * a coherent view must serialize updates with higher-level synchronization.
+     *
+     * @param mem_type The memory type whose limit is being updated.
+     * @param limit The new byte limit. Negative values are permitted; they make
+     * `memory_available(mem_type)` always negative and so trigger continuous
+     * spilling.
+     */
+    void set_memory_limit(MemoryType mem_type, std::int64_t limit) noexcept;
 
     /**
      * @brief Get the current reserved memory of the specified memory type.
@@ -408,10 +420,14 @@ class BufferResource {
 
   private:
     std::mutex mutex_;
+    // The internal RmmResourceAdaptor wraps the user's device MR so that
+    // allocations are tracked for the DEVICE memory_available calculation.
+    // Declared before device_mr_ because device_mr_ is initialized from it.
+    RmmResourceAdaptor device_adaptor_;
     cuda::mr::any_resource<cuda::mr::device_accessible> device_mr_;
     std::optional<PinnedMemoryResource> pinned_mr_;
     HostMemoryResource host_mr_;
-    std::unordered_map<MemoryType, MemoryAvailable> memory_available_;
+    std::array<std::atomic<std::int64_t>, MEMORY_TYPES.size()> memory_limits_;
     // Zero initialized reserved counters.
     std::array<std::size_t, MEMORY_TYPES.size()> memory_reserved_ = {};
     std::shared_ptr<rmm::cuda_stream_pool> stream_pool_;
@@ -420,62 +436,17 @@ class BufferResource {
 };
 
 /**
- * @brief A functor for querying the remaining available memory within a defined limit
- * from an RMM statistics resource.
+ * @brief Parse the `spill_device_limit` parameter from configuration options.
  *
- * This class is designed to be used as a callback to provide available memory
- * information in the context of memory management, such as when working with
- * `BufferResource`. The available memory is determined as the difference
- * between a user-defined limit and the memory currently used, as reported
- * by an RMM statistics resource adaptor.
+ * Reads the `spill_device_limit` option, falling back to 80% of total device
+ * memory when unset. The result is aligned down to
+ * `rmm::CUDA_ALLOCATION_ALIGNMENT`.
  *
- * By enforcing a limit, this functor can be used to simulate constrained memory
- * environments or to prevent memory allocation beyond a specific threshold.
- *
- * @see rapidsmpf::BufferResource::MemoryAvailable
- */
-class LimitAvailableMemory {
-  public:
-    /**
-     * @brief Constructs a `LimitAvailableMemory` instance.
-     *
-     * @param mr The RMM resource adaptor.
-     * @param limit The maximum memory available (in bytes). Used to calculate the
-     * remaining memory.
-     */
-    LimitAvailableMemory(RmmResourceAdaptor mr, std::int64_t limit)
-        : limit{limit}, mr_{std::move(mr)} {}
-
-    /**
-     * @brief Returns the remaining available memory within the defined limit.
-     *
-     * This operator queries the `RmmResourceAdaptor` to determine the memory
-     * currently used and calculates the remaining memory as:
-     * `limit - used_memory`.
-     *
-     * @return The remaining memory in bytes.
-     */
-    std::int64_t operator()() const {
-        return limit - mr_.current_allocated();
-    }
-
-  public:
-    std::int64_t const limit;  ///< The memory limit.
-
-  private:
-    RmmResourceAdaptor const mr_;
-};
-
-/**
- * @brief Construct a map of memory-available functions from configuration options.
- *
- * @param mr The RMM resource adaptor.
  * @param options Configuration options.
  *
- * @return The map of memory-available functions.
+ * @return The device memory limit in bytes.
  */
-std::unordered_map<MemoryType, BufferResource::MemoryAvailable>
-memory_available_from_options(RmmResourceAdaptor mr, config::Options options);
+std::int64_t device_limit_from_options(config::Options options);
 
 /**
  * @brief Get the `periodic_spill_check` parameter from configuration options.

--- a/cpp/include/rapidsmpf/memory/pinned_memory_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/pinned_memory_resource.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <cstddef>
-#include <functional>
 #include <memory>
 
 #include <cuda.h>
@@ -228,15 +227,6 @@ class PinnedMemoryResource final
     [[nodiscard]] constexpr PinnedPoolProperties const& properties() const noexcept {
         return pool_properties_;
     }
-
-    /**
-     * @brief Returns a memory-availability callback for the pinned pool, if the pool has
-     * a configured maximum size.
-     *
-     * @return A callable `std::int64_t()`. If no maximum pool size is configured, returns
-     * `std::numeric_limits<std::int64_t>::%max` (unbounded).
-     */
-    [[nodiscard]] std::function<std::int64_t()> get_memory_available_cb() const;
 
     /**
      * @brief Enables the `cuda::mr::host_accessible` property.

--- a/cpp/src/coll/allgather.cpp
+++ b/cpp/src/coll/allgather.cpp
@@ -95,7 +95,7 @@ std::size_t AllGather::spill(std::optional<std::size_t> amount) {
     if (amount.has_value()) {
         spill_need = amount.value();
     } else {
-        std::int64_t const headroom = br_->memory_available(MemoryType::DEVICE)();
+        std::int64_t const headroom = br_->memory_available(MemoryType::DEVICE);
         spill_need = headroom < 0 ? safe_cast<std::size_t>(std::abs(headroom)) : 0;
     }
     std::size_t spilled{0};

--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -20,62 +20,74 @@
 
 namespace rapidsmpf {
 
-namespace {
-/// @brief Helper that adds missing functions to the `memory_available` argument.
-auto add_missing_availability_functions(
-    std::unordered_map<MemoryType, BufferResource::MemoryAvailable>&& memory_available,
-    bool pinned_mr_is_not_available
-) {
-    for (MemoryType mem_type : MEMORY_TYPES) {
-        // Add missing memory availability functions.
-        memory_available.try_emplace(mem_type, std::numeric_limits<std::int64_t>::max);
-    }
-    if (pinned_mr_is_not_available) {
-        memory_available[MemoryType::PINNED_HOST] = []() -> std::int64_t { return 0; };
-    }
-    return memory_available;
-}
-}  // namespace
-
 BufferResource::BufferResource(
     cuda::mr::any_resource<cuda::mr::device_accessible> device_mr,
     std::optional<PinnedMemoryResource> pinned_mr,
-    std::unordered_map<MemoryType, MemoryAvailable> memory_available,
+    std::unordered_map<MemoryType, std::int64_t> memory_limits,
     std::optional<Duration> periodic_spill_check,
     std::shared_ptr<rmm::cuda_stream_pool> stream_pool,
     std::shared_ptr<Statistics> statistics
 )
-    : device_mr_{std::move(device_mr)},
+    : device_adaptor_{std::move(device_mr)},
+      device_mr_{device_adaptor_},  // any_resource shares state via shared_resource
       pinned_mr_{std::move(pinned_mr)},
       host_mr_{},
-      memory_available_{add_missing_availability_functions(
-          std::move(memory_available), pinned_mr_ == PinnedMemoryResource::Disabled
-      )},
       stream_pool_{std::move(stream_pool)},
       spill_manager_{this, periodic_spill_check},
       statistics_{std::move(statistics)} {
+    // Default every limit to unlimited, then apply caller overrides.
+    for (auto& limit : memory_limits_) {
+        limit.store(std::numeric_limits<std::int64_t>::max(), std::memory_order_relaxed);
+    }
+    for (auto const& [mem_type, limit] : memory_limits) {
+        memory_limits_[static_cast<std::size_t>(mem_type)].store(
+            limit, std::memory_order_relaxed
+        );
+    }
     RAPIDSMPF_EXPECTS(stream_pool_ != nullptr, "the stream pool pointer cannot be NULL");
     RAPIDSMPF_EXPECTS(statistics_ != nullptr, "the statistics pointer cannot be NULL");
 }
 
 std::shared_ptr<BufferResource> BufferResource::from_options(
-    RmmResourceAdaptor mr, config::Options options
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr, config::Options options
 ) {
     auto pinned_mr = PinnedMemoryResource::from_options(options);
-    auto mem_available = memory_available_from_options(mr, options);
-
-    if (pinned_mr != PinnedMemoryResource::Disabled) {
-        mem_available[MemoryType::PINNED_HOST] = pinned_mr->get_memory_available_cb();
-    }
-
+    std::unordered_map<MemoryType, std::int64_t> memory_limits{
+        {MemoryType::DEVICE, device_limit_from_options(options)}
+    };
     auto statistics = Statistics::from_options(options);
     return std::make_shared<BufferResource>(
         std::move(mr),
         std::move(pinned_mr),
-        std::move(mem_available),
+        std::move(memory_limits),
         periodic_spill_check_from_options(options),
         stream_pool_from_options(options),
         std::move(statistics)
+    );
+}
+
+std::int64_t BufferResource::memory_available(MemoryType mem_type) const noexcept {
+    std::int64_t const limit = memory_limits_[static_cast<std::size_t>(mem_type)].load(
+        std::memory_order_acquire
+    );
+    switch (mem_type) {
+    case MemoryType::DEVICE:
+        return limit - device_adaptor_.current_allocated();
+    case MemoryType::PINNED_HOST:
+        if (pinned_mr_ == PinnedMemoryResource::Disabled) {
+            return 0;
+        } else {
+            return limit - pinned_mr_->current_allocated();
+        }
+    case MemoryType::HOST:
+        return limit;
+    }
+    return std::numeric_limits<std::int64_t>::max();
+}
+
+void BufferResource::set_memory_limit(MemoryType mem_type, std::int64_t limit) noexcept {
+    memory_limits_[static_cast<std::size_t>(mem_type)].store(
+        limit, std::memory_order_release
     );
 }
 
@@ -112,13 +124,13 @@ std::pair<MemoryReservation, std::size_t> BufferResource::reserve(
         std::invalid_argument
     );
 
-    auto const& available = memory_available(mem_type);
+    std::int64_t const available = memory_available(mem_type);
     std::lock_guard<std::mutex> lock(mutex_);
     std::size_t& reserved = memory_reserved_[static_cast<std::size_t>(mem_type)];
 
     // Calculate the available memory _after_ the memory has been reserved.
     std::int64_t headroom =
-        available() - (safe_cast<std::int64_t>(reserved) + safe_cast<std::int64_t>(size));
+        available - (safe_cast<std::int64_t>(reserved) + safe_cast<std::int64_t>(size));
     // If negative, we are overbooking.
     std::size_t overbooking =
         headroom < 0 ? safe_cast<std::size_t>(std::abs(headroom)) : 0;
@@ -281,23 +293,14 @@ std::shared_ptr<Statistics> BufferResource::statistics() {
     return statistics_;
 }
 
-std::unordered_map<MemoryType, BufferResource::MemoryAvailable>
-memory_available_from_options(RmmResourceAdaptor mr, config::Options options) {
-    // Create a memory availability map that limits device memory based on the
-    // `spill_device_limit` option.
-    return {
-        {MemoryType::DEVICE,
-         LimitAvailableMemory{
-             std::move(mr),
-             options.get<std::int64_t>("spill_device_limit", [](auto const& s) {
-                 auto const [_, total_mem] = rmm::available_device_memory();
-                 return rmm::align_down(
-                     parse_nbytes_or_percent(s.empty() ? "80%" : s, total_mem),
-                     rmm::CUDA_ALLOCATION_ALIGNMENT
-                 );
-             })
-         }}
-    };
+std::int64_t device_limit_from_options(config::Options options) {
+    return options.get<std::int64_t>("spill_device_limit", [](auto const& s) {
+        auto const [_, total_mem] = rmm::available_device_memory();
+        return rmm::align_down(
+            parse_nbytes_or_percent(s.empty() ? "80%" : s, total_mem),
+            rmm::CUDA_ALLOCATION_ALIGNMENT
+        );
+    });
 }
 
 std::optional<Duration> periodic_spill_check_from_options(config::Options options) {

--- a/cpp/src/memory/pinned_memory_resource.cpp
+++ b/cpp/src/memory/pinned_memory_resource.cpp
@@ -103,15 +103,4 @@ std::optional<PinnedMemoryResource> PinnedMemoryResource::from_options(
     return PinnedMemoryResource::Disabled;
 }
 
-std::function<std::int64_t()> PinnedMemoryResource::get_memory_available_cb() const {
-    auto const max_pool_size = pool_properties_.max_pool_size.value_or(0);
-    if (max_pool_size > 0) {
-        auto const limit = safe_cast<std::int64_t>(max_pool_size);
-        return [tracker = *this, limit]() {
-            return limit - tracker.get().current_allocated();
-        };
-    }
-    return std::numeric_limits<std::int64_t>::max;
-}
-
 }  // namespace rapidsmpf

--- a/cpp/src/memory/spill_manager.cpp
+++ b/cpp/src/memory/spill_manager.cpp
@@ -80,7 +80,7 @@ std::size_t SpillManager::spill(std::size_t amount) {
 
 std::size_t SpillManager::spill_to_make_headroom(std::int64_t headroom) {
     // TODO: check other memory types.
-    std::int64_t available = br_->memory_available(MemoryType::DEVICE)();
+    std::int64_t available = br_->memory_available(MemoryType::DEVICE);
     if (headroom <= available) {
         return 0;
     }

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -352,7 +352,7 @@ void Shuffler::insert(std::unordered_map<PartID, PackedData>&& chunks) {
         }
 
         // Check if we should spill the chunk before inserting into the inbox.
-        std::int64_t const headroom = br_->memory_available(MemoryType::DEVICE)();
+        std::int64_t const headroom = br_->memory_available(MemoryType::DEVICE);
         if (headroom < 0 && packed_data.data) {
             auto reservation =
                 br_->reserve_or_fail(packed_data.data->size, SPILL_TARGET_MEMORY_TYPES);
@@ -441,7 +441,7 @@ std::size_t Shuffler::spill(std::optional<std::size_t> amount) {
     if (amount.has_value()) {
         spill_need = amount.value();
     } else {
-        std::int64_t const headroom = br_->memory_available(MemoryType::DEVICE)();
+        std::int64_t const headroom = br_->memory_available(MemoryType::DEVICE);
         if (headroom < 0) {
             spill_need = safe_cast<std::size_t>(std::abs(headroom));
         }

--- a/cpp/src/streaming/core/memory_reserve_or_wait.cpp
+++ b/cpp/src/streaming/core/memory_reserve_or_wait.cpp
@@ -166,8 +166,8 @@ Duration MemoryReserveOrWait::timeout() const noexcept {
 
 coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
     // Helper that returns available memory, clamped so negative values become zero.
-    auto memory_available = [f = br_->memory_available(mem_type_)]() -> std::size_t {
-        std::int64_t const ret = f();
+    auto memory_available = [this]() -> std::size_t {
+        std::int64_t const ret = br_->memory_available(mem_type_);
         return safe_cast<std::size_t>(std::max(ret, std::int64_t{0}));
     };
 

--- a/cpp/tests/streaming/base_streaming_fixture.hpp
+++ b/cpp/tests/streaming/base_streaming_fixture.hpp
@@ -34,9 +34,7 @@ class BaseStreamingFixture : public ::testing::Test {
 
     void SetUpWithThreads(
         int num_streaming_threads,
-        std::unordered_map<
-            rapidsmpf::MemoryType,
-            rapidsmpf::BufferResource::MemoryAvailable> memory_available = {}
+        std::unordered_map<rapidsmpf::MemoryType, std::int64_t> memory_limits = {}
     ) {
         // create a new options object, since we can not modify values in the global
         // options object
@@ -46,7 +44,7 @@ class BaseStreamingFixture : public ::testing::Test {
 
         stream = cudf::get_default_stream();
         br = std::make_shared<rapidsmpf::BufferResource>(
-            mr_cuda, rapidsmpf::PinnedMemoryResource::Disabled, memory_available
+            mr_cuda, rapidsmpf::PinnedMemoryResource::Disabled, std::move(memory_limits)
         );
         ctx = std::make_shared<rapidsmpf::streaming::Context>(
             std::move(options), GlobalEnvironment->comm_->logger(), br

--- a/cpp/tests/streaming/test_fanout.cpp
+++ b/cpp/tests/streaming/test_fanout.cpp
@@ -544,12 +544,11 @@ class SpillingStreamingFanout : public BaseStreamingFixture {
         SetUpWithThreads(4);
 
         // override br and context with no device memory
-        std::unordered_map<MemoryType, BufferResource::MemoryAvailable> memory_available =
-            {
-                {MemoryType::DEVICE, []() -> std::int64_t { return 0; }},
-            };
+        std::unordered_map<MemoryType, std::int64_t> memory_limits = {
+            {MemoryType::DEVICE, 0},
+        };
         br = std::make_shared<rapidsmpf::BufferResource>(
-            mr_cuda, rapidsmpf::PinnedMemoryResource::Disabled, memory_available
+            mr_cuda, rapidsmpf::PinnedMemoryResource::Disabled, memory_limits
         );
         auto options = ctx->options();
         ctx = std::make_shared<rapidsmpf::streaming::Context>(

--- a/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
+++ b/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <atomic>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -27,25 +26,20 @@ class StreamingMemoryReserveOrWait
       public ::testing::WithParamInterface<ReserveOrWaitParam> {
   public:
     void SetUp() override {
-        auto dev_mem_available = [this]() -> std::int64_t {
-            return mem_avail_.load(std::memory_order_acquire);
-        };
-        SetUpWithThreads(
-            GetParam().num_threads, {{rapidsmpf::MemoryType::DEVICE, dev_mem_available}}
-        );
+        // Drive device memory availability by mutating the DEVICE limit. No real
+        // device allocations occur in these tests, so `memory_available(DEVICE)`
+        // equals whatever limit we set.
+        SetUpWithThreads(GetParam().num_threads, {{rapidsmpf::MemoryType::DEVICE, 0}});
     }
 
   protected:
     void set_mem_avail(std::int64_t size) {
-        mem_avail_.store(size, std::memory_order_release);
+        br->set_memory_limit(rapidsmpf::MemoryType::DEVICE, size);
     }
 
     std::int64_t get_mem_avail() {
-        return mem_avail_.load(std::memory_order_acquire);
+        return br->memory_available(rapidsmpf::MemoryType::DEVICE);
     }
-
-  private:
-    std::atomic<std::int64_t> mem_avail_{0};
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/tests/streaming/test_table_chunk.cpp
+++ b/cpp/tests/streaming/test_table_chunk.cpp
@@ -36,8 +36,7 @@ class StreamingTableChunk : public BaseStreamingFixture,
             rapidsmpf::config::get_environment_variables()
         );
 
-        std::unordered_map<MemoryType, rapidsmpf::BufferResource::MemoryAvailable>
-            memory_available{};
+        std::unordered_map<MemoryType, std::int64_t> memory_limits{};
         auto stream_pool = std::make_shared<rmm::cuda_stream_pool>(
             16, rmm::cuda_stream::flags::non_blocking
         );
@@ -45,7 +44,7 @@ class StreamingTableChunk : public BaseStreamingFixture,
         br = std::make_shared<rapidsmpf::BufferResource>(
             mr_cuda,  // device_mr
             rapidsmpf::PinnedMemoryResource::make_if_available(),  // pinned_mr
-            memory_available,  // memory_available
+            memory_limits,  // memory_limits
             std::chrono::milliseconds{1},  // periodic_spill_check
             stream_pool,  // stream_pool
             Statistics::disabled()  // statistics

--- a/cpp/tests/test_buffer.cpp
+++ b/cpp/tests/test_buffer.cpp
@@ -56,7 +56,7 @@ class BufferRebindStreamTest : public ::testing::TestWithParam<MemoryType> {
         br = std::make_unique<BufferResource>(
             cudf::get_current_device_resource_ref(),
             PinnedMemoryResource::make_if_available(),
-            std::unordered_map<MemoryType, BufferResource::MemoryAvailable>{},
+            std::unordered_map<MemoryType, std::int64_t>{},
             std::nullopt,
             stream_pool
         );

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -51,12 +51,11 @@ std::unique_ptr<Buffer> zeros(
 }
 
 TEST(BufferResource, ReservationOverbooking) {
-    // Create a buffer resource that always have 10 KiB of available device memory.
-    auto dev_mem_available = []() -> std::int64_t { return 10_KiB; };
+    // Create a buffer resource that always reports 10 KiB of available device memory.
     BufferResource br{
         cudf::get_current_device_resource_ref(),
         PinnedMemoryResource::Disabled,
-        {{MemoryType::DEVICE, dev_mem_available}}
+        {{MemoryType::DEVICE, 10_KiB}}
     };
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 0);
@@ -118,13 +117,12 @@ TEST(BufferResource, ReservationOverbooking) {
 }
 
 TEST(BufferResource, ReservationReleasing) {
-    // Create a buffer resource that always have 10 KiB of available host and device
+    // Create a buffer resource that always reports 10 KiB of available host and device
     // memory.
-    auto dev_mem_available = []() -> std::int64_t { return 10_KiB; };
     BufferResource br{
         cudf::get_current_device_resource_ref(),
         PinnedMemoryResource::Disabled,
-        {{MemoryType::DEVICE, dev_mem_available}, {MemoryType::HOST, dev_mem_available}}
+        {{MemoryType::DEVICE, 10_KiB}, {MemoryType::HOST, 10_KiB}}
     };
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 0);
@@ -169,17 +167,15 @@ TEST(BufferResource, ReservationReleasing) {
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 10_KiB);
 }
 
-TEST(BufferResource, LimitAvailableMemory) {
+TEST(BufferResource, MemoryLimit) {
     rmm::mr::cuda_memory_resource mr_cuda;
-    RmmResourceAdaptor mr{mr_cuda};
     auto stream = cudf::get_default_stream();
 
-    // Create a buffer resource that limit available device memory to 10 KiB.
-    LimitAvailableMemory dev_mem_available{mr, 10_KiB};
+    // Create a buffer resource that limits available device memory to 10 KiB.
     BufferResource br{
-        mr, PinnedMemoryResource::Disabled, {{MemoryType::DEVICE, dev_mem_available}}
+        mr_cuda, PinnedMemoryResource::Disabled, {{MemoryType::DEVICE, 10_KiB}}
     };
-    EXPECT_EQ(dev_mem_available(), 10_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 10_KiB);
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 0);
 
@@ -198,14 +194,14 @@ TEST(BufferResource, LimitAvailableMemory) {
     EXPECT_EQ(reserve1.size(), 0);
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0_KiB);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 0_KiB);
-    EXPECT_EQ(dev_mem_available(), 0);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 0);
 
     // Insufficent reservation for the allocation.
     EXPECT_THROW(zeros(br, 10_KiB, stream, reserve1), rapidsmpf::reservation_error);
 
     // Freeing a buffer increases the available but the reserved memory is unchanged.
     dev_buf1.reset();
-    EXPECT_EQ(dev_mem_available(), 10_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 10_KiB);
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0_KiB);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 0_KiB);
 
@@ -218,20 +214,20 @@ TEST(BufferResource, LimitAvailableMemory) {
         br.reserve(MemoryType::HOST, 10_KiB, AllowOverbooking::YES);
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0_KiB);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 10_KiB);
-    EXPECT_EQ(dev_mem_available(), 0);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 0);
 
     auto host_buf2 = br.move(std::move(dev_buf2), reserve3);
     EXPECT_EQ(host_buf2->mem_type(), MemoryType::HOST);
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0_KiB);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 0_KiB);
-    EXPECT_EQ(dev_mem_available(), 10_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 10_KiB);
 
     // Moving buffers to the same memory type accepts an empty reservation.
     auto host_buf3 = br.move(std::move(host_buf2), reserve3);
     EXPECT_EQ(host_buf3->mem_type(), MemoryType::HOST);
     EXPECT_EQ(br.memory_reserved(MemoryType::DEVICE), 0_KiB);
     EXPECT_EQ(br.memory_reserved(MemoryType::HOST), 0_KiB);
-    EXPECT_EQ(dev_mem_available(), 10_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 10_KiB);
 
     // The reservation must be of the correct memory type.
     auto [reserve4, overbooking4] =
@@ -254,16 +250,19 @@ TEST_P(PinnedMaxPoolSizeReservationLimitTest, TwoReservations) {
     auto const expect_second_succeeds = [&] { return max_pool_size.value_or(0) == 0; };
 
     rmm::mr::cuda_memory_resource cuda_mr;
-    RmmResourceAdaptor mr{cuda_mr};
 
     auto pinned_mr = PinnedMemoryResource::make_if_available(
         get_current_numa_node(), PinnedPoolProperties{.max_pool_size = max_pool_size}
     );
     ASSERT_NE(pinned_mr, PinnedMemoryResource::Disabled);
 
-    BufferResource br{
-        mr, pinned_mr, {{MemoryType::PINNED_HOST, pinned_mr->get_memory_available_cb()}}
-    };
+    // Wire the PINNED_HOST limit to the pool's max_pool_size (or unlimited if the
+    // pool is unbounded) so reservations respect the same ceiling as allocations.
+    std::unordered_map<MemoryType, std::int64_t> memory_limits;
+    if (max_pool_size.has_value() && *max_pool_size > 0) {
+        memory_limits[MemoryType::PINNED_HOST] = safe_cast<std::int64_t>(*max_pool_size);
+    }
+    BufferResource br{cuda_mr, pinned_mr, std::move(memory_limits)};
 
     // First 1 KiB reservation always succeeds.
     auto [r1, ob1] = br.reserve(MemoryType::PINNED_HOST, 1_KiB, AllowOverbooking::NO);
@@ -288,11 +287,10 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(BufferResource, AllocStatistics) {
     rmm::mr::cuda_memory_resource mr_cuda;
-    RmmResourceAdaptor mr{mr_cuda};
     auto stats = std::make_shared<Statistics>(/* enable = */ true);
     auto pinned_mr = PinnedMemoryResource::make_if_available();
     BufferResource br{
-        mr,
+        mr_cuda,
         pinned_mr,
         {},
         std::nullopt,
@@ -355,18 +353,15 @@ class BufferResourceReserveOrFailTest : public ::testing::Test {
   protected:
     void SetUp() override {
         // Create a buffer resource with limited device memory (10 KiB) and unlimited
-        // host memory.
-        mr = std::make_unique<RmmResourceAdaptor>(rmm::mr::cuda_memory_resource{});
+        // host memory. BufferResource auto-wraps mr_cuda for allocation tracking.
         br = std::make_unique<BufferResource>(
-            *mr,
+            mr_cuda,
             PinnedMemoryResource::Disabled,
-            std::unordered_map<MemoryType, BufferResource::MemoryAvailable>{
-                {MemoryType::DEVICE, LimitAvailableMemory{*mr, 10_KiB}}
-            }
+            std::unordered_map<MemoryType, std::int64_t>{{MemoryType::DEVICE, 10_KiB}}
         );
     }
 
-    std::unique_ptr<RmmResourceAdaptor> mr;
+    rmm::mr::cuda_memory_resource mr_cuda;
     std::unique_ptr<BufferResource> br;
 };
 

--- a/cpp/tests/test_config.cpp
+++ b/cpp/tests/test_config.cpp
@@ -513,57 +513,32 @@ TEST(OptionsTest, PinnedMemoryResourceFromOptionsDisabledByDefault) {
     EXPECT_FALSE(pmr.has_value());
 }
 
-TEST(OptionsTest, MemoryAvailableFromOptionsCreatesMapWithDeviceLimit) {
+TEST(OptionsTest, DeviceLimitFromOptionsReturnsConfiguredLimit) {
     std::unordered_map<std::string, std::string> strings = {
         {"spill_device_limit", "1GiB"}
     };
     Options opts(strings);
 
-    rmm::mr::cuda_memory_resource cuda_mr;
-    RmmResourceAdaptor mr{cuda_mr};
-    auto mem_available = memory_available_from_options(mr, opts);
-
-    // Should contain a DEVICE entry
-    ASSERT_TRUE(mem_available.find(MemoryType::DEVICE) != mem_available.end());
-
-    // Should return the configured limit (1 GiB)
-    auto available = mem_available[MemoryType::DEVICE]();
-    EXPECT_EQ(available, 1_GiB);
+    EXPECT_EQ(device_limit_from_options(opts), static_cast<std::int64_t>(1_GiB));
 }
 
-TEST(OptionsTest, MemoryAvailableFromOptionsUsesPercentageOfTotalMemory) {
+TEST(OptionsTest, DeviceLimitFromOptionsParsesPercentageOfTotalMemory) {
     std::unordered_map<std::string, std::string> strings = {
         {"spill_device_limit", "50%"}
     };
     Options opts(strings);
 
-    rmm::mr::cuda_memory_resource cuda_mr;
-    RmmResourceAdaptor mr{cuda_mr};
-    auto mem_available = memory_available_from_options(mr, opts);
-
-    ASSERT_TRUE(mem_available.find(MemoryType::DEVICE) != mem_available.end());
-
-    // Should return 50% of total device memory
     auto [_, total_mem] = rmm::available_device_memory();
     auto expected = rmm::align_down(total_mem / 2, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    auto available = mem_available[MemoryType::DEVICE]();
-    EXPECT_EQ(available, expected);
+    EXPECT_EQ(device_limit_from_options(opts), static_cast<std::int64_t>(expected));
 }
 
-TEST(OptionsTest, MemoryAvailableFromOptionsUsesDefaultWhenNotSet) {
+TEST(OptionsTest, DeviceLimitFromOptionsUsesDefaultWhenNotSet) {
     Options opts;  // Empty options
 
-    rmm::mr::cuda_memory_resource cuda_mr;
-    RmmResourceAdaptor mr{cuda_mr};
-    auto mem_available = memory_available_from_options(mr, opts);
-
-    ASSERT_TRUE(mem_available.find(MemoryType::DEVICE) != mem_available.end());
-
-    // Should use default of 80%
     auto [_, total_mem] = rmm::available_device_memory();
     auto expected = rmm::align_down(total_mem * 4 / 5, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    auto available = mem_available[MemoryType::DEVICE]();
-    EXPECT_EQ(available, expected);
+    EXPECT_EQ(device_limit_from_options(opts), static_cast<std::int64_t>(expected));
 }
 
 TEST(OptionsTest, PeriodicSpillCheckFromOptionsParsesMilliseconds) {
@@ -652,8 +627,7 @@ TEST(OptionsTest, BufferResourceFromOptionsCreatesInstanceWithExplicitOptions) {
 
     EXPECT_TRUE(br->statistics()->enabled());
     EXPECT_EQ(br->stream_pool().get_pool_size(), 8);
-    auto mem_avail = br->memory_available(MemoryType::DEVICE);
-    EXPECT_EQ(mem_avail(), 1_GiB);
+    EXPECT_EQ(br->memory_available(MemoryType::DEVICE), 1_GiB);
 }
 
 TEST(OptionsTest, BufferResourceFromOptionsUsesDefaultWhenOptionsEmpty) {
@@ -666,8 +640,7 @@ TEST(OptionsTest, BufferResourceFromOptionsUsesDefaultWhenOptionsEmpty) {
     EXPECT_EQ(br->stream_pool().get_pool_size(), 16);
     auto [_, total_mem] = rmm::available_device_memory();
     auto expected = rmm::align_down(total_mem * 4 / 5, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    auto mem_avail = br->memory_available(MemoryType::DEVICE);
-    EXPECT_EQ(mem_avail(), expected);
+    EXPECT_EQ(br->memory_available(MemoryType::DEVICE), expected);
 }
 
 TEST(OptionsTest, BufferResourceFromOptionsEnablesStatisticsWhenRequested) {
@@ -694,8 +667,7 @@ TEST(OptionsTest, BufferResourceFromOptionsAcceptsPercentageForDeviceLimit) {
     // Verify device memory limit is 50% of total
     auto [_, total_mem] = rmm::available_device_memory();
     auto expected = rmm::align_down(total_mem / 2, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    auto mem_avail = br->memory_available(MemoryType::DEVICE);
-    EXPECT_EQ(mem_avail(), expected);
+    EXPECT_EQ(br->memory_available(MemoryType::DEVICE), expected);
 }
 
 TEST(OptionsTest, BufferResourceFromOptionsEnablesPinnedMemoryWhenSupported) {

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -107,23 +107,22 @@ TEST(MetadataMessage, round_trip) {
     EXPECT_EQ(metadata, *result.release_metadata_buffer());
 }
 
-using MemoryAvailableMap =
-    std::unordered_map<rapidsmpf::MemoryType, rapidsmpf::BufferResource::MemoryAvailable>;
+using MemoryLimitsMap = std::unordered_map<rapidsmpf::MemoryType, std::int64_t>;
 
-// Help function to get the `memory_available` argument for a `BufferResource`
+// Help function to get the `memory_limits` argument for a `BufferResource`
 // that prioritizes the specified memory type.
-MemoryAvailableMap get_memory_available_map(rapidsmpf::MemoryType priorities) {
+MemoryLimitsMap get_memory_limits_map(rapidsmpf::MemoryType priorities) {
     using namespace rapidsmpf;
 
-    // We set all memory types to use an available function that is unlimited.
-    MemoryAvailableMap ret = {
-        {MemoryType::DEVICE, std::numeric_limits<std::int64_t>::max},
-        {MemoryType::HOST, std::numeric_limits<std::int64_t>::max}
+    // We set all memory types to be unlimited.
+    MemoryLimitsMap ret = {
+        {MemoryType::DEVICE, std::numeric_limits<std::int64_t>::max()},
+        {MemoryType::HOST, std::numeric_limits<std::int64_t>::max()}
     };
 
     // And then set device memory to zero if it isn't prioritized.
     if (priorities != MemoryType::DEVICE) {
-        ret.at(MemoryType::DEVICE) = []() -> std::int64_t { return 0; };
+        ret.at(MemoryType::DEVICE) = 0;
     }
     // Note, we never set host memory to zero because it is used to allocate
     // stuff like metadata and control messages.
@@ -229,17 +228,17 @@ void test_shuffler(
     }
 }
 
-class MemoryAvailable_NumPartition
+class MemoryLimits_NumPartition
     : public cudf::test::BaseFixtureWithParam<
-          std::tuple<MemoryAvailableMap, rapidsmpf::shuffler::PartID, std::size_t>> {
+          std::tuple<MemoryLimitsMap, rapidsmpf::shuffler::PartID, std::size_t>> {
   public:
     void SetUp() override {
         stream = cudf::get_default_stream();
-        memory_available = std::get<0>(GetParam());
+        memory_limits = std::get<0>(GetParam());
         total_num_partitions = std::get<1>(GetParam());
         total_num_rows = std::get<2>(GetParam());
         br = std::make_unique<rapidsmpf::BufferResource>(
-            mr(), rapidsmpf::PinnedMemoryResource::Disabled, memory_available
+            mr(), rapidsmpf::PinnedMemoryResource::Disabled, memory_limits
         );
 
         shuffler = std::make_unique<rapidsmpf::shuffler::Shuffler>(
@@ -255,7 +254,7 @@ class MemoryAvailable_NumPartition
     }
 
   protected:
-    MemoryAvailableMap memory_available;
+    MemoryLimitsMap memory_limits;
     rapidsmpf::shuffler::PartID total_num_partitions;
     std::size_t total_num_rows;
     std::int64_t seed = 42;
@@ -268,23 +267,23 @@ class MemoryAvailable_NumPartition
 // test different `memory_available` and `total_num_partitions`.
 INSTANTIATE_TEST_SUITE_P(
     Shuffler,
-    MemoryAvailable_NumPartition,
+    MemoryLimits_NumPartition,
     testing::Combine(
         testing::ValuesIn(
-            {get_memory_available_map(rapidsmpf::MemoryType::HOST),
-             get_memory_available_map(rapidsmpf::MemoryType::DEVICE)}
+            {get_memory_limits_map(rapidsmpf::MemoryType::HOST),
+             get_memory_limits_map(rapidsmpf::MemoryType::DEVICE)}
         ),
         testing::Values(1, 2, 5, 10),  // total_num_partitions
         testing::Values(1, 9, 100, 100'000)  // total_num_rows
     ),
-    [](const testing::TestParamInfo<MemoryAvailable_NumPartition::ParamType>& info) {
+    [](const testing::TestParamInfo<MemoryLimits_NumPartition::ParamType>& info) {
         return std::to_string(info.index) + "__nparts_"
                + std::to_string(std::get<1>(info.param)) + "__nrows_"
                + std::to_string(std::get<2>(info.param));
     }
 );
 
-TEST_P(MemoryAvailable_NumPartition, round_trip) {
+TEST_P(MemoryLimits_NumPartition, round_trip) {
     EXPECT_NO_FATAL_FAILURE(test_shuffler(
         GlobalEnvironment->comm_,
         *shuffler,
@@ -317,7 +316,7 @@ class ConcurrentShuffleTest
     void TearDown() override {}
 
     // test run for each thread. The test follows the same logic as
-    // `MemoryAvailable_NumPartition` test, but without any memory limitations
+    // `MemoryLimits_NumPartition` test, but without any memory limitations
     template <typename InsertFn, typename InsertFinishedFn>
     void RunTest(int t_id, InsertFn&& insert_fn, InsertFinishedFn&& insert_finished_fn) {
         rapidsmpf::shuffler::Shuffler shuffler(
@@ -404,24 +403,23 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
     cudf::hash_id const hash_fn = cudf::hash_id::HASH_MURMUR3;
     auto stream = cudf::get_default_stream();
 
-    // Use RapidsMPF's memory resource adaptor.
+    // Use RapidsMPF's memory resource adaptor so the test can observe per-rank
+    // allocation counts via `get_main_record().num_current_allocs()`.
     rapidsmpf::RmmResourceAdaptor mr{cudf::get_current_device_resource_ref()};
 
-    // Create a buffer resource with an available device memory we can control
-    // through the variable `device_memory_available`.
-    std::int64_t device_memory_available{0};
+    // Control spilling by adjusting the DEVICE memory limit at runtime.
+    // `memory_available(DEVICE)` is computed as `limit - current_allocated()`, so a
+    // sufficiently large positive limit reliably keeps available memory > 0 (no spill),
+    // while a sufficiently large negative limit reliably keeps available memory < 0
+    // (force spill), regardless of how many bytes are currently allocated from `mr`.
+    constexpr std::int64_t k_no_spill_limit = (1LL << 40);
+    constexpr std::int64_t k_force_spill_limit = -(1LL << 40);
     rapidsmpf::BufferResource br{
         mr,
         rapidsmpf::PinnedMemoryResource::Disabled,
-        {{rapidsmpf::MemoryType::DEVICE,
-          [&device_memory_available]() -> std::int64_t {
-              return device_memory_available;
-          }}},
+        {{rapidsmpf::MemoryType::DEVICE, k_no_spill_limit}},
         std::nullopt  // disable periodic spill check
     };
-    EXPECT_EQ(
-        br.memory_available(rapidsmpf::MemoryType::DEVICE)(), device_memory_available
-    );
 
     // Create a communicator of size 1, such that each shuffler will run locally.
     auto comm = GlobalEnvironment->split_comm();
@@ -454,7 +452,7 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
     EXPECT_EQ(mr.get_main_record().num_current_allocs(), 2);
 
     // Let's force spilling.
-    device_memory_available = -1000;
+    br.set_memory_limit(rapidsmpf::MemoryType::DEVICE, k_force_spill_limit);
 
     {
         // Now extract triggers spilling of the partition not being extracted.
@@ -481,7 +479,7 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
     EXPECT_EQ(mr.get_main_record().num_current_allocs(), 2);
 
     // Disable spilling and insert the first partition.
-    device_memory_available = 1000;
+    br.set_memory_limit(rapidsmpf::MemoryType::DEVICE, k_no_spill_limit);
     {
         std::unordered_map<rapidsmpf::shuffler::PartID, rapidsmpf::PackedData> chunk;
         chunk.emplace(0, std::move(out0.at(0)));
@@ -492,7 +490,7 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
     // Enable spilling and insert the second partition, which should trigger spilling
     // of both the first partition already in the shuffler and the second partition
     // that are being inserted.
-    device_memory_available = -1000;
+    br.set_memory_limit(rapidsmpf::MemoryType::DEVICE, k_force_spill_limit);
     {
         std::unordered_map<rapidsmpf::shuffler::PartID, rapidsmpf::PackedData> chunk;
         chunk.emplace(1, std::move(out1.at(0)));

--- a/cpp/tests/test_spill_manager.cpp
+++ b/cpp/tests/test_spill_manager.cpp
@@ -24,25 +24,27 @@
 using namespace rapidsmpf;
 
 TEST(SpillManager, SpillFunction) {
-    // Create a buffer resource that report `mem_available` as the available memory.
+    // Drive available device memory by adjusting the DEVICE limit at runtime.
+    // No real allocations occur in this test, so memory_available equals the
+    // currently configured limit.
     std::int64_t mem_available = 10_KiB;
     BufferResource br{
         cudf::get_current_device_resource_ref(),
         rapidsmpf::PinnedMemoryResource::Disabled,
-        {{MemoryType::DEVICE,
-          [&mem_available]() -> std::int64_t { return mem_available; }}}
+        {{MemoryType::DEVICE, mem_available}}
     };
-    EXPECT_EQ(br.memory_available(MemoryType::DEVICE)(), 10_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 10_KiB);
 
     // Spill function that increases the available memory perfectly.
     SpillManager::SpillFunction func1 =
-        [&mem_available](std::size_t amount) -> std::size_t {
-        mem_available += amount;
+        [&br, &mem_available](std::size_t amount) -> std::size_t {
+        mem_available += safe_cast<std::int64_t>(amount);
+        br.set_memory_limit(MemoryType::DEVICE, mem_available);
         return amount;
     };
     br.spill_manager().add_spill_function(func1, /* priority = */ 1);
     EXPECT_EQ(br.spill_manager().spill(10_KiB), 10_KiB);
-    EXPECT_EQ(br.memory_available(MemoryType::DEVICE)(), 20_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 20_KiB);
 
     // Spill function that never spill any memory but has a higher priority.
     bool func2_called = false;
@@ -54,23 +56,23 @@ TEST(SpillManager, SpillFunction) {
     EXPECT_EQ(br.spill_manager().spill(10_KiB), 10_KiB);
     EXPECT_TRUE(func2_called);
     func2_called = false;
-    EXPECT_EQ(br.memory_available(MemoryType::DEVICE)(), 30_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 30_KiB);
 
     // Removing `func2` means it shouldn't run.
     br.spill_manager().remove_spill_function(fid2);
     EXPECT_EQ(br.spill_manager().spill(10_KiB), 10_KiB);
     EXPECT_FALSE(func2_called);
-    EXPECT_EQ(br.memory_available(MemoryType::DEVICE)(), 40_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 40_KiB);
 
     // If the headroom is already there, no spilling should be happening.
     EXPECT_EQ(br.spill_manager().spill_to_make_headroom(10_KiB), 0);
-    EXPECT_EQ(br.memory_available(MemoryType::DEVICE)(), 40_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 40_KiB);
 
     // If the headroom isn't there, we should spill to get the headroom.
     EXPECT_EQ(br.spill_manager().spill_to_make_headroom(100_KiB), 60_KiB);
-    EXPECT_EQ(br.memory_available(MemoryType::DEVICE)(), 100_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 100_KiB);
 
     // A negative headroom is allowed.
     EXPECT_EQ(br.spill_manager().spill_to_make_headroom(-100_KiB), 0);
-    EXPECT_EQ(br.memory_available(MemoryType::DEVICE)(), 100_KiB);
+    EXPECT_EQ(br.memory_available(MemoryType::DEVICE), 100_KiB);
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,8 +141,6 @@ def setup(app):
 
 
 nitpick_ignore_regex = [
-    # Cython turns __call__ into a slot_wrapper that autodoc doesn't understand.
-    ("py:obj", "rapidsmpf.memory.buffer_resource.LimitAvailableMemory.__call__"),
     # We're subclassing this from RMM, and sphinx can't find these methods.
     ("py:obj", "rapidsmpf.rmm_resource_adaptor.RmmResourceAdaptor.allocate"),
     ("py:obj", "rapidsmpf.rmm_resource_adaptor.RmmResourceAdaptor.deallocate"),

--- a/python/rapidsmpf/rapidsmpf/benchmarks/streaming_benchmark.py
+++ b/python/rapidsmpf/rapidsmpf/benchmarks/streaming_benchmark.py
@@ -21,7 +21,7 @@ import rapidsmpf.bootstrap
 import rapidsmpf.communicator.mpi
 from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.memory.buffer import MemoryType
-from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
+from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.memory.packed_data import PackedData
 from rapidsmpf.progress_thread import ProgressThread
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
@@ -256,12 +256,10 @@ def setup_and_run(args: argparse.Namespace) -> None:
 
     # Create a buffer resource that limits device memory if `--spill-device`
     # is not None.
-    memory_available = (
-        None
-        if args.spill_device is None
-        else {MemoryType.DEVICE: LimitAvailableMemory(mr, limit=args.spill_device)}
+    memory_limits = (
+        None if args.spill_device is None else {MemoryType.DEVICE: args.spill_device}
     )
-    br = BufferResource(mr, memory_available=memory_available, statistics=stats)
+    br = BufferResource(mr, memory_limits=memory_limits, statistics=stats)
 
     args.out_nparts = args.out_nparts if args.out_nparts is not None else comm.nranks
     args.part_size = args.part_size if args.part_size is not None else args.local_size

--- a/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/bulk_mpi_shuffle.py
@@ -25,7 +25,7 @@ from rapidsmpf.integrations.cudf.partition import (
     unspill_partitions,
 )
 from rapidsmpf.memory.buffer import MemoryType
-from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
+from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.progress_thread import ProgressThread
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.shuffler import Shuffler
@@ -313,12 +313,10 @@ def setup_and_run(args: argparse.Namespace) -> None:
 
     # Create a buffer resource that limits device memory if `--spill-device`
     # is not None.
-    memory_available = (
-        None
-        if args.spill_device is None
-        else {MemoryType.DEVICE: LimitAvailableMemory(mr, limit=args.spill_device)}
+    memory_limits = (
+        None if args.spill_device is None else {MemoryType.DEVICE: args.spill_device}
     )
-    br = BufferResource(mr, memory_available=memory_available)
+    br = BufferResource(mr, memory_limits=memory_limits)
 
     stats = Statistics(enable=args.statistics)
 

--- a/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
+++ b/python/rapidsmpf/rapidsmpf/examples/ray/bulk_ray_shuffle.py
@@ -23,7 +23,7 @@ from rapidsmpf.integrations.cudf.partition import (
 )
 from rapidsmpf.integrations.ray import RapidsMPFActor, setup_ray_ucxx_cluster
 from rapidsmpf.memory.buffer import MemoryType
-from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
+from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.shuffler import Shuffler
 from rapidsmpf.statistics import Statistics
@@ -88,16 +88,12 @@ class BulkRayShufflerActor(RapidsMPFActor):
         )
         rmm.mr.set_current_device_resource(self.mr)
         # Create a buffer resource that limits device memory if `--spill-device`
-        memory_available = (
+        memory_limits = (
             None
             if self.spill_device is None
-            else {
-                MemoryType.DEVICE: LimitAvailableMemory(
-                    self.mr, limit=self.spill_device
-                )
-            }
+            else {MemoryType.DEVICE: self.spill_device}
         )
-        br = BufferResource(self.mr, memory_available=memory_available)
+        br = BufferResource(self.mr, memory_limits=memory_limits)
         self.br = br
         super().__init__(nranks, Statistics(enable=enable_statistics))
 

--- a/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
+++ b/python/rapidsmpf/rapidsmpf/examples/streaming/basic_example.py
@@ -16,7 +16,6 @@ from rapidsmpf.communicator.single import (
 from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.progress_thread import ProgressThread
-from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.streaming.core.actor import (
     define_actor,
     run_actor_network,
@@ -42,7 +41,7 @@ def main() -> int:
     comm = single_process_comm(options, ProgressThread())
     ctx = Context(
         logger=comm.logger,
-        br=BufferResource(RmmResourceAdaptor(rmm.mr.get_current_device_resource())),
+        br=BufferResource(rmm.mr.get_current_device_resource()),
         options=options,
     )
 

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
@@ -5,7 +5,6 @@ from libc.stddef cimport size_t
 from libc.stdint cimport int64_t
 from libcpp cimport bool as bool_t
 from libcpp.memory cimport shared_ptr
-from libcpp.unordered_map cimport unordered_map
 from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
 from rmm.pylibrmm.cuda_stream_pool cimport CudaStreamPool
 from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource
@@ -16,8 +15,6 @@ from rapidsmpf.memory.buffer cimport MemoryType
 from rapidsmpf.memory.memory_reservation cimport cpp_MemoryReservation
 from rapidsmpf.memory.pinned_memory_resource cimport PinnedMemoryResource
 from rapidsmpf.memory.spill_manager cimport SpillManager, cpp_SpillManager
-from rapidsmpf.rmm_resource_adaptor cimport (RmmResourceAdaptor,
-                                             cpp_RmmResourceAdaptor)
 from rapidsmpf.statistics cimport Statistics, cpp_Statistics
 from rapidsmpf.utils.time cimport cpp_Duration
 
@@ -27,14 +24,11 @@ cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
         NO
         YES
 
-cdef extern from "<functional>" nogil:
-    cdef cppclass cpp_MemoryAvailable "std::function<std::int64_t()>":
-        pass
-
 cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
     cdef cppclass cpp_BufferResource "rapidsmpf::BufferResource":
         size_t memory_reserved(MemoryType mem_type) except +ex_handler
-        cpp_MemoryAvailable memory_available(MemoryType mem_type) except +ex_handler
+        int64_t memory_available(MemoryType mem_type) except +ex_handler
+        void set_memory_limit(MemoryType mem_type, int64_t limit) except +ex_handler
         cpp_SpillManager &spill_manager() except +ex_handler
         const cuda_stream_pool &stream_pool() except +ex_handler
         size_t release(cpp_MemoryReservation&, size_t) except +ex_handler
@@ -50,18 +44,3 @@ cdef class BufferResource:
     cdef CudaStreamPool _stream_pool
     cdef Statistics _statistics
     cdef const cuda_stream_pool* stream_pool(self)
-
-cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
-    cdef cppclass cpp_LimitAvailableMemory "rapidsmpf::LimitAvailableMemory":
-        cpp_LimitAvailableMemory(
-            cpp_RmmResourceAdaptor mr, int64_t limit
-        ) except +ex_handler
-        int64_t operator()() except +ex_handler
-
-
-cdef class LimitAvailableMemory:
-    cdef shared_ptr[cpp_LimitAvailableMemory] _handle
-    cdef RmmResourceAdaptor _mr
-
-cdef class AvailableMemoryMap:
-    cdef unordered_map[MemoryType, cpp_MemoryAvailable] _handle

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyi
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyi
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Self
 
 from rmm.pylibrmm.cuda_stream_pool import CudaStreamPool
@@ -12,7 +12,6 @@ from rapidsmpf.memory.buffer import MemoryType
 from rapidsmpf.memory.memory_reservation import MemoryReservation
 from rapidsmpf.memory.pinned_memory_resource import PinnedMemoryResource
 from rapidsmpf.memory.spill_manager import SpillManager
-from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.statistics import Statistics
 
 class BufferResource:
@@ -21,16 +20,14 @@ class BufferResource:
         device_mr: DeviceMemoryResource,
         *,
         pinned_mr: PinnedMemoryResource | None = None,
-        memory_available: Mapping[MemoryType, Callable[[], int]]
-        | AvailableMemoryMap
-        | None = None,
+        memory_limits: Mapping[MemoryType, int] | None = None,
         periodic_spill_check: float | None = 1e-3,
         stream_pool: CudaStreamPool | None = None,
         statistics: Statistics | None = None,
     ) -> None: ...
     @classmethod
     def from_options(
-        cls: type[Self], mr: RmmResourceAdaptor, options: Options
+        cls: type[Self], mr: DeviceMemoryResource, options: Options
     ) -> Self: ...
     @property
     def device_mr(self) -> DeviceMemoryResource: ...
@@ -38,6 +35,7 @@ class BufferResource:
     def pinned_mr(self) -> PinnedMemoryResource | None: ...
     def memory_available(self, mem_type: MemoryType) -> int: ...
     def memory_reserved(self, mem_type: MemoryType) -> int: ...
+    def set_memory_limit(self, mem_type: MemoryType, limit: int) -> None: ...
     @property
     def spill_manager(self) -> SpillManager: ...
     @property
@@ -54,19 +52,6 @@ class BufferResource:
     def release(self, reservation: MemoryReservation, size: int) -> int: ...
     def stream_pool_size(self) -> int: ...
 
-class LimitAvailableMemory:
-    def __init__(
-        self,
-        mr: RmmResourceAdaptor,
-        limit: int,
-    ) -> None: ...
-    def __call__(self) -> int: ...
-
-class AvailableMemoryMap:
-    @classmethod
-    def from_options(
-        cls: type[Self], mr: RmmResourceAdaptor, options: Options
-    ) -> Self: ...
-
+def device_limit_from_options(options: Options) -> int: ...
 def periodic_spill_check_from_options(options: Options) -> float | None: ...
 def stream_pool_from_options(options: Options) -> CudaStreamPool: ...

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -28,19 +28,6 @@ from rapidsmpf.statistics cimport Statistics
 
 cdef extern from *:
     """
-    std::function<std::int64_t()> to_MemoryAvailable(
-        std::shared_ptr<rapidsmpf::LimitAvailableMemory> functor
-    ) {
-        return *functor;
-    }
-
-    std::int64_t _call_memory_available(
-        rapidsmpf::BufferResource* resource,
-        rapidsmpf::MemoryType mem_type
-    ) {
-        return resource->memory_available(mem_type)();
-    }
-
     // Helper function to create a non-owning shared_ptr from a raw pointer
     // The Python object retains ownership via its unique_ptr
     std::shared_ptr<rmm::cuda_stream_pool> make_non_owning_stream_pool_ref(
@@ -51,13 +38,6 @@ cdef extern from *:
         );
     }
     """
-    cpp_MemoryAvailable to_MemoryAvailable(
-        shared_ptr[cpp_LimitAvailableMemory]
-    ) except +ex_handler
-    int64_t _call_memory_available(
-        cpp_BufferResource* resource,
-        MemoryType mem_type
-    ) except +ex_handler nogil
     shared_ptr[cuda_stream_pool] make_non_owning_stream_pool_ref(
         cuda_stream_pool* ptr
     ) except +ex_handler
@@ -134,23 +114,21 @@ cdef class BufferResource:
     Parameters
     ----------
     device_mr
-        Reference to the RMM device memory resource used for device allocations.
+        The RMM device memory resource used for device allocations. The
+        BufferResource transparently wraps this resource in an internal RMM
+        adaptor for allocation tracking — callers don't need to wrap it
+        themselves.
     pinned_mr
         The pinned host memory resource used for :attr:`~.MemoryType.PINNED_HOST`
         allocations. If None, pinned host allocations are disabled. In that case,
-        any attempt to allocate pinned memory will fail regardless of what
-        `memory_available` reports.
-    memory_available
-        Optional memory availability functions. Memory types without availability
-        functions are unlimited. A function must return the current available
-        memory of a specific type. It must be thread-safe if used by multiple
-        `BufferResource` instances concurrently.
-        Warning: calling any `BufferResource` instance methods within the function
-        might result in a deadlock. This is because the buffer resource is locked
-        when the function is called.
+        any attempt to allocate pinned memory will fail regardless of any
+        ``memory_limits`` entry for ``PINNED_HOST``.
+    memory_limits
+        Optional mapping from :class:`~.MemoryType` to an integer byte limit.
+        Memory types not present in the mapping are treated as unlimited.
     periodic_spill_check
         Enable periodic spill checks. A dedicated thread continuously checks and
-        perform spilling based on the memory availability functions. The value of
+        performs spilling based on memory availability. The value of
         ``periodic_spill_check`` is used as the pause between checks (in seconds).
         If None, no periodic spill check is performed.
     stream_pool
@@ -166,24 +144,15 @@ cdef class BufferResource:
         DeviceMemoryResource device_mr not None,
         *,
         PinnedMemoryResource pinned_mr = None,
-        memory_available = None,
+        memory_limits = None,
         periodic_spill_check = 1e-3,
         stream_pool = None,
         statistics = None,
     ):
-        cdef unordered_map[MemoryType, cpp_MemoryAvailable] _mem_available
-        if isinstance(memory_available, AvailableMemoryMap):
-            _mem_available = move((<AvailableMemoryMap>memory_available)._handle)
-        elif memory_available is not None:
-            for mem_type, func in memory_available.items():
-                if not isinstance(func, LimitAvailableMemory):
-                    raise NotImplementedError(
-                        "Currently, BufferResource only accept `LimitAvailableMemory` "
-                        "as memory available functions."
-                    )
-                _mem_available[<MemoryType?>mem_type] = to_MemoryAvailable(
-                    (<LimitAvailableMemory?>func)._handle
-                )
+        cdef unordered_map[MemoryType, int64_t] _mem_limits
+        if memory_limits is not None:
+            for mem_type, limit in memory_limits.items():
+                _mem_limits[<MemoryType?>mem_type] = <int64_t>limit
         cdef optional[cpp_Duration] period
         if periodic_spill_check is not None:
             period = cpp_Duration(periodic_spill_check)
@@ -231,7 +200,7 @@ cdef class BufferResource:
             self._handle = make_shared[cpp_BufferResource](
                 make_any_device_resource(device_mr.get_mr()),
                 cpp_pinned_mr,
-                move(_mem_available),
+                move(_mem_limits),
                 period,
                 cpp_stream_pool,
                 stats_handle,
@@ -239,17 +208,18 @@ cdef class BufferResource:
         self.spill_manager = SpillManager._create(self)
 
     @classmethod
-    def from_options(cls, RmmResourceAdaptor mr not None, Options options not None):
+    def from_options(cls, DeviceMemoryResource mr not None, Options options not None):
         """
         Construct a BufferResource from configuration options.
 
         This factory method creates a BufferResource using configuration options to
-        initialize all components.
+        initialize all components. The supplied device memory resource is wrapped
+        internally for allocation tracking — callers don't need to pre-wrap it.
 
         Parameters
         ----------
         mr
-            RMM resource adaptor. The adaptor must outlive the returned BufferResource.
+            A device-accessible RMM memory resource.
         options
             Configuration options.
 
@@ -261,7 +231,7 @@ cdef class BufferResource:
         return cls(
             device_mr=mr,
             pinned_mr=pinned_mr,
-            memory_available=AvailableMemoryMap.from_options(mr, options),
+            memory_limits={MemoryType.DEVICE: device_limit_from_options(options)},
             periodic_spill_check=periodic_spill_check_from_options(options),
             stream_pool=stream_pool_from_options(options),
             statistics=Statistics.from_options(options),
@@ -337,11 +307,32 @@ cdef class BufferResource:
         Get the current available memory of the specified memory type.
         """
         cdef int64_t ret
-        cdef cpp_BufferResource* resource_ptr = self.ptr()
-        # Use inline C++ to handle the function object call
         with nogil:
-            ret = _call_memory_available(resource_ptr, mem_type)
+            ret = deref(self._handle).memory_available(mem_type)
         return ret
+
+    def set_memory_limit(self, MemoryType mem_type, int64_t limit):
+        """
+        Set the byte limit for the specified memory type.
+
+        The store is atomic, but readers (e.g. ``memory_available()`` and
+        ``reserve()``) observe the limit and the allocation count independently.
+        A concurrent ``set_memory_limit()`` call can change the limit between a
+        caller's read of ``memory_available()`` and a subsequent allocation
+        decision; callers that need a coherent view must serialize updates with
+        higher-level synchronization.
+
+        Parameters
+        ----------
+        mem_type
+            The memory type whose limit is being updated.
+        limit
+            The new byte limit. Negative values are allowed; they make
+            ``memory_available(mem_type)`` always negative and so trigger
+            continuous spilling.
+        """
+        with nogil:
+            deref(self._handle).set_memory_limit(mem_type, limit)
 
     def reserve(self, MemoryType mem_type, size_t size, *, bool_t allow_overbooking):
         """
@@ -501,118 +492,39 @@ cdef class BufferResource:
         return self._statistics
 
 
-cdef class LimitAvailableMemory:
-    """
-    A callback class for querying the remaining available memory within a defined
-    limit from an RMM resource adaptor.
-
-    This class is primarily designed to simulate constrained memory environments
-    or prevent memory allocation beyond a specific threshold. It provides
-    information about the available memory by subtracting the memory currently
-    used (as reported by the RMM resource adaptor) from a user-defined limit.
-
-    It is typically used in the context of memory management operations such as
-    with `BufferResource`.
-
-    Parameters
-    ----------
-    mr
-        A statistics resource adaptor that tracks memory usage and provides
-        statistics about the memory consumption. The `LimitAvailableMemory`
-        instance keeps a reference to ``mr`` to keep it alive.
-    limit
-        The maximum memory limit (in bytes). Used to calculate the remaining
-        available memory.
-
-    Notes
-    -----
-    The ``mr`` resource must not be destroyed while this object is
-    still in use.
-
-    Examples
-    --------
-    >>> mr = RmmResourceAdaptor(...)
-    >>> memory_limiter = LimitAvailableMemory(mr, limit=1_000_000)
-    """
-    def __init__(self, RmmResourceAdaptor mr not None, int64_t limit):
-        self._mr = mr  # Keep a copy of mr alive.
-        cdef cpp_RmmResourceAdaptor* handle = mr.get_handle()
-        with nogil:
-            self._handle = make_shared[cpp_LimitAvailableMemory](deref(handle), limit)
-
-    def __call__(self):
-        """
-        Returns the remaining available memory within the defined limit.
-
-        This method queries the ``rmm_statistics_resource`` to determine the memory
-        currently in use and calculates the remaining memory as:
-        ``limit - used_memory``.
-
-        Returns
-        -------
-        int
-            The remaining memory in bytes.
-        """
-        cdef int64_t ret
-        with nogil:
-            ret = deref(self._handle)()
-        return ret
-
-    def __dealloc__(self):
-        with nogil:
-            self._handle.reset()
-
-
 cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
-    cdef unordered_map[MemoryType, cpp_MemoryAvailable] \
-        cpp_memory_available_from_options \
-        "rapidsmpf::memory_available_from_options"(
-            cpp_RmmResourceAdaptor mr, cpp_Options options
+    cdef int64_t cpp_device_limit_from_options \
+        "rapidsmpf::device_limit_from_options"(
+            cpp_Options options
         ) except +ex_handler
 
-
-cdef class AvailableMemoryMap:
-    """
-    Map of functions reporting available memory for different memory types.
-
-    This class acts as an opaque handle to C++ memory-availability functions
-    that cannot be directly represented or exposed in Python. It enables
-    RapidsMPF to configure and use such functions from Python while keeping
-    the implementation in C++.
-
-    Instances of this class should be constructed from configuration options
-    using the :meth:`from_options` factory method.
-    """
-
-    @classmethod
-    def from_options(cls, RmmResourceAdaptor mr not None, Options options not None):
-        """
-        Construct an AvailableMemoryMap from configuration options.
-
-        Parameters
-        ----------
-        mr
-            Pointer to a memory resource adaptor.
-        options
-            Configuration options.
-
-        Returns
-        -------
-        The constructed map of memory-available functions.
-        """
-        cdef AvailableMemoryMap ret = cls.__new__(cls)
-        cdef cpp_RmmResourceAdaptor* mr_handle = mr.get_handle()
-        with nogil:
-            ret._handle = cpp_memory_available_from_options(deref(mr_handle),
-                                                            options._handle)
-        return ret
-
-
-cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
     cdef optional[cpp_Duration] cpp_periodic_spill_check_from_options \
         "rapidsmpf::periodic_spill_check_from_options"(
             cpp_Options options
         ) except +ex_handler
+
+
+def device_limit_from_options(Options options not None):
+    """
+    Get the ``spill_device_limit`` parameter from configuration options.
+
+    Reads the ``spill_device_limit`` option, falling back to 80% of total device
+    memory when unset.
+
+    Parameters
+    ----------
+    options
+        Configuration options.
+
+    Returns
+    -------
+    int
+        The device memory limit in bytes.
+    """
+    cdef int64_t ret
+    with nogil:
+        ret = cpp_device_limit_from_options(options._handle)
+    return ret
 
 
 def periodic_spill_check_from_options(Options options not None):

--- a/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pyx
@@ -44,8 +44,8 @@ cdef class PinnedMemoryResource:
     through CUDA streams. Pinned memory enables higher bandwidth and lower
     latency for device transfers compared to regular pageable host memory.
 
-    The pool has no maximum size. To limit its growth, use
-    ``LimitAvailableMemory`` or a similar mechanism.
+    The pool has no maximum size. To limit its growth, pass an explicit
+    ``PINNED_HOST`` entry in :class:`BufferResource`'s ``memory_limits``.
 
     Parameters
     ----------

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_memory_reserve_or_wait.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_memory_reserve_or_wait.py
@@ -15,9 +15,8 @@ from rapidsmpf.communicator.single import (
 )
 from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.memory.buffer import MemoryType
-from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
+from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.progress_thread import ProgressThread
-from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.streaming.core.actor import define_actor, run_actor_network
 from rapidsmpf.streaming.core.context import Context
 from rapidsmpf.streaming.core.memory_reserve_or_wait import (
@@ -34,10 +33,9 @@ def make_context(
         env.update(overwrite_options)
     options = Options(env)
     comm = single_process_comm(options, ProgressThread())
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
     br = BufferResource(
-        mr,
-        memory_available={MemoryType.DEVICE: LimitAvailableMemory(mr, limit=dev_limit)},
+        rmm.mr.CudaMemoryResource(),
+        memory_limits={MemoryType.DEVICE: dev_limit},
     )
     return Context(comm.logger, br, options)
 

--- a/python/rapidsmpf/rapidsmpf/tests/test_buffer_resource.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_buffer_resource.py
@@ -8,9 +8,8 @@ import rmm.mr
 
 from rapidsmpf.error import ReservationError
 from rapidsmpf.memory.buffer import MemoryType
-from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
+from rapidsmpf.memory.buffer_resource import BufferResource
 from rapidsmpf.memory.memory_reservation import opaque_memory_usage
-from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.statistics import Statistics
 
 
@@ -18,66 +17,20 @@ def KiB(x: int) -> int:
     return x * 2**10
 
 
-def test_limit_available_memory() -> None:
-    with pytest.raises(
-        TypeError,
-        match="RmmResourceAdaptor",
-    ):
-        LimitAvailableMemory(rmm.mr.CudaMemoryResource(), limit=KiB(100))
-
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    mem_available = LimitAvailableMemory(mr, limit=KiB(100))
-    assert mem_available() == KiB(100)
-
-    # Allocate a buffer reduces available memory.
-    buf1 = rmm.DeviceBuffer(size=KiB(50), mr=mr)
-    assert mem_available() == KiB(50)
-
-    # But not when allocating using another memory resource.
-    mr2 = rmm.mr.CudaMemoryResource()
-    buf2 = rmm.DeviceBuffer(size=KiB(50), mr=mr2)
-    assert mem_available() == KiB(50)
-    del buf2
-
-    # Available memory can be negative.
-    buf3 = rmm.DeviceBuffer(size=KiB(100), mr=mr)
-    assert mem_available() == -KiB(50)
-
-    # Freeing buffers increases available memory.
-    del buf1
-    assert mem_available() == 0
-    del buf3
-    assert mem_available() == KiB(100)
-
-
 def test_buffer_resource() -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-
-    with pytest.raises(
-        NotImplementedError,
-        match="only accept `LimitAvailableMemory` as memory available functions",
-    ):
-        BufferResource(mr, memory_available={MemoryType.DEVICE: lambda: 42})
-
-    mem_available = LimitAvailableMemory(mr, limit=KiB(100))
-    br = BufferResource(mr, memory_available={MemoryType.DEVICE: mem_available})
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={MemoryType.DEVICE: KiB(100)})
     assert br.memory_reserved(MemoryType.DEVICE) == 0
     assert br.memory_reserved(MemoryType.HOST) == 0
 
-    # Check BufferResource.memory_available
-    assert br.memory_available(MemoryType.DEVICE) == mem_available() == KiB(100)
-    buf1 = rmm.DeviceBuffer(size=KiB(50), mr=mr)
-    assert br.memory_available(MemoryType.DEVICE) == mem_available() == KiB(50)
-    del buf1
-    assert br.memory_available(MemoryType.DEVICE) == mem_available() == KiB(100)
+    # Memory availability starts at the configured limit.
+    assert br.memory_available(MemoryType.DEVICE) == KiB(100)
 
 
 @pytest.mark.parametrize("mem_type", [MemoryType.DEVICE, MemoryType.HOST])
 def test_memory_reservation(mem_type: MemoryType) -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(
-        mr, memory_available={mem_type: LimitAvailableMemory(mr, limit=KiB(100))}
-    )
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={mem_type: KiB(100)})
     res1, ob = br.reserve(mem_type, KiB(100), allow_overbooking=False)
     assert res1.br is br
     assert res1.mem_type == mem_type
@@ -123,7 +76,7 @@ def test_memory_reservation(mem_type: MemoryType) -> None:
 
 def test_stream_pool() -> None:
     """Test that stream_pool parameter can be configured."""
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
+    mr = rmm.mr.CudaMemoryResource()
 
     # Test with default stream pool size (16)
     br_default = BufferResource(mr)
@@ -137,7 +90,7 @@ def test_stream_pool() -> None:
 
 def test_statistics() -> None:
     """Test that statistics parameter can be configured."""
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
+    mr = rmm.mr.CudaMemoryResource()
 
     # Disabled by default
     br_default = BufferResource(mr)
@@ -151,10 +104,8 @@ def test_statistics() -> None:
 
 @pytest.mark.parametrize("mem_type", [MemoryType.DEVICE, MemoryType.HOST])
 def test_opaque_memory_usage_basic(mem_type: MemoryType) -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(
-        mr, memory_available={mem_type: LimitAvailableMemory(mr, limit=KiB(100))}
-    )
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={mem_type: KiB(100)})
 
     res, _ = br.reserve(mem_type, KiB(50), allow_overbooking=False)
     assert res.size == KiB(50)
@@ -168,10 +119,8 @@ def test_opaque_memory_usage_basic(mem_type: MemoryType) -> None:
 
 @pytest.mark.parametrize("mem_type", [MemoryType.DEVICE, MemoryType.HOST])
 def test_opaque_memory_usage_clears_on_exception(mem_type: MemoryType) -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(
-        mr, memory_available={mem_type: LimitAvailableMemory(mr, limit=KiB(100))}
-    )
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={mem_type: KiB(100)})
 
     res, _ = br.reserve(mem_type, KiB(60), allow_overbooking=False)
     assert res.size == KiB(60)
@@ -184,10 +133,8 @@ def test_opaque_memory_usage_clears_on_exception(mem_type: MemoryType) -> None:
 
 @pytest.mark.parametrize("mem_type", [MemoryType.DEVICE, MemoryType.HOST])
 def test_opaque_memory_usage_multiple_reservations(mem_type: MemoryType) -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(
-        mr, memory_available={mem_type: LimitAvailableMemory(mr, limit=KiB(200))}
-    )
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={mem_type: KiB(200)})
 
     res1, _ = br.reserve(mem_type, KiB(50), allow_overbooking=False)
     assert res1.size == KiB(50)
@@ -208,10 +155,8 @@ def test_opaque_memory_usage_multiple_reservations(mem_type: MemoryType) -> None
 
 @pytest.mark.parametrize("mem_type", [MemoryType.DEVICE, MemoryType.HOST])
 def test_opaque_memory_usage_nested(mem_type: MemoryType) -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(
-        mr, memory_available={mem_type: LimitAvailableMemory(mr, limit=KiB(200))}
-    )
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={mem_type: KiB(200)})
 
     res1, _ = br.reserve(mem_type, KiB(40), allow_overbooking=False)
     res2, _ = br.reserve(mem_type, KiB(60), allow_overbooking=False)
@@ -232,10 +177,8 @@ def test_opaque_memory_usage_nested(mem_type: MemoryType) -> None:
 
 @pytest.mark.parametrize("mem_type", [MemoryType.DEVICE, MemoryType.HOST])
 def test_opaque_memory_usage_partial_consumption(mem_type: MemoryType) -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(
-        mr, memory_available={mem_type: LimitAvailableMemory(mr, limit=KiB(100))}
-    )
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={mem_type: KiB(100)})
 
     res, _ = br.reserve(mem_type, KiB(80), allow_overbooking=False)
     assert res.size == KiB(80)
@@ -251,11 +194,8 @@ def test_opaque_memory_usage_partial_consumption(mem_type: MemoryType) -> None:
 
 
 def test_reserve_or_fail() -> None:
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource(
-        mr,
-        memory_available={MemoryType.DEVICE: LimitAvailableMemory(mr, limit=KiB(100))},
-    )
+    mr = rmm.mr.CudaMemoryResource()
+    br = BufferResource(mr, memory_limits={MemoryType.DEVICE: KiB(100)})
 
     # Succeeds on the first available memory type.
     res = br.reserve_or_fail(KiB(50), [MemoryType.DEVICE, MemoryType.HOST])

--- a/python/rapidsmpf/rapidsmpf/tests/test_config.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_config.py
@@ -15,8 +15,8 @@ from rapidsmpf.communicator import single as single_comm
 from rapidsmpf.config import Optional, OptionalBytes, Options
 from rapidsmpf.memory.buffer import MemoryType
 from rapidsmpf.memory.buffer_resource import (
-    AvailableMemoryMap,
     BufferResource,
+    device_limit_from_options,
     periodic_spill_check_from_options,
     stream_pool_from_options,
 )
@@ -424,18 +424,16 @@ def test_pinned_memory_resource_from_options(
         assert pmr is None
 
 
-def test_available_memory_map_from_options_creates_map() -> None:
+def test_device_limit_from_options_returns_configured_limit() -> None:
     opts = Options({"spill_device_limit": "1GiB"})
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    mem_map = AvailableMemoryMap.from_options(mr, opts)
-    assert mem_map is not None
+    assert device_limit_from_options(opts) == 1024 * 1024 * 1024
 
 
-def test_available_memory_map_from_options_uses_default() -> None:
+def test_device_limit_from_options_uses_default() -> None:
     opts = Options()
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    mem_map = AvailableMemoryMap.from_options(mr, opts)
-    assert mem_map is not None
+    # The default is 80% of total device memory, which we can't predict exactly;
+    # just check it's a sensible positive value.
+    assert device_limit_from_options(opts) > 0
 
 
 @pytest.mark.parametrize(
@@ -487,8 +485,7 @@ def test_buffer_resource_from_options_creates_instance_with_explicit_options() -
             "num_streams": "8",
         }
     )
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource.from_options(mr, opts)
+    br = BufferResource.from_options(rmm.mr.CudaMemoryResource(), opts)
 
     assert br.statistics.enabled
     assert br.stream_pool_size() == 8
@@ -498,8 +495,7 @@ def test_buffer_resource_from_options_creates_instance_with_explicit_options() -
 
 def test_buffer_resource_from_options_uses_default_when_options_empty() -> None:
     opts = Options()
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource.from_options(mr, opts)
+    br = BufferResource.from_options(rmm.mr.CudaMemoryResource(), opts)
 
     assert not br.statistics.enabled
     assert br.stream_pool_size() == 16
@@ -511,16 +507,14 @@ def test_buffer_resource_from_options_uses_default_when_options_empty() -> None:
 
 def test_buffer_resource_from_options_enables_statistics_when_requested() -> None:
     opts = Options({"statistics": "ON"})
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource.from_options(mr, opts)
+    br = BufferResource.from_options(rmm.mr.CudaMemoryResource(), opts)
 
     assert br.statistics.enabled
 
 
 def test_buffer_resource_from_options_accepts_percentage_for_device_limit() -> None:
     opts = Options({"spill_device_limit": "50%"})
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource.from_options(mr, opts)
+    br = BufferResource.from_options(rmm.mr.CudaMemoryResource(), opts)
 
     # Verify device memory limit is set (exact value depends on system memory)
     mem_avail = br.memory_available(MemoryType.DEVICE)
@@ -532,8 +526,7 @@ def test_buffer_resource_from_options_enables_pinned_memory_when_supported() -> 
         pytest.skip("Pinned memory not supported on this system")
 
     opts = Options({"pinned_memory": "True"})
-    mr = RmmResourceAdaptor(rmm.mr.CudaMemoryResource())
-    br = BufferResource.from_options(mr, opts)
+    br = BufferResource.from_options(rmm.mr.CudaMemoryResource(), opts)
     assert br.pinned_mr is not None
 
 

--- a/python/rapidsmpf/rapidsmpf/tests/test_spill_manager.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_spill_manager.py
@@ -9,8 +9,7 @@ import pytest
 
 from rapidsmpf.error import BadAlloc, OutOfMemory, ReservationError
 from rapidsmpf.memory.buffer import MemoryType
-from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
-from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
+from rapidsmpf.memory.buffer_resource import BufferResource
 
 if TYPE_CHECKING:
     import rmm.mr
@@ -104,12 +103,11 @@ def test_periodic_spill_check(
     device_mr: rmm.mr.CudaMemoryResource,
 ) -> None:
     # Create a buffer resource with a negative limit to trigger spilling and
-    # a periodic spill check enabled.
-    mr = RmmResourceAdaptor(device_mr)
-    mem_available = LimitAvailableMemory(mr, limit=-100)
+    # a periodic spill check enabled. (memory_available = limit - allocated; with
+    # limit = -100 and no allocations, the available value is always negative.)
     br = BufferResource(
-        mr,
-        memory_available={MemoryType.DEVICE: mem_available},
+        device_mr,
+        memory_limits={MemoryType.DEVICE: -100},
         periodic_spill_check=1e-3,
     )
 
@@ -129,11 +127,9 @@ def test_spill_to_make_headroom(
     device_mr: rmm.mr.CudaMemoryResource,
 ) -> None:
     # Create a buffer resource with a fixed limit of 100 bytes.
-    mr = RmmResourceAdaptor(device_mr)
-    mem_available = LimitAvailableMemory(mr, limit=100)
     br = BufferResource(
-        mr,
-        memory_available={MemoryType.DEVICE: mem_available},
+        device_mr,
+        memory_limits={MemoryType.DEVICE: 100},
         periodic_spill_check=None,
     )
 
@@ -155,11 +151,9 @@ def test_reserve_device_memory_and_spill(
     device_mr: rmm.mr.CudaMemoryResource,
 ) -> None:
     # Create a buffer resource with a fixed limit of 100 bytes.
-    mr = RmmResourceAdaptor(device_mr)
-    mem_available = LimitAvailableMemory(mr, limit=100)
     br = BufferResource(
-        mr,
-        memory_available={MemoryType.DEVICE: mem_available},
+        device_mr,
+        memory_limits={MemoryType.DEVICE: 100},
         periodic_spill_check=None,
     )
 


### PR DESCRIPTION
As part of the upcoming work for #641, `RmmResourceAdaptor` will be merged into `BufferResource`, which removes most of the motivation for supporting a generic memory-availability callback.

This PR simplifies the API to match how it is actually used. Today, `BufferResource` accepts an arbitrary `std::function<std::int64_t()>` per `MemoryType`, but every real caller simply wraps `LimitAvailableMemory(adaptor, limit)`, which reduces to a straightforward `limit - current_allocated()` computation.

This PR replaces the callback map with a plain integer limit, defaulting to `std::numeric_limits<std::int64_t>::max()` to represent "unlimited".

To further simplify the API, `BufferResource` now constructs the `RmmResourceAdaptor` internally, so users no longer need to interact with `RmmResourceAdaptor` directly.