### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/recipes/rapidsmpf/recipe.yaml
+++ b/conda/recipes/rapidsmpf/recipe.yaml
@@ -106,7 +106,7 @@ requirements:
       else: cuda-python >=13.0.1,<14.0
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - cudf =${{ minor_version }}
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - librapidsmpf =${{ version }}
     - mpi4py
     - numpy >=1.23,<3.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -431,7 +431,7 @@ dependencies:
           - numpy >=1.23,<3.0
       - output_types: conda
         packages:
-          - cupy>=13.6.0
+          - cupy>=13.6.0,!=14.0.0,!=14.1.0
     specific:
       - output_types: [conda, requirements, pyproject]
         matrices:
@@ -448,11 +448,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
   depends_on_librapidsmpf:
     common:
       - output_types: conda

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
     "cuda-python>=13.0.1,<14.0",
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "librapidsmpf==26.6.*,>=0.0.0a0",
     "numpy >=1.23,<3.0",
     "pylibcudf==26.6.*,>=0.0.0a0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
