### PR TITLE
Use std::span for cudf::split/cudf::concatenate calls

### DIFF
--- a/cpp/src/integrations/cudf/partition.cpp
+++ b/cpp/src/integrations/cudf/partition.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <utility>
+#include <span>
 
 #include <cudf/concatenate.hpp>
 #include <cudf/contiguous_split.hpp>
@@ -68,7 +69,7 @@ partition_and_split(
     // hash_partition() returns the start offset of each partition thus we have to
     // skip the first offset. See: <https://github.com/rapidsai/cudf/issues/4607>.
     auto partition_offsets =
-        cudf::host_span<cudf::size_type const>(offsets.data() + 1, offsets.size() - 2);
+        std::span<cudf::size_type const>(offsets.data() + 1, offsets.size() - 2);
 
     // split does not make any copies.
     auto tbl_partitioned =


### PR DESCRIPTION
# Summary
cudf is migrating its public APIs from `cudf::host_span` to `std::span` (rapidsai/cudf#22588). That migration changes the mangled symbols of several exported libcudf functions, two of which rapidsmpf calls: `cudf::split` and `cudf::concatenate`. Because rapidsmpf is consumed prebuilt from nightlies, its compiled librapidsmpf.so references the old host_span symbols and fails to load against the new libcudf with:

```
ImportError: librapidsmpf.so: undefined symbol:
    cudf::concatenate(cudf::host_span<cudf::table_view const>, rmm::cuda_stream_view, ...)
```
This PR updates rapidsmpf's call sites to the new signatures so it builds and links against the migrated libcudf.

# Changes
All in `cpp/src/integrations/cudf/partition.cpp`:

 - `cudf::split` — the partition_offsets argument was an explicit `cudf::host_span<cudf::size_type const>;` changed to `std::span<cudf::size_type const>` to match the new cudf::split signature.
- cudf::concatenate — no source change; the argument (`std::vector<cudf::table_view>`) converts implicitly to `std::span`, so
  recompiling against the new libcudf resolves the symbol.
 - Added `#include <span>`.