### PR TITLE
Use cuCascade topology-only build mode

### DIFF
--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -11,16 +11,17 @@
 function(find_and_configure_cucascade)
   rapids_cpm_find(
     cuCascade 0.1.0
-    GLOBAL_TARGETS cuCascade::cucascade cuCascade::cucascade_topology_discovery
+    GLOBAL_TARGETS cuCascade::cucascade_topology_discovery
     CPM_ARGS
-    GIT_REPOSITORY https://github.com/NVIDIA/cuCascade.git
-    GIT_TAG main
+    GIT_REPOSITORY https://github.com/vyasr/cuCascade.git
+    GIT_TAG feat/topology_only
     GIT_SHALLOW FALSE
     OPTIONS "CUCASCADE_BUILD_TESTS OFF"
             "CUCASCADE_BUILD_BENCHMARKS OFF"
             "CUCASCADE_BUILD_SHARED_LIBS OFF"
             "CUCASCADE_BUILD_STATIC_LIBS ON"
             "CUCASCADE_WARNINGS_AS_ERRORS OFF"
+            "CUCASCADE_TOPOLOGY_ONLY ON"
     EXCLUDE_FROM_ALL
   )
 endfunction()


### PR DESCRIPTION
This PR switches rapidsmpf to use cuCascade's new `CUCASCADE_TOPOLOGY_ONLY=ON` mode, which builds only the topology discovery library without requiring cudf/rmm dependencies at cuCascade configure time.

This breaks the circular dependency where:
- rapidsmpf depends on cuCascade (topology discovery)
- cuCascade (full build) depends on cudf
- cudf depends on rapidsmpf

With topology-only mode, cuCascade only needs CUDAToolkit (for NVML), making the dependency chain linear.

Depends on:
- https://github.com/NVIDIA/cuCascade/pull/141