### PR TITLE
Cudf-free shuffler tests

### DIFF
--- a/cpp/include/rapidsmpf/utils/misc.hpp
+++ b/cpp/include/rapidsmpf/utils/misc.hpp
@@ -4,8 +4,10 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <concepts>
 #include <cstdlib>
 #include <functional>
 #include <memory>
@@ -191,6 +193,49 @@ bool is_running_under_valgrind();
 template <typename T>
 constexpr T safe_div(T x, T y) {
     return (y == 0) ? 0 : x / y;
+}
+
+/**
+ * @brief Computes the ceiling of the division of two integers.
+ *
+ * Returns the smallest integer not less than `x / y`. Both operands must be
+ * non-negative and the denominator must be non-zero.
+ *
+ * @tparam T An integral type.
+ * @param x The numerator (must be non-negative).
+ * @param y The denominator (must be positive).
+ * @return T The ceiling of `x / y`.
+ */
+template <std::integral T>
+constexpr T ceil_div(T x, T y) {
+    return (x + y - 1) / y;
+}
+
+/**
+ * @brief Splits the index range `[0, count)` into exactly `num_chunks` contiguous chunks.
+ *
+ * Each chunk is a half-open `[begin, end)` index pair. Chunks are front-loaded with
+ * size `ceil(count / num_chunks)`; the last non-empty chunk may be smaller and, when
+ * `count < num_chunks`, the trailing chunks are empty (`begin == end`). The chunks
+ * exactly tile `[0, count)`, so their sizes sum to `count`.
+ *
+ * Unlike `std::ranges::chunk_view` (C++23), this always yields exactly `num_chunks`
+ * chunks, injecting empty trailing chunks as needed.
+ *
+ * @param count The number of elements to split.
+ * @param num_chunks The number of chunks to produce (must be positive).
+ * @return A lazy view of `num_chunks` `std::pair<std::size_t, std::size_t>` `[begin,
+ * end)` index pairs.
+ */
+[[nodiscard]] inline auto chunk_indices(std::size_t count, std::size_t num_chunks) {
+    std::size_t const chunk_size = ceil_div(count, num_chunks);
+    return std::views::iota(std::size_t{0}, num_chunks)
+           | std::views::transform([count, chunk_size](std::size_t k) {
+                 return std::pair<std::size_t, std::size_t>{
+                     std::min(k * chunk_size, count),
+                     std::min((k + 1) * chunk_size, count)
+                 };
+             });
 }
 
 // Macro to concatenate two tokens x and y.

--- a/cpp/include/rapidsmpf/utils/misc.hpp
+++ b/cpp/include/rapidsmpf/utils/misc.hpp
@@ -199,7 +199,8 @@ constexpr T safe_div(T x, T y) {
  * @brief Computes the ceiling of the division of two integers.
  *
  * Returns the smallest integer not less than `x / y`. Both operands must be
- * non-negative and the denominator must be non-zero.
+ * non-negative and the denominator must be non-zero. Computed as `x / y + (x % y != 0)`
+ * to avoid the overflow (and signed UB)
  *
  * @tparam T An integral type.
  * @param x The numerator (must be non-negative).
@@ -208,7 +209,7 @@ constexpr T safe_div(T x, T y) {
  */
 template <std::integral T>
 constexpr T ceil_div(T x, T y) {
-    return (x + y - 1) / y;
+    return x / y + (x % y != 0 ? T{1} : T{0});
 }
 
 /**

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ target_sources(
           test_pausable_thread_loop.cpp
           test_progress_thread.cpp
           test_rmm_resource_adaptor.cpp
+          test_shuffler.cpp
           test_sparse_alltoall.cpp
           test_spill_manager.cpp
           test_spilling.cpp
@@ -99,7 +100,8 @@ target_sources(
 if(RAPIDSMPF_HAVE_STREAMING)
   target_sources(
     test_sources
-    PRIVATE streaming/test_allreduce.cpp
+    PRIVATE streaming/test_allgather.cpp
+            streaming/test_allreduce.cpp
             streaming/test_channel.cpp
             streaming/test_error_handling.cpp
             streaming/test_fanout.cpp
@@ -113,19 +115,14 @@ endif()
 
 # cudf-dependent test sources, gated behind BUILD_CUDF_TESTS
 if(BUILD_CUDF_TESTS)
-  target_sources(
-    test_sources PRIVATE test_partition.cpp test_shuffler.cpp test_shuffler_many_streams.cpp
-  )
+  target_sources(test_sources PRIVATE test_partition.cpp test_shuffler_many_streams.cpp)
   target_link_libraries(
     test_sources PRIVATE cudf_streaming::cudf_streaming cudf::cudftestutil cudf::cudftestutil_impl
   )
   target_compile_definitions(test_sources PRIVATE RAPIDSMPF_HAVE_CUDF)
 
   if(RAPIDSMPF_HAVE_STREAMING)
-    target_sources(
-      test_sources PRIVATE streaming/test_allgather.cpp streaming/test_leaf_actor.cpp
-                           streaming/test_shuffler.cpp
-    )
+    target_sources(test_sources PRIVATE streaming/test_leaf_actor.cpp streaming/test_shuffler.cpp)
   endif()
 endif()
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ if(RAPIDSMPF_HAVE_STREAMING)
             streaming/test_message.cpp
             streaming/test_sparse_alltoall.cpp
             streaming/test_spillable_messages.cpp
+            streaming/test_shuffler.cpp
   )
 endif()
 
@@ -122,7 +123,7 @@ if(BUILD_CUDF_TESTS)
   target_compile_definitions(test_sources PRIVATE RAPIDSMPF_HAVE_CUDF)
 
   if(RAPIDSMPF_HAVE_STREAMING)
-    target_sources(test_sources PRIVATE streaming/test_leaf_actor.cpp streaming/test_shuffler.cpp)
+    target_sources(test_sources PRIVATE streaming/test_leaf_actor.cpp)
   endif()
 endif()
 

--- a/cpp/tests/streaming/test_allgather.cpp
+++ b/cpp/tests/streaming/test_allgather.cpp
@@ -10,8 +10,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cudf_streaming/integrations/partition.hpp>
-
 #include <coro/latch.hpp>
 
 #include <rapidsmpf/communicator/single.hpp>

--- a/cpp/tests/streaming/test_shuffler.cpp
+++ b/cpp/tests/streaming/test_shuffler.cpp
@@ -13,6 +13,7 @@
 #include <rapidsmpf/cuda_stream.hpp>
 #include <rapidsmpf/memory/buffer.hpp>
 #include <rapidsmpf/shuffler/shuffler.hpp>
+#include <rapidsmpf/streaming/chunks/partition.hpp>
 #include <rapidsmpf/streaming/coll/shuffler.hpp>
 #include <rapidsmpf/streaming/core/actor.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
@@ -98,25 +99,21 @@ TEST_P(StreamingShuffler, basic_shuffler) {
     const int64_t base = static_cast<int64_t>(comm->rank()) * num_rows;
     std::vector<Message> input_chunks;  // Message contains a PartitionMapChunk
     for (size_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
-        ContentDescription cd{};
         std::unordered_map<shuffler::PartID, PackedData> chunks;
         chunks.reserve(num_partitions);
         for (size_t j = 0; j < num_partitions; ++j) {
             auto [start, end] = pieces[chunk_idx * num_partitions + j];
             // end > start is guaranteed.
-            auto [it, _] = chunks.emplace(
+            chunks.emplace(
                 static_cast<shuffler::PartID>(j),
                 generate_packed_data<int64_t>(
                     end - start, base + static_cast<int64_t>(start), stream, *br
                 )
             );
-            cd.content_size(it->second.data->mem_type()) += it->second.data->size;
         }
-        input_chunks.emplace_back(Message(
-            chunk_idx,
-            std::make_unique<PartitionMapChunk>(std::move(chunks)),
-            std::move(cd)
-        ));
+        input_chunks.emplace_back(
+            to_message(chunk_idx, std::make_unique<PartitionMapChunk>(std::move(chunks)))
+        );
     }
     EXPECT_EQ(input_chunks.size(), num_chunks);
 
@@ -150,7 +147,7 @@ TEST_P(StreamingShuffler, basic_shuffler) {
 
         auto p_vec = chunk.release<PartitionVectorChunk>();
         // for each local pid, it should receive num_chunks * nranks chunks.
-        EXPECT_EQ(p_vec.data.size(), num_chunks * n_ranks);
+        ASSERT_EQ(p_vec.data.size(), num_chunks * n_ranks);
 
         // since values are offset by rank, if we sort packed data by their first element,
         // then it will be in rank & chunk-index order.

--- a/cpp/tests/streaming/test_shuffler.cpp
+++ b/cpp/tests/streaming/test_shuffler.cpp
@@ -3,18 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <algorithm>
+#include <ranges>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <cudf/copying.hpp>
-#include <cudf_streaming/integrations/partition.hpp>
-#include <cudf_streaming/streaming/partition.hpp>
-#include <cudf_streaming/streaming/table_chunk.hpp>
-#include <cudf_test/table_utilities.hpp>
 
 #include <rapidsmpf/communicator/single.hpp>
 #include <rapidsmpf/cuda_stream.hpp>
 #include <rapidsmpf/memory/buffer.hpp>
+#include <rapidsmpf/shuffler/shuffler.hpp>
 #include <rapidsmpf/streaming/coll/shuffler.hpp>
 #include <rapidsmpf/streaming/core/actor.hpp>
 #include <rapidsmpf/streaming/core/context.hpp>
@@ -55,13 +53,12 @@ TEST_F(BaseStreamingShuffle, zero_owned_partitions_completes) {
 class StreamingShuffler : public BaseStreamingShuffle,
                           public ::testing::WithParamInterface<int> {
   public:
-    const unsigned int num_partitions = 10;
-    const unsigned int num_rows = 1000;
-    const unsigned int num_chunks = 5;
-    const unsigned int chunk_size = num_rows / num_chunks;
-    const std::int64_t seed = 42;
-    const cudf::hash_id hash_function = cudf::hash_id::HASH_MURMUR3;
-    const OpID op_id = 0;
+    static constexpr size_t num_partitions = 10;
+    static constexpr size_t num_rows = 1000;
+    static constexpr size_t num_chunks = 5;
+    static constexpr OpID op_id = 0;
+
+    shuffler::Shuffler::PartitionOwner partition_owner = shuffler::Shuffler::round_robin;
 
     void SetUp() override {
         BaseStreamingShuffle::SetUpWithThreads(GetParam());
@@ -69,100 +66,6 @@ class StreamingShuffler : public BaseStreamingShuffle,
 
     void TearDown() override {
         BaseStreamingShuffle::TearDown();
-    }
-
-    void run_test(auto make_shuffler_actor_fn) {
-        // Create the full input table and slice it into chunks.
-        cudf::table full_input_table = random_table_with_index(seed, num_rows, 0, 10);
-        std::vector<Message> input_chunks;
-        for (unsigned int i = 0; i < num_chunks; ++i) {
-            input_chunks.emplace_back(
-                cudf_streaming::streaming::to_message(
-                    i,
-                    std::make_unique<cudf_streaming::streaming::TableChunk>(
-                        std::make_unique<cudf::table>(
-                            cudf::slice(
-                                full_input_table,
-                                {static_cast<cudf::size_type>(i * chunk_size),
-                                 static_cast<cudf::size_type>((i + 1) * chunk_size)},
-                                stream
-                            )
-                                .at(0),
-                            stream,
-                            ctx->br()->device_mr()
-                        ),
-                        stream
-                    )
-                )
-            );
-        }
-
-        // Create and run the streaming pipeline.
-        std::vector<Message> output_chunks;
-        {
-            std::vector<Actor> actors;
-            auto ch1 = ctx->create_channel();
-            actors.push_back(actor::push_to_channel(ctx, ch1, std::move(input_chunks)));
-
-            auto ch2 = ctx->create_channel();
-            actors.push_back(
-                cudf_streaming::streaming::actor::partition_and_pack(
-                    ctx, ch1, ch2, {1}, num_partitions, hash_function, seed
-                )
-            );
-
-            auto ch3 = ctx->create_channel();
-            actors.emplace_back(make_shuffler_actor_fn(ch2, ch3));
-
-            auto ch4 = ctx->create_channel();
-            actors.push_back(
-                cudf_streaming::streaming::actor::unpack_and_concat(ctx, ch3, ch4)
-            );
-
-            actors.push_back(actor::pull_from_channel(ctx, ch4, output_chunks));
-
-            run_actor_network(std::move(actors));
-        }
-
-        auto comm = GlobalEnvironment->comm_;
-        std::unique_ptr<cudf::table> expected_table;
-        if (comm->nranks() == 1) {  // full_input table is expected
-            expected_table = std::make_unique<cudf::table>(std::move(full_input_table));
-        } else {  // full_input table is replicated on all ranks
-            // local partitions
-            auto [table, offsets] = cudf::hash_partition(
-                full_input_table.view(), {1}, num_partitions, hash_function, seed
-            );
-
-            auto local_pids = shuffler::Shuffler::local_partitions(
-                comm, num_partitions, shuffler::Shuffler::round_robin
-            );
-
-            // every partition is replicated on all ranks
-            std::vector<cudf::table_view> expected_tables;
-            for (auto pid : local_pids) {
-                auto t_view =
-                    cudf::slice(table->view(), {offsets[pid], offsets[pid + 1]}).at(0);
-                // this will be replicated on all ranks
-                for (rapidsmpf::Rank rank = 0; rank < comm->nranks(); ++rank) {
-                    expected_tables.push_back(t_view);
-                }
-            }
-            expected_table = cudf::concatenate(expected_tables);
-        }
-
-        // Concat all output chunks to a single table.
-        std::vector<cudf::table_view> output_chunks_as_views;
-        for (auto& chunk : output_chunks) {
-            output_chunks_as_views.push_back(
-                chunk.get<cudf_streaming::streaming::TableChunk>().table_view()
-            );
-        }
-        auto result_table = cudf::concatenate(output_chunks_as_views);
-
-        CUDF_TEST_EXPECT_TABLES_EQUIVALENT(
-            sort_table(result_table->view()), sort_table(expected_table->view())
-        );
     }
 };
 
@@ -175,12 +78,111 @@ INSTANTIATE_TEST_SUITE_P(
     }
 );
 
+// Verifies end-to-end correctness of the streaming shuffler actor.
+//
+// Each rank sends num_chunks messages, where each message is a PartitionMapChunk covering
+// all num_partitions partitions. The data for partition j in chunk c_idx on rank r is a
+// contiguous integer sequence whose values encode both the rank and the row range, making
+// them globally unique and independently verifiable.
+//
+// After shuffling, each local partition should have received exactly num_chunks * nranks
+// packed-data items (one per (rank, chunk) pair). The items are sorted by their first
+// element — which equals rank * num_rows + row_start — to reconstruct rank-major,
+// chunk-minor order, and then validated against the expected row range from `pieces`.
 TEST_P(StreamingShuffler, basic_shuffler) {
-    EXPECT_NO_FATAL_FAILURE(run_test([&](auto ch_in, auto ch_out) -> Actor {
-        return actor::shuffler(
-            ctx, GlobalEnvironment->comm_, ch_in, ch_out, op_id, num_partitions
+    auto comm = GlobalEnvironment->comm_;
+    // split a span [0, num_rows) into num_partitions * num_chunks contiguous pieces.
+    auto const pieces = rapidsmpf::chunk_indices(num_rows, num_partitions * num_chunks);
+
+    // each rank contributes num_chunks messages, each covering num_partitions pieces.
+    const int64_t base = static_cast<int64_t>(comm->rank()) * num_rows;
+    std::vector<Message> input_chunks;  // Message contains a PartitionMapChunk
+    for (size_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
+        ContentDescription cd{};
+        std::unordered_map<shuffler::PartID, PackedData> chunks;
+        chunks.reserve(num_partitions);
+        for (size_t j = 0; j < num_partitions; ++j) {
+            auto [start, end] = pieces[chunk_idx * num_partitions + j];
+            // end > start is guaranteed.
+            auto [it, _] = chunks.emplace(
+                static_cast<shuffler::PartID>(j),
+                generate_packed_data<int64_t>(
+                    end - start, base + static_cast<int64_t>(start), stream, *br
+                )
+            );
+            cd.content_size(it->second.data->mem_type()) += it->second.data->size;
+        }
+        input_chunks.emplace_back(Message(
+            chunk_idx,
+            std::make_unique<PartitionMapChunk>(std::move(chunks)),
+            std::move(cd)
+        ));
+    }
+    EXPECT_EQ(input_chunks.size(), num_chunks);
+
+    // Create and run the streaming pipeline.
+    std::vector<Message> output_chunks;
+    {
+        std::vector<Actor> actors;
+        auto ch1 = ctx->create_channel();
+        actors.push_back(actor::push_to_channel(ctx, ch1, std::move(input_chunks)));
+
+        auto ch2 = ctx->create_channel();
+        actors.emplace_back(
+            actor::shuffler(ctx, comm, ch1, ch2, op_id, num_partitions, partition_owner)
         );
-    }));
+
+        actors.push_back(actor::pull_from_channel(ctx, ch2, output_chunks));
+
+        run_actor_network(std::move(actors));
+    }
+
+    auto local_pids =
+        shuffler::Shuffler::local_partitions(comm, num_partitions, partition_owner);
+
+    // Since all partitions are non-empty, each local partition ID should a corresponding
+    // output chunk.
+    EXPECT_EQ(local_pids.size(), output_chunks.size());
+    const size_t n_ranks = static_cast<size_t>(comm->nranks());
+    for (auto& chunk : output_chunks) {
+        auto pid = chunk.sequence_number();
+        std::erase_if(local_pids, [pid](auto& p) { return p == pid; });
+
+        auto p_vec = chunk.release<PartitionVectorChunk>();
+        // for each local pid, it should receive num_chunks * nranks chunks.
+        EXPECT_EQ(p_vec.data.size(), num_chunks * n_ranks);
+
+        // since values are offset by rank, if we sort packed data by their first element,
+        // then it will be in rank & chunk-index order.
+        std::ranges::sort(p_vec.data, [](auto& a, auto& b) {
+            std::int64_t oa{}, ob{};
+            std::memcpy(&oa, a.metadata->data(), sizeof(std::int64_t));
+            std::memcpy(&ob, b.metadata->data(), sizeof(std::int64_t));
+            return oa < ob;
+        });
+
+        // p_vec.data is sorted by first element, so entries are ordered
+        // (rank=0,chunk=0), (rank=0,chunk=1), ..., (rank=1,chunk=0), ...
+        // i.e. flat index r*num_chunks + c_idx.
+        for (size_t r = 0; r < n_ranks; ++r) {
+            auto r_base = static_cast<int64_t>(r) * num_rows;  // rank-base offset
+            for (size_t c_idx = 0; c_idx < num_chunks; ++c_idx) {
+                const auto [start, end] = pieces[c_idx * num_partitions + pid];
+                SCOPED_TRACE(
+                    "pid=" + std::to_string(pid) + ", rank=" + std::to_string(r)
+                    + ", chunk_idx=" + std::to_string(c_idx)
+                );
+                validate_packed_data<int64_t>(
+                    std::move(p_vec.data[r * num_chunks + c_idx]),
+                    end - start,
+                    r_base + static_cast<int64_t>(start),
+                    stream,
+                    *br
+                );
+            }
+        }
+    }
+    EXPECT_TRUE(local_pids.empty());
 }
 
 class ShufflerAsyncTest

--- a/cpp/tests/test_misc.cpp
+++ b/cpp/tests/test_misc.cpp
@@ -233,6 +233,44 @@ TEST(MiscTest, SafeCastZeroAndBoundaries) {
     EXPECT_THROW(safe_cast<std::uint8_t>(std::uint16_t{256}), std::overflow_error);
 }
 
+// Test ceil_div edge cases. `ceil_div` is constexpr, so these are all
+// constant-evaluated and verified at compile time.
+TEST(MiscTest, CeilDiv) {
+    // Basic behavior.
+    static_assert(ceil_div(0, 1) == 0);
+    static_assert(ceil_div(1, 1) == 1);
+    static_assert(ceil_div(10, 5) == 2);  // exact division
+    static_assert(ceil_div(11, 5) == 3);  // remainder rounds up
+    static_assert(ceil_div(9, 5) == 2);
+    static_assert(ceil_div(1, 5) == 1);  // numerator smaller than denominator
+    static_assert(ceil_div(5, 1) == 5);  // denominator of one
+
+    // A zero numerator always yields zero, regardless of denominator.
+    static_assert(ceil_div(0u, 1u) == 0u);
+    static_assert(ceil_div(0u, 7u) == 0u);
+    static_assert(
+        ceil_div(std::size_t{0}, std::numeric_limits<std::size_t>::max())
+        == std::size_t{0}
+    );
+
+    // Large unsigned values that would overflow the naive `(x + y - 1) / y`.
+    constexpr auto umax = std::numeric_limits<std::uint64_t>::max();
+    static_assert(ceil_div(umax, umax) == std::uint64_t{1});  // `x + y - 1` wraps to 0
+    static_assert(ceil_div(umax - 1, umax) == std::uint64_t{1});
+    static_assert(ceil_div(umax, std::uint64_t{1}) == umax);
+    // `umax` is odd, so ceil(umax / 2) rounds up to 2^63.
+    static_assert(ceil_div(umax, std::uint64_t{2}) == (umax / 2) + 1);
+
+    // Large signed values near the maximum must not trigger signed-overflow UB.
+    constexpr auto imax = std::numeric_limits<std::int64_t>::max();
+    static_assert(ceil_div(imax, imax) == std::int64_t{1});
+    static_assert(ceil_div(imax - 1, imax) == std::int64_t{1});
+    static_assert(ceil_div(imax, std::int64_t{1}) == imax);
+    static_assert(ceil_div(imax, std::int64_t{2}) == (imax / 2) + 1);
+
+    SUCCEED();
+}
+
 // Test mixed signed/unsigned of different sizes
 TEST(MiscTest, SafeCastMixedSignednessAndSize) {
     // std::int64_t to std::uint32_t

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -6,17 +6,15 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstring>
 #include <future>
 #include <memory>
 #include <thread>
 
 #include <gtest/gtest.h>
 
-#include <cudf_streaming/integrations/partition.hpp>
-#include <cudf_test/base_fixture.hpp>
-#include <cudf_test/column_wrapper.hpp>
-#include <cudf_test/debug_utilities.hpp>
-#include <cudf_test/table_utilities.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 
 #include <rapidsmpf/memory/buffer.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
@@ -32,7 +30,7 @@
 extern Environment* GlobalEnvironment;
 
 TEST(ReceivedChunks, spill_skips_control_messages) {
-    auto mr = cudf::get_current_device_resource_ref();
+    auto mr = rmm::mr::get_current_device_resource_ref();
     auto br = rapidsmpf::BufferResource::create(mr);
 
     rapidsmpf::shuffler::detail::ReceivedChunks received;
@@ -49,9 +47,9 @@ TEST(ReceivedChunks, spill_skips_control_messages) {
 }
 
 TEST(ReceivedChunks, spill_respects_amount) {
-    auto mr = cudf::get_current_device_resource_ref();
+    auto mr = rmm::mr::get_current_device_resource_ref();
     auto br = rapidsmpf::BufferResource::create(mr);
-    auto stream = cudf::get_default_stream();
+    auto stream = rmm::cuda_stream_default;
 
     rapidsmpf::shuffler::detail::ReceivedChunks received;
     constexpr std::size_t chunk_size = 100;
@@ -74,8 +72,8 @@ TEST(ReceivedChunks, spill_respects_amount) {
 }
 
 TEST(MetadataMessage, round_trip) {
-    auto stream = cudf::get_default_stream();
-    auto mr = cudf::get_current_device_resource_ref();
+    auto stream = rmm::cuda_stream_default;
+    auto mr = rmm::mr::get_current_device_resource_ref();
     auto br = rapidsmpf::BufferResource::create(mr);
 
     auto metadata = iota_vector<std::uint8_t>(100);
@@ -108,6 +106,8 @@ TEST(MetadataMessage, round_trip) {
     EXPECT_EQ(metadata, *result.release_metadata_buffer());
 }
 
+namespace {
+
 using MemoryLimitsMap = std::unordered_map<rapidsmpf::MemoryType, std::int64_t>;
 
 // Help function to get the `memory_limits` argument for a `BufferResource`
@@ -130,20 +130,95 @@ MemoryLimitsMap get_memory_limits_map(rapidsmpf::MemoryType priorities) {
     return ret;
 }
 
-/// @tparam InsertFn: lambda that inserts the packed chunks into the shuffler.
-/// Signature: void(std::vector<rapidsmpf::PackedData>&& packed_chunks)
-/// @tparam InsertFinishedFn: lambda that inserts the finished flag into the shuffler.
-/// Signature: void()
-template <typename InsertFn, typename InsertFinishedFn>
+// Conservation-preserving data model shared by the shuffler round-trip tests.
+//
+// We split the index range [0, total_num_rows) into total_num_partitions^2 contiguous
+// sub-regions via chunk_indices (front-loaded, so when N < P*P the trailing sub-regions
+// are empty). Sub-region (local_pidx, split_idx) is piece k = local_pidx*P + split_idx
+// and is routed to destination partition split_idx; input region local_pidx is the union
+// of its P sub-regions. The pieces exactly tile [0,N), so the total shuffled data == N
+// regardless of rank/partition counts (conservation). A per-shuffle `base` offset is
+// added to every value so distinct shuffles carry distinct data.
+
+// Produces the non-empty sub-regions of one owned input region `local_pidx`, keyed by
+// destination partition. Since local_partitions() across ranks partition [0,P), every
+// input region is produced exactly once, so rows are not replicated.
+std::unordered_map<rapidsmpf::shuffler::PartID, rapidsmpf::PackedData>
+make_partition_data(
+    rapidsmpf::shuffler::PartID total_num_partitions,
+    std::size_t total_num_rows,
+    rapidsmpf::shuffler::PartID local_pidx,
+    rmm::cuda_stream_view stream,
+    rapidsmpf::BufferResource& br,
+    std::int64_t base = 0
+) {
+    auto const P = static_cast<std::size_t>(total_num_partitions);
+    auto const pieces = rapidsmpf::chunk_indices(total_num_rows, P * P);
+
+    std::unordered_map<rapidsmpf::shuffler::PartID, rapidsmpf::PackedData> chunks;
+    for (rapidsmpf::shuffler::PartID split_idx = 0; split_idx < total_num_partitions;
+         ++split_idx)
+    {
+        auto [start, end] = pieces[static_cast<std::size_t>(local_pidx) * P + split_idx];
+        if (end > start) {
+            chunks.emplace(
+                split_idx,
+                generate_packed_data(
+                    end - start, base + static_cast<std::int64_t>(start), stream, br
+                )
+            );
+        }
+    }
+    return chunks;
+}
+
+// Verifies that the `received` chunks for partition `j` match the non-empty sub-regions
+// expected for it.
+void validate_partition_data(
+    std::vector<rapidsmpf::PackedData> received,
+    rapidsmpf::shuffler::PartID total_num_partitions,
+    std::size_t total_num_rows,
+    rapidsmpf::shuffler::PartID j,
+    rapidsmpf::BufferResource& br,
+    std::int64_t base = 0
+) {
+    auto const P = static_cast<std::size_t>(total_num_partitions);
+    auto const pieces = rapidsmpf::chunk_indices(total_num_rows, P * P);
+
+    // Locally recompute the non-empty (offset, count) sub-regions expected for partition
+    // j, in increasing input-region-index (== increasing offset) order.
+    std::vector<std::pair<std::int64_t, std::size_t>> expected;
+    for (rapidsmpf::shuffler::PartID i = 0; i < total_num_partitions; ++i) {
+        auto [start, end] = pieces[static_cast<std::size_t>(i) * P + j];
+        if (end > start) {
+            expected.emplace_back(base + static_cast<std::int64_t>(start), end - start);
+        }
+    }
+
+    EXPECT_EQ(received.size(), expected.size());
+
+    // Sort received chunks by their first metadata int64 (== offset) so they align 1:1
+    // with the expected list, which is already in offset order.
+    std::sort(received.begin(), received.end(), [](auto const& a, auto const& b) {
+        std::int64_t oa{}, ob{};
+        std::memcpy(&oa, a.metadata->data(), sizeof(std::int64_t));
+        std::memcpy(&ob, b.metadata->data(), sizeof(std::int64_t));
+        return oa < ob;
+    });
+
+    for (std::size_t k = 0; k < received.size() && k < expected.size(); ++k) {
+        auto const [off, cnt] = expected[k];
+        auto const cs = received[k].stream();
+        EXPECT_NO_FATAL_FAILURE(
+            validate_packed_data<std::int64_t>(std::move(received[k]), cnt, off, cs, br)
+        );
+    }
+}
+
 void test_shuffler(
-    std::shared_ptr<rapidsmpf::Communicator> const& comm,
     rapidsmpf::shuffler::Shuffler& shuffler,
     rapidsmpf::shuffler::PartID total_num_partitions,
-    InsertFn&& insert_fn,
-    InsertFinishedFn&& insert_finished_fn,
     std::size_t total_num_rows,
-    std::int64_t seed,
-    cudf::hash_id hash_fn,
     rmm::cuda_stream_view stream,
     rapidsmpf::BufferResource* br
 ) {
@@ -151,95 +226,35 @@ void test_shuffler(
     // shuffle shouldn't get near 30s.
     std::chrono::seconds const wait_timeout(30);
 
-    // Every rank creates the full input table and all the expected partitions (also
-    // partitions this rank might not get after the shuffle).
-    cudf::table full_input_table = random_table_with_index(seed, total_num_rows, 0, 10);
-    auto [expect_partitions, owner] = cudf_streaming::integrations::partition_and_split(
-        full_input_table,
-        {1},
-        static_cast<std::int32_t>(total_num_partitions),
-        hash_fn,
-        seed,
-        stream,
-        br,
-        rapidsmpf::AllowOverbooking::YES
-    );
-
-    cudf::size_type row_offset = 0;
-    cudf::size_type partiton_size =
-        full_input_table.num_rows() / static_cast<cudf::size_type>(total_num_partitions);
-    for (rapidsmpf::shuffler::PartID i = 0; i < total_num_partitions; ++i) {
-        // To simulate that `full_input_table` is distributed between multiple ranks,
-        // we divided them into `total_num_partitions` number of partitions and pick
-        // the partitions this rank should use as input. We pick using round robin but
-        // any distribution would work (as long as no rows are picked by multiple
-        // ranks).
-        // TODO: we should test different distributions of the input partitions.
-        if (rapidsmpf::shuffler::Shuffler::round_robin(comm, i, total_num_partitions)
-            == comm->rank())
-        {
-            cudf::size_type row_end = row_offset + partiton_size;
-            if (i == total_num_partitions - 1) {
-                // Include the reminder of rows in the very last partition.
-                row_end = full_input_table.num_rows();
-            }
-            // Select the partition from the full input table.
-            auto slice = cudf::slice(full_input_table, {row_offset, row_end}).at(0);
-            // Hash the `slice` into chunks and pack (serialize) them.
-            auto packed_chunks = cudf_streaming::integrations::partition_and_pack(
-                slice,
-                {1},
-                static_cast<std::int32_t>(total_num_partitions),
-                hash_fn,
-                seed,
-                stream,
-                br,
-                rapidsmpf::AllowOverbooking::YES
-            );
-            // Add the chunks to the shuffle
-            insert_fn(std::move(packed_chunks));
-        }
-        row_offset += partiton_size;
+    for (rapidsmpf::shuffler::PartID local_pidx : shuffler.local_partitions()) {
+        shuffler.insert(make_partition_data(
+            total_num_partitions, total_num_rows, local_pidx, stream, *br
+        ));
     }
-    // Tell the shuffler that we have no more input partitions.
-    insert_finished_fn();
+    shuffler.insert_finished();
 
     EXPECT_NO_THROW(shuffler.wait(wait_timeout));
-    for (auto finished_partition : shuffler.local_partitions()) {
-        auto packed_chunks = shuffler.extract(finished_partition);
-        auto result = cudf_streaming::integrations::unpack_and_concat(
-            rapidsmpf::unspill_partitions(
-                std::move(packed_chunks), br, rapidsmpf::AllowOverbooking::YES
-            ),
-            stream,
-            br,
-            rapidsmpf::AllowOverbooking::YES
-        );
 
-        // We should only receive the partitions assigned to this rank.
-        EXPECT_EQ(
-            shuffler.partition_owner(comm, finished_partition, total_num_partitions),
-            comm->rank()
-        );
-
-        // Check the result while ignoring the row order.
-        CUDF_TEST_EXPECT_TABLES_EQUIVALENT(
-            sort_table(result), sort_table(expect_partitions[finished_partition])
+    for (auto j : shuffler.local_partitions()) {
+        validate_partition_data(
+            shuffler.extract(j), total_num_partitions, total_num_rows, j, *br
         );
     }
 }
 
+}  // namespace
+
 class MemoryLimits_NumPartition
-    : public cudf::test::BaseFixtureWithParam<
+    : public ::testing::TestWithParam<
           std::tuple<MemoryLimitsMap, rapidsmpf::shuffler::PartID, std::size_t>> {
   public:
     void SetUp() override {
-        stream = cudf::get_default_stream();
-        memory_limits = std::get<0>(GetParam());
-        total_num_partitions = std::get<1>(GetParam());
-        total_num_rows = std::get<2>(GetParam());
+        stream = rmm::cuda_stream_default;
+        std::tie(memory_limits, total_num_partitions, total_num_rows) = GetParam();
         br = rapidsmpf::BufferResource::create(
-            mr(), rapidsmpf::PinnedMemoryResource::Disabled, memory_limits
+            rmm::mr::get_current_device_resource_ref(),
+            rapidsmpf::PinnedMemoryResource::Disabled,
+            memory_limits
         );
 
         shuffler = std::make_unique<rapidsmpf::shuffler::Shuffler>(
@@ -258,8 +273,6 @@ class MemoryLimits_NumPartition
     MemoryLimitsMap memory_limits;
     rapidsmpf::shuffler::PartID total_num_partitions;
     std::size_t total_num_rows;
-    std::int64_t seed = 42;
-    cudf::hash_id hash_fn = cudf::hash_id::HASH_MURMUR3;
     rmm::cuda_stream_view stream;
     std::shared_ptr<rapidsmpf::BufferResource> br;
     std::unique_ptr<rapidsmpf::shuffler::Shuffler> shuffler;
@@ -285,82 +298,54 @@ INSTANTIATE_TEST_SUITE_P(
 );
 
 TEST_P(MemoryLimits_NumPartition, round_trip) {
-    EXPECT_NO_FATAL_FAILURE(test_shuffler(
-        GlobalEnvironment->comm_,
-        *shuffler,
-        total_num_partitions,
-        [&](auto&& packed_chunks) { shuffler->insert(std::move(packed_chunks)); },
-        [&]() { shuffler->insert_finished(); },
-        total_num_rows,
-        seed,
-        hash_fn,
-        stream,
-        br.get()
-    ));
+    EXPECT_NO_FATAL_FAILURE(
+        test_shuffler(*shuffler, total_num_partitions, total_num_rows, stream, br.get())
+    );
 }
 
 // Test that the same communicator can be used concurrently by multiple shufflers in
 // separate threads
-class ConcurrentShuffleTest
-    : public cudf::test::BaseFixtureWithParam<std::tuple<int, int>> {
+class ConcurrentShuffleTest : public ::testing::TestWithParam<
+                                  std::tuple<std::size_t, rapidsmpf::shuffler::PartID>> {
   public:
     void SetUp() override {
-        num_shufflers = std::get<0>(GetParam());
-        total_num_partitions =
-            static_cast<rapidsmpf::shuffler::PartID>(std::get<1>(GetParam()));
+        std::tie(num_shufflers, total_num_partitions) = GetParam();
 
         // these resources will be used by multiple threads to instantiate shufflers
-        br = rapidsmpf::BufferResource::create(mr());
-        stream = cudf::get_default_stream();
+        br =
+            rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
+        stream = rmm::cuda_stream_default;
     }
 
     void TearDown() override {}
 
     // test run for each thread. The test follows the same logic as
     // `MemoryLimits_NumPartition` test, but without any memory limitations
-    template <typename InsertFn, typename InsertFinishedFn>
-    void RunTest(int t_id, InsertFn&& insert_fn, InsertFinishedFn&& insert_finished_fn) {
+    void RunTest(std::size_t t_id) {
         rapidsmpf::shuffler::Shuffler shuffler(
             GlobalEnvironment->comm_,
-            t_id,  // op_id, use t_id as a proxy
+            static_cast<rapidsmpf::OpID>(t_id),  // op_id, use t_id as a proxy
             total_num_partitions,
             br.get()
         );
 
         EXPECT_NO_FATAL_FAILURE(test_shuffler(
-            GlobalEnvironment->comm_,
             shuffler,
             total_num_partitions,
-            [&](auto&& packed_chunks) { insert_fn(shuffler, std::move(packed_chunks)); },
-            [&]() { insert_finished_fn(shuffler); },
             100'000,  // total_num_rows
-            t_id,  // seed
-            cudf::hash_id::HASH_MURMUR3,
             stream,
             br.get()
         ));
     }
 
-    template <typename InsertFn, typename InsertFinishedFn>
-    void RunTestTemplate(InsertFn insert_fn, InsertFinishedFn insert_finished_fn) {
+    void RunTestTemplate() {
         std::vector<std::future<void>> futures;
-        futures.reserve(static_cast<std::size_t>(num_shufflers));
+        futures.reserve(num_shufflers);
 
-        for (int t_id = 0; t_id < num_shufflers; t_id++) {
-            // pass a copy of the insert_fn and insert_finished_fn to each thread
-            futures.push_back(
-                std::async(
-                    std::launch::async,
-                    [this,
-                     t_id,
-                     insert_fn1 = insert_fn,
-                     insert_finished_fn1 = insert_finished_fn] {
-                        ASSERT_NO_FATAL_FAILURE(this->RunTest(
-                            t_id, std::move(insert_fn1), std::move(insert_finished_fn1)
-                        ));
-                    }
-                )
-            );
+        for (std::size_t t_id = 0; t_id < num_shufflers; t_id++) {
+            futures.push_back(std::async(std::launch::async, [this, t_id] {
+                ASSERT_NO_FATAL_FAILURE(this->RunTest(t_id));
+            }));
         }
 
         for (auto& f : futures) {
@@ -368,7 +353,7 @@ class ConcurrentShuffleTest
         }
     }
 
-    int num_shufflers;
+    std::size_t num_shufflers;
     rapidsmpf::shuffler::PartID total_num_partitions;
 
     rmm::cuda_stream_view stream;
@@ -376,12 +361,7 @@ class ConcurrentShuffleTest
 };
 
 TEST_P(ConcurrentShuffleTest, round_trip) {
-    ASSERT_NO_FATAL_FAILURE(RunTestTemplate(
-        [&](auto& shuffler, auto&& packed_chunks) {
-            shuffler.insert(std::move(packed_chunks));
-        },
-        [&](auto& shuffler) { shuffler.insert_finished(); }
-    ));
+    ASSERT_NO_FATAL_FAILURE(RunTestTemplate());
 }
 
 // test different `num_shufflers` and `total_num_partitions`.
@@ -389,8 +369,12 @@ INSTANTIATE_TEST_SUITE_P(
     ConcurrentShuffle,
     ConcurrentShuffleTest,
     testing::Combine(
-        testing::ValuesIn({1, 2, 4}),  // num_shufflers
-        testing::ValuesIn({1, 10, 100})  // total_num_partitions
+        testing::Values(std::size_t{1}, std::size_t{2}, std::size_t{4}),  // num_shufflers
+        testing::Values(  // total_num_partitions
+            rapidsmpf::shuffler::PartID{1},
+            rapidsmpf::shuffler::PartID{10},
+            rapidsmpf::shuffler::PartID{100}
+        )
     ),
     [](const testing::TestParamInfo<ConcurrentShuffleTest::ParamType>& info) {
         return "num_shufflers_" + std::to_string(std::get<0>(info.param))
@@ -400,13 +384,11 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(Shuffler, SpillOnInsertAndExtraction) {
     rapidsmpf::shuffler::PartID const total_num_partitions = 2;
-    std::int64_t const seed = 42;
-    cudf::hash_id const hash_fn = cudf::hash_id::HASH_MURMUR3;
-    auto stream = cudf::get_default_stream();
+    auto stream = rmm::cuda_stream_default;
 
     // Use RapidsMPF's memory resource adaptor so the test can observe per-rank
     // allocation counts via `get_main_record().num_current_allocs()`.
-    rapidsmpf::RmmResourceAdaptor mr{cudf::get_current_device_resource_ref()};
+    rapidsmpf::RmmResourceAdaptor mr{rmm::mr::get_current_device_resource_ref()};
 
     // Control spilling by adjusting the DEVICE memory limit at runtime.
     // `memory_available(DEVICE)` is computed as `limit - current_allocated()`, so a
@@ -433,17 +415,12 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
         total_num_partitions,
         br.get()
     );
-    cudf::table input_table = random_table_with_index(seed, 1000, 0, 10);
-    auto input_chunks = cudf_streaming::integrations::partition_and_pack(
-        input_table,
-        {1},
-        total_num_partitions,
-        hash_fn,
-        seed,
-        stream,
-        br.get(),
-        rapidsmpf::AllowOverbooking::YES
-    );  // with overbooking
+    // Create one non-empty chunk per partition. Each chunk owns a single device
+    // buffer, so we start with exactly `total_num_partitions` device allocations.
+    std::unordered_map<rapidsmpf::shuffler::PartID, rapidsmpf::PackedData> input_chunks;
+    for (rapidsmpf::shuffler::PartID pid = 0; pid < total_num_partitions; ++pid) {
+        input_chunks.emplace(pid, generate_packed_data(1000, 0, stream, *br));
+    }
 
     // Insert spills does nothing when device memory is available, we start
     // with 2 device allocations.
@@ -675,7 +652,7 @@ TEST_P(ContiguousPartitionAssignmentTest, contiguous) {
 
 TEST(Shuffler, ShutdownWhilePaused) {
     auto progress_thread = GlobalEnvironment->comm_->progress_thread();
-    auto mr = cudf::get_current_device_resource_ref();
+    auto mr = rmm::mr::get_current_device_resource_ref();
 
     auto br = rapidsmpf::BufferResource::create(mr);
 
@@ -692,27 +669,15 @@ TEST(Shuffler, ShutdownWhilePaused) {
     EXPECT_NO_THROW(shuffler.shutdown());
 }
 
-// check cudf pack conditions for empty table
-TEST(EmptyPartitions, cudf_pack) {
-    auto stream = cudf::get_default_stream();
-    cudf::table tbl = random_table_with_index(0, 0, 0, 0);
-    EXPECT_EQ(0, tbl.num_rows());
-
-    // following conditions should be met for an empty cudf table
-    auto packed = cudf::pack(tbl, stream);
-    EXPECT_TRUE(packed.metadata);
-    EXPECT_TRUE(packed.gpu_data);
-    EXPECT_EQ(0, packed.gpu_data->size());
-}
-
-class ExtractEmptyPartitionsTest : public cudf::test::BaseFixture {
+class ExtractEmptyPartitionsTest : public ::testing::Test {
   public:
     static constexpr rapidsmpf::shuffler::PartID nparts = 10;
     static constexpr auto wait_timeout = std::chrono::seconds(30);
 
     void SetUp() override {
-        stream = cudf::get_default_stream();
-        br = rapidsmpf::BufferResource::create(mr());
+        stream = rmm::cuda_stream_default;
+        br =
+            rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
 
         shuffler = std::make_unique<rapidsmpf::shuffler::Shuffler>(
             GlobalEnvironment->comm_, 0, nparts, br.get()
@@ -811,7 +776,8 @@ TEST_F(ExtractEmptyPartitionsTest, SomeEmptyAndNonEmptyInsertions) {
 
 TEST(ShufflerTest, multiple_shutdowns) {
     auto& comm = GlobalEnvironment->comm_;
-    auto br = rapidsmpf::BufferResource::create(cudf::get_current_device_resource_ref());
+    auto br =
+        rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
     auto shuffler = std::make_unique<rapidsmpf::shuffler::Shuffler>(
         comm, 0, comm->nranks(), br.get()
     );
@@ -835,83 +801,44 @@ TEST(ShufflerTest, multiple_shutdowns) {
 // Test that multiple threads can call wait() concurrently.
 TEST(Shuffler, concurrent_wait) {
     auto const& comm = GlobalEnvironment->comm_;
-    auto stream = cudf::get_default_stream();
-    auto br = rapidsmpf::BufferResource::create(cudf::get_current_device_resource_ref());
+    auto br =
+        rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
 
     // Use more partitions than ranks so each rank owns multiple partitions, ensuring
     // multiple threads call wait() concurrently on the same shuffler.
     auto const total_num_partitions =
         rapidsmpf::safe_cast<rapidsmpf::shuffler::PartID>(comm->nranks()) * 8;
     constexpr std::size_t total_num_rows = 1000;
-    constexpr cudf::hash_id hash_fn = cudf::hash_id::HASH_MURMUR3;
-    constexpr std::int64_t seed = 42;
     constexpr auto wait_timeout = std::chrono::seconds{30};
 
     rapidsmpf::shuffler::Shuffler shuffler(comm, 0, total_num_partitions, br.get());
 
-    cudf::table full_input = random_table_with_index(seed, total_num_rows, 0, 10);
-    auto [expected, owner] = cudf_streaming::integrations::partition_and_split(
-        full_input,
-        {1},
-        static_cast<std::int32_t>(total_num_partitions),
-        hash_fn,
-        seed,
-        stream,
-        br.get(),
-        rapidsmpf::AllowOverbooking::YES
-    );
-
+    // Insert each owned input region concurrently, each thread using its own pool stream.
     {
         std::vector<std::future<void>> insert_futures;
-        cudf::size_type row_offset = 0;
-        cudf::size_type part_size =
-            full_input.num_rows() / static_cast<cudf::size_type>(total_num_partitions);
-        for (rapidsmpf::shuffler::PartID i = 0; i < total_num_partitions; ++i) {
-            if (rapidsmpf::shuffler::Shuffler::round_robin(comm, i, total_num_partitions)
-                == comm->rank())
-            {
-                cudf::size_type row_end = row_offset + part_size;
-                if (i == total_num_partitions - 1) {
-                    row_end = full_input.num_rows();
-                }
-                auto slice = cudf::slice(full_input, {row_offset, row_end}).at(0);
-                insert_futures.push_back(std::async(std::launch::async, [&, slice] {
-                    shuffler.insert(
-                        cudf_streaming::integrations::partition_and_pack(
-                            slice,
-                            {1},
-                            static_cast<std::int32_t>(total_num_partitions),
-                            hash_fn,
-                            seed,
-                            br->stream_pool().get_stream(),
-                            br.get(),
-                            rapidsmpf::AllowOverbooking::YES
-                        )
-                    );
-                }));
-            }
-            row_offset += part_size;
+        for (rapidsmpf::shuffler::PartID local_pidx : shuffler.local_partitions()) {
+            insert_futures.push_back(std::async(std::launch::async, [&, local_pidx] {
+                shuffler.insert(make_partition_data(
+                    total_num_partitions,
+                    total_num_rows,
+                    local_pidx,
+                    br->stream_pool().get_stream(),
+                    *br
+                ));
+            }));
         }
         std::ranges::for_each(insert_futures, [](auto& f) { f.get(); });
         shuffler.insert_finished();
     }
 
-    auto local_pids = shuffler.local_partitions();
+    // Wait + extract + validate each local partition concurrently, so multiple threads
+    // call wait() on the same shuffler at once.
     std::vector<std::future<void>> futures;
-    for (auto pid : local_pids) {
-        futures.push_back(std::async(std::launch::async, [&, pid] {
+    for (auto j : shuffler.local_partitions()) {
+        futures.push_back(std::async(std::launch::async, [&, j] {
             EXPECT_NO_THROW(shuffler.wait(wait_timeout));
-            auto chunks = shuffler.extract(pid);
-            auto result = cudf_streaming::integrations::unpack_and_concat(
-                rapidsmpf::unspill_partitions(
-                    std::move(chunks), br.get(), rapidsmpf::AllowOverbooking::YES
-                ),
-                stream,
-                br.get(),
-                rapidsmpf::AllowOverbooking::YES
-            );
-            CUDF_TEST_EXPECT_TABLES_EQUIVALENT(
-                sort_table(result), sort_table(expected[pid])
+            validate_partition_data(
+                shuffler.extract(j), total_num_partitions, total_num_rows, j, *br
             );
         }));
     }
@@ -931,11 +858,10 @@ TEST(Shuffler, opid_reuse) {
         GTEST_SKIP() << "OpID reuse test requires multiple ranks";
     }
 
-    auto stream = cudf::get_default_stream();
+    auto stream = rmm::cuda_stream_default;
     auto const total_num_partitions =
         rapidsmpf::safe_cast<rapidsmpf::shuffler::PartID>(comm->nranks());
     constexpr std::size_t total_num_rows = 1000;
-    constexpr cudf::hash_id hash_fn = cudf::hash_id::HASH_MURMUR3;
     constexpr rapidsmpf::OpID op_id = 0;
     constexpr auto wait_timeout = std::chrono::seconds{30};
 
@@ -953,61 +879,21 @@ TEST(Shuffler, opid_reuse) {
         shuffler_br = delayed_br.get();
     }
 
-    auto insert_data = [&](rapidsmpf::shuffler::Shuffler& shuffler, std::int64_t seed) {
-        cudf::table full_input = random_table_with_index(seed, total_num_rows, 0, 10);
-        cudf::size_type row_offset = 0;
-        cudf::size_type part_size =
-            full_input.num_rows() / static_cast<cudf::size_type>(total_num_partitions);
-        for (rapidsmpf::shuffler::PartID i = 0; i < total_num_partitions; ++i) {
-            if (rapidsmpf::shuffler::Shuffler::round_robin(comm, i, total_num_partitions)
-                == comm->rank())
-            {
-                cudf::size_type row_end = row_offset + part_size;
-                if (i == total_num_partitions - 1) {
-                    row_end = full_input.num_rows();
-                }
-                auto slice = cudf::slice(full_input, {row_offset, row_end}).at(0);
-                auto packed = cudf_streaming::integrations::partition_and_pack(
-                    slice,
-                    {1},
-                    static_cast<std::int32_t>(total_num_partitions),
-                    hash_fn,
-                    seed,
-                    stream,
-                    br.get(),
-                    rapidsmpf::AllowOverbooking::YES
-                );
-                shuffler.insert(std::move(packed));
-            }
-            row_offset += part_size;
+    // Each shuffle uses a distinct base offset (in place of a seed) so the two shuffles
+    // carry different data; a cross-matched message would therefore fail validation.
+    auto insert_data = [&](rapidsmpf::shuffler::Shuffler& shuffler, std::int64_t base) {
+        for (rapidsmpf::shuffler::PartID local_pidx : shuffler.local_partitions()) {
+            shuffler.insert(make_partition_data(
+                total_num_partitions, total_num_rows, local_pidx, stream, *br, base
+            ));
         }
     };
 
     auto validate_results = [&](rapidsmpf::shuffler::Shuffler& shuffler,
-                                std::int64_t seed) {
-        cudf::table full_input = random_table_with_index(seed, total_num_rows, 0, 10);
-        auto [expected, owner] = cudf_streaming::integrations::partition_and_split(
-            full_input,
-            {1},
-            static_cast<std::int32_t>(total_num_partitions),
-            hash_fn,
-            seed,
-            stream,
-            br.get(),
-            rapidsmpf::AllowOverbooking::YES
-        );
-        for (auto pid : shuffler.local_partitions()) {
-            auto chunks = shuffler.extract(pid);
-            auto result = cudf_streaming::integrations::unpack_and_concat(
-                rapidsmpf::unspill_partitions(
-                    std::move(chunks), br.get(), rapidsmpf::AllowOverbooking::YES
-                ),
-                stream,
-                br.get(),
-                rapidsmpf::AllowOverbooking::YES
-            );
-            CUDF_TEST_EXPECT_TABLES_EQUIVALENT(
-                sort_table(result), sort_table(expected[pid])
+                                std::int64_t base) {
+        for (auto j : shuffler.local_partitions()) {
+            validate_partition_data(
+                shuffler.extract(j), total_num_partitions, total_num_rows, j, *br, base
             );
         }
     };
@@ -1039,10 +925,9 @@ TEST(Shuffler, opid_reuse_with_empty_partitions) {
         GTEST_SKIP() << "OpID reuse test requires multiple ranks";
     }
 
-    auto stream = cudf::get_default_stream();
+    auto stream = rmm::cuda_stream_default;
     constexpr rapidsmpf::shuffler::PartID total_num_partitions = 1;
     constexpr std::size_t total_num_rows = 1000;
-    constexpr cudf::hash_id hash_fn = cudf::hash_id::HASH_MURMUR3;
     constexpr rapidsmpf::OpID op_id = 0;
     constexpr auto wait_timeout = std::chrono::seconds{30};
 
@@ -1060,51 +945,23 @@ TEST(Shuffler, opid_reuse_with_empty_partitions) {
         shuffler_br = delayed_br.get();
     }
 
-    auto insert_data = [&](rapidsmpf::shuffler::Shuffler& shuffler, std::int64_t seed) {
-        cudf::table full_input = random_table_with_index(seed, total_num_rows, 0, 10);
-        // With total_num_partitions=1, only rank 0 owns the single partition.
-        if (rapidsmpf::shuffler::Shuffler::round_robin(comm, 0, total_num_partitions)
-            == comm->rank())
-        {
-            auto packed = cudf_streaming::integrations::partition_and_pack(
-                full_input,
-                {1},
-                static_cast<std::int32_t>(total_num_partitions),
-                hash_fn,
-                seed,
-                stream,
-                br.get(),
-                rapidsmpf::AllowOverbooking::YES
-            );
-            shuffler.insert(std::move(packed));
+    // Each shuffle uses a distinct base offset (in place of a seed) so the two shuffles
+    // carry different data; a cross-matched message would therefore fail validation.
+    // With total_num_partitions=1, only rank 0 owns the single partition; all other ranks
+    // have empty local_partitions(), so they insert/validate nothing.
+    auto insert_data = [&](rapidsmpf::shuffler::Shuffler& shuffler, std::int64_t base) {
+        for (rapidsmpf::shuffler::PartID local_pidx : shuffler.local_partitions()) {
+            shuffler.insert(make_partition_data(
+                total_num_partitions, total_num_rows, local_pidx, stream, *br, base
+            ));
         }
     };
 
     auto validate_results = [&](rapidsmpf::shuffler::Shuffler& shuffler,
-                                std::int64_t seed) {
-        cudf::table full_input = random_table_with_index(seed, total_num_rows, 0, 10);
-        auto [expected, owner] = cudf_streaming::integrations::partition_and_split(
-            full_input,
-            {1},
-            static_cast<std::int32_t>(total_num_partitions),
-            hash_fn,
-            seed,
-            stream,
-            br.get(),
-            rapidsmpf::AllowOverbooking::YES
-        );
-        for (auto pid : shuffler.local_partitions()) {
-            auto chunks = shuffler.extract(pid);
-            auto result = cudf_streaming::integrations::unpack_and_concat(
-                rapidsmpf::unspill_partitions(
-                    std::move(chunks), br.get(), rapidsmpf::AllowOverbooking::YES
-                ),
-                stream,
-                br.get(),
-                rapidsmpf::AllowOverbooking::YES
-            );
-            CUDF_TEST_EXPECT_TABLES_EQUIVALENT(
-                sort_table(result), sort_table(expected[pid])
+                                std::int64_t base) {
+        for (auto j : shuffler.local_partitions()) {
+            validate_partition_data(
+                shuffler.extract(j), total_num_partitions, total_num_rows, j, *br, base
             );
         }
     };

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -235,9 +235,13 @@ void test_shuffler(
 
     EXPECT_NO_THROW(shuffler.wait(wait_timeout));
 
-    for (auto j : shuffler.local_partitions()) {
+    for (auto local_pidx : shuffler.local_partitions()) {
         validate_partition_data(
-            shuffler.extract(j), total_num_partitions, total_num_rows, j, *br
+            shuffler.extract(local_pidx),
+            total_num_partitions,
+            total_num_rows,
+            local_pidx,
+            *br
         );
     }
 }

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -110,8 +110,19 @@ namespace {
 
 using MemoryLimitsMap = std::unordered_map<rapidsmpf::MemoryType, std::int64_t>;
 
-// Help function to get the `memory_limits` argument for a `BufferResource`
-// that prioritizes the specified memory type.
+/**
+ * @brief Build a `memory_limits` map for a `BufferResource` that prioritizes one memory
+ * type.
+ *
+ * All memory types are initialised to unlimited. If @p priorities is not
+ * `MemoryType::DEVICE`, the device-memory limit is then set to zero, forcing
+ * the `BufferResource` to allocate exclusively in host memory. Host memory is
+ * never zeroed because it backs metadata and control-message allocations that
+ * must always succeed.
+ *
+ * @param priorities The memory type to keep unlimited (all others are zeroed).
+ * @return A map from each `MemoryType` to its byte limit (`std::int64_t`).
+ */
 MemoryLimitsMap get_memory_limits_map(rapidsmpf::MemoryType priorities) {
     using namespace rapidsmpf;
 
@@ -130,19 +141,35 @@ MemoryLimitsMap get_memory_limits_map(rapidsmpf::MemoryType priorities) {
     return ret;
 }
 
-// Conservation-preserving data model shared by the shuffler round-trip tests.
-//
-// We split the index range [0, total_num_rows) into total_num_partitions^2 contiguous
-// sub-regions via chunk_indices (front-loaded, so when N < P*P the trailing sub-regions
-// are empty). Sub-region (local_pidx, split_idx) is piece k = local_pidx*P + split_idx
-// and is routed to destination partition split_idx; input region local_pidx is the union
-// of its P sub-regions. The pieces exactly tile [0,N), so the total shuffled data == N
-// regardless of rank/partition counts (conservation). A per-shuffle `base` offset is
-// added to every value so distinct shuffles carry distinct data.
+/// Conservation-preserving data model shared by the shuffler round-trip tests.
+///
+/// The index range `[0, total_num_rows)` is split into `total_num_partitions^2`
+/// contiguous sub-regions via `chunk_indices` (front-loaded, so trailing sub-regions
+/// are empty when `N < P*P`). Sub-region `(local_pidx, split_idx)` is piece
+/// `k = local_pidx * P + split_idx` and is routed to destination partition
+/// `split_idx`. The pieces exactly tile `[0, N)`, so the total shuffled row
+/// count equals `N` regardless of rank or partition counts (conservation). A
+/// per-shuffle `base` offset is added to every value so distinct shuffles carry
+/// distinct data.
 
-// Produces the non-empty sub-regions of one owned input region `local_pidx`, keyed by
-// destination partition. Since local_partitions() across ranks partition [0,P), every
-// input region is produced exactly once, so rows are not replicated.
+
+/**
+ * @brief Build the input data for one owned partition region ready for insertion.
+ *
+ * Produces all non-empty sub-regions of the input region `local_pidx`, keyed by
+ * their destination partition. Because `local_partitions()` across all ranks
+ * partitions `[0, P)`, every input region is produced exactly once and rows are
+ * never replicated.
+ *
+ * @param total_num_partitions Total number of shuffle partitions `P`.
+ * @param total_num_rows       Total row count `N` tiled across all sub-regions.
+ * @param local_pidx           Index of the locally-owned input region to generate.
+ * @param stream               CUDA stream used for device allocations.
+ * @param br                   Buffer resource used to allocate packed data.
+ * @param base                 Offset added to every generated value (default 0).
+ * @return Map from destination `PartID` to the corresponding `PackedData` chunk;
+ *         empty sub-regions are omitted.
+ */
 std::unordered_map<rapidsmpf::shuffler::PartID, rapidsmpf::PackedData>
 make_partition_data(
     rapidsmpf::shuffler::PartID total_num_partitions,
@@ -172,8 +199,22 @@ make_partition_data(
     return chunks;
 }
 
-// Verifies that the `received` chunks for partition `j` match the non-empty sub-regions
-// expected for it.
+/**
+ * @brief Verify that received chunks for a partition match the expected sub-regions.
+ *
+ * Recomputes the non-empty `(offset, count)` sub-regions expected for partition
+ * `j` from the same conservation model used by `make_partition_data`, then
+ * checks that @p received contains exactly those chunks (in any order). Chunks
+ * are sorted by their embedded offset before comparison so the validation is
+ * order-independent.
+ *
+ * @param received             Chunks extracted from the shuffler for partition `j`.
+ * @param total_num_partitions Total number of shuffle partitions `P`.
+ * @param total_num_rows       Total row count `N` used to tile sub-regions.
+ * @param j                    Destination partition index being validated.
+ * @param br                   Buffer resource used for unpacking received data.
+ * @param base                 Offset that was added to every generated value (default 0).
+ */
 void validate_partition_data(
     std::vector<rapidsmpf::PackedData> received,
     rapidsmpf::shuffler::PartID total_num_partitions,
@@ -215,12 +256,27 @@ void validate_partition_data(
     }
 }
 
+/**
+ * @brief Execute a full shuffler round-trip and validate every local partition.
+ *
+ * For each locally-owned partition, generates input data with `make_partition_data`,
+ * inserts it into the shuffler, signals insertion completion, then waits (with a
+ * 30-second timeout to catch deadlocks) and validates every received partition
+ * with `validate_partition_data`.
+ *
+ * @param shuffler             The shuffler instance under test.
+ * @param total_num_partitions Total number of shuffle partitions `P`.
+ * @param total_num_rows       Total row count `N` distributed across all sub-regions.
+ * @param stream               CUDA stream used for device allocations.
+ * @param br                   Buffer resource used to allocate and validate data.
+ */
 void test_shuffler(
     rapidsmpf::shuffler::Shuffler& shuffler,
     rapidsmpf::shuffler::PartID total_num_partitions,
     std::size_t total_num_rows,
     rmm::cuda_stream_view stream,
-    rapidsmpf::BufferResource* br
+    rapidsmpf::BufferResource* br,
+    std::int64_t base = 0
 ) {
     // To expose unexpected deadlocks, we use a 30s timeout. In a normal run, the
     // shuffle shouldn't get near 30s.
@@ -228,7 +284,7 @@ void test_shuffler(
 
     for (rapidsmpf::shuffler::PartID local_pidx : shuffler.local_partitions()) {
         shuffler.insert(make_partition_data(
-            total_num_partitions, total_num_rows, local_pidx, stream, *br
+            total_num_partitions, total_num_rows, local_pidx, stream, *br, base
         ));
     }
     shuffler.insert_finished();
@@ -241,7 +297,8 @@ void test_shuffler(
             total_num_partitions,
             total_num_rows,
             local_pidx,
-            *br
+            *br,
+            base
         );
     }
 }
@@ -338,7 +395,8 @@ class ConcurrentShuffleTest : public ::testing::TestWithParam<
             total_num_partitions,
             100'000,  // total_num_rows
             stream,
-            br.get()
+            br.get(),
+            static_cast<std::int64_t>(t_id)
         ));
     }
 

--- a/cpp/tests/utils.hpp
+++ b/cpp/tests/utils.hpp
@@ -36,6 +36,7 @@
 
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
+#include <rapidsmpf/memory/cuda_memcpy_async.hpp>
 #include <rapidsmpf/memory/packed_data.hpp>
 
 /**
@@ -192,58 +193,70 @@ template <typename T>
 /**
  * @brief Generate a packed data object with the given number of elements and offset.
  *
- * Both metadata and GPU data contain the same integer sequence.
+ * Both metadata and GPU data contain the same integer sequence of type T.
  *
+ * @tparam T Element type stored in the buffer (default: int).
  * @param n_elements Number of elements in the sequence.
  * @param offset Starting value of the sequence.
  * @param stream CUDA stream for device allocation.
  * @param br Buffer resource used for allocations.
  * @return A packed data object containing metadata and GPU data.
  */
+template <typename T = int>
 [[nodiscard]] inline rapidsmpf::PackedData generate_packed_data(
-    int n_elements,
-    int offset,
+    std::size_t n_elements,
+    T offset,
     rmm::cuda_stream_view stream,
-    rapidsmpf::BufferResource& br
+    rapidsmpf::BufferResource& br,
+    rapidsmpf::AllowOverbooking allow_overbooking = rapidsmpf::AllowOverbooking::YES
 ) {
-    auto values = iota_vector<int>(n_elements, offset);
+    auto const values = iota_vector<T>(n_elements, offset);
+    auto const* bytes = reinterpret_cast<std::uint8_t const*>(values.data());
 
-    auto metadata = std::make_unique<std::vector<std::uint8_t>>(n_elements * sizeof(int));
-    std::memcpy(metadata->data(), values.data(), n_elements * sizeof(int));
-
-    auto data = std::make_unique<rmm::device_buffer>(
-        values.data(), n_elements * sizeof(int), stream, br.device_mr()
+    auto metadata = std::make_unique<std::vector<std::uint8_t>>(
+        bytes, bytes + values.size() * sizeof(T)
     );
+    auto [reservation, _] =
+        br.reserve(rapidsmpf::MemoryType::DEVICE, metadata->size(), allow_overbooking);
+    auto data = br.make_buffer(stream, std::move(reservation));
 
-    return {std::move(metadata), br.move(std::move(data), stream)};
+    data->write_access([d_ptr = metadata->data(), m_size = metadata->size()](
+                           std::byte* ptr, rmm::cuda_stream_view op_stream
+                       ) {
+        RAPIDSMPF_CUDA_TRY(rapidsmpf::cuda_memcpy_async(ptr, d_ptr, m_size, op_stream));
+    });
+
+    return {std::move(metadata), std::move(data)};
 }
 
 /**
  * @brief Validate a packed data object by checking metadata and GPU data contents.
  *
+ * @tparam T Element type stored in the buffer (default: int).
  * @param packed_data Packed data object to validate.
  * @param n_elements Expected number of elements.
  * @param offset Expected starting value of the sequence.
  * @param stream CUDA stream used for device-host transfers.
  * @param br Buffer resource used for host allocation.
  */
+template <typename T = int>
 inline void validate_packed_data(
     rapidsmpf::PackedData&& packed_data,
-    int n_elements,
-    int offset,
+    std::size_t n_elements,
+    T offset,
     rmm::cuda_stream_view stream,
     rapidsmpf::BufferResource& br
 ) {
     auto const& metadata = *packed_data.metadata;
-    EXPECT_EQ(n_elements * sizeof(int), metadata.size());
+    EXPECT_EQ(n_elements * sizeof(T), metadata.size());
 
-    for (int i = 0; i < n_elements; i++) {
-        int val;
-        std::memcpy(&val, metadata.data() + i * sizeof(int), sizeof(int));
-        EXPECT_EQ(offset + i, val);
+    for (std::size_t i = 0; i < n_elements; i++) {
+        T val;
+        std::memcpy(&val, metadata.data() + i * sizeof(T), sizeof(T));
+        EXPECT_EQ(offset + static_cast<T>(i), val);
     }
 
-    EXPECT_EQ(n_elements * sizeof(int), packed_data.data->size);
+    EXPECT_EQ(n_elements * sizeof(T), packed_data.data->size);
 
     auto res = br.reserve_or_fail(packed_data.data->size, rapidsmpf::MemoryType::HOST);
     auto data_on_host = br.move_to_host_buffer(std::move(packed_data.data), res);

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pyi
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pyi
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
+from rmm.pylibrmm.device_buffer import DeviceBuffer
+from rmm.pylibrmm.stream import Stream
+
 from rapidsmpf.memory.buffer_resource import BufferResource
 
 class PackedData:
@@ -7,5 +10,13 @@ class PackedData:
     @classmethod
     def from_host_bytes(
         cls, data: bytes | bytearray, br: BufferResource
+    ) -> PackedData: ...
+    @classmethod
+    def from_device_buffer(
+        cls,
+        gpu_data: DeviceBuffer,
+        metadata: bytes | bytearray,
+        stream: Stream,
+        br: BufferResource,
     ) -> PackedData: ...
     def to_host_bytes(self) -> bytes: ...

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
@@ -7,6 +7,8 @@ from libcpp.utility cimport move
 from libcpp.vector cimport vector
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
+from rmm.pylibrmm.device_buffer cimport DeviceBuffer
+from rmm.pylibrmm.stream cimport Stream
 
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.memory.buffer_resource cimport (BufferResource,
@@ -57,6 +59,21 @@ cdef extern from *:
         );
     }
 
+    std::unique_ptr<rapidsmpf::PackedData> cpp_packed_data_from_device_buffer(
+        const std::uint8_t* metadata,
+        std::size_t metadata_size,
+        std::unique_ptr<rmm::device_buffer> gpu_data,
+        rmm::cuda_stream_view stream,
+        rapidsmpf::BufferResource* br
+    ) {
+        auto meta = std::make_unique<std::vector<std::uint8_t>>(
+            metadata, metadata + metadata_size
+        );
+        return std::make_unique<rapidsmpf::PackedData>(
+            std::move(meta), br->move(std::move(gpu_data), stream)
+        );
+    }
+
     std::vector<std::uint8_t> cpp_packed_data_to_host_bytes(
         rapidsmpf::PackedData* pd
     ) {
@@ -85,6 +102,14 @@ cdef extern from *:
         size_t size,
         cpp_BufferResource* br,
     ) except + nogil
+
+    unique_ptr[cpp_PackedData] cpp_packed_data_from_device_buffer(
+        const uint8_t* metadata,
+        size_t metadata_size,
+        unique_ptr[device_buffer] gpu_data,
+        cuda_stream_view stream,
+        cpp_BufferResource* br,
+    ) except +ex_handler nogil
 
     vector[uint8_t] cpp_packed_data_to_host_bytes(
         cpp_PackedData* pd,
@@ -138,6 +163,51 @@ cdef class PackedData:
             data_ptr = <const uint8_t*>&data[0]
         with nogil:
             ret.c_obj = cpp_packed_data_from_host_bytes(data_ptr, size, _br)
+        ret._br = br
+        return ret
+
+    @classmethod
+    def from_device_buffer(
+        cls,
+        DeviceBuffer gpu_data not None,
+        const uint8_t[::1] metadata not None,
+        Stream stream not None,
+        BufferResource br not None,
+    ):
+        """
+        Construct a PackedData from an rmm device buffer and host metadata.
+
+        Takes ownership of ``gpu_data``; the input buffer is left empty after this
+        call. The metadata bytes are copied into a host-side metadata buffer.
+
+        Parameters
+        ----------
+        gpu_data
+            Device buffer holding the data payload. Consumed by this call.
+        metadata
+            Contiguous buffer of host bytes (bytes, bytearray, or buffer-protocol
+            object). Must be non-empty.
+        stream
+            CUDA stream used to take ownership of the device buffer.
+        br
+            Buffer resource for memory management.
+
+        Returns
+        -------
+        A new PackedData instance owning the device buffer.
+        """
+        cdef cpp_BufferResource* _br = br.ptr()
+        cdef size_t meta_size = len(metadata)
+        cdef const uint8_t* meta_ptr = NULL
+        if meta_size > 0:
+            meta_ptr = <const uint8_t*>&metadata[0]
+        cdef cuda_stream_view sv = stream.view()
+        cdef unique_ptr[device_buffer] gpu = move(gpu_data.c_obj)
+        cdef PackedData ret = cls.__new__(cls)
+        with nogil:
+            ret.c_obj = cpp_packed_data_from_device_buffer(
+                meta_ptr, meta_size, move(gpu), sv, _br
+            )
         ret._br = br
         return ret
 

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyi
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyi
@@ -2,21 +2,33 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Self
 
 from rapidsmpf.memory.buffer_resource import BufferResource
+from rapidsmpf.memory.packed_data import PackedData
 from rapidsmpf.streaming.core.message import Message
 
 class PartitionMapChunk:
     @classmethod
-    def from_message(
-        cls: type[Self], message: Message[Self], br: BufferResource
+    def from_packed_data_map(
+        cls: type[Self], data: Mapping[int, PackedData], br: BufferResource
     ) -> Self: ...
-    def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...
-
-class PartitionVectorChunk:
     @classmethod
     def from_message(
         cls: type[Self], message: Message[Self], br: BufferResource
     ) -> Self: ...
+    def to_packed_data_map(self) -> dict[int, PackedData]: ...
+    def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...
+
+class PartitionVectorChunk:
+    @classmethod
+    def from_packed_data_list(
+        cls: type[Self], data: Sequence[PackedData], br: BufferResource
+    ) -> Self: ...
+    @classmethod
+    def from_message(
+        cls: type[Self], message: Message[Self], br: BufferResource
+    ) -> Self: ...
+    def to_packed_data_list(self) -> list[PackedData]: ...
     def into_message(self, sequence_number: int, message: Message[Self]) -> None: ...

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
-from libc.stdint cimport uint64_t
+from libc.stdint cimport uint32_t, uint64_t
 from libcpp.memory cimport make_unique, unique_ptr
 from libcpp.utility cimport move
+from libcpp.vector cimport vector
 
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.memory.buffer_resource cimport BufferResource
+from rapidsmpf.memory.packed_data cimport PackedData, cpp_PackedData
 from rapidsmpf.streaming.core.message cimport Message, cpp_Message
 
 
@@ -19,6 +21,72 @@ cdef extern from "<rapidsmpf/streaming/chunks/partition.hpp>" nogil:
         except +ex_handler
 
 
+# Move PackedData into a chunk's container. We implement these in C++ because
+# PackedData doesn't have a default ctor.
+cdef extern from * nogil:
+    """
+    namespace {
+    void cpp_insert_into_partition_map(
+        rapidsmpf::streaming::PartitionMapChunk* chunk,
+        std::uint32_t pid,
+        std::unique_ptr<rapidsmpf::PackedData> packed_data
+    ) {
+        chunk->data.emplace(pid, std::move(*packed_data));
+    }
+
+    void cpp_append_to_partition_vector(
+        rapidsmpf::streaming::PartitionVectorChunk* chunk,
+        std::unique_ptr<rapidsmpf::PackedData> packed_data
+    ) {
+        chunk->data.push_back(std::move(*packed_data));
+    }
+
+    void cpp_drain_partition_map(
+        rapidsmpf::streaming::PartitionMapChunk* chunk,
+        std::vector<std::uint32_t>& keys,
+        std::vector<std::unique_ptr<rapidsmpf::PackedData>>& values
+    ) {
+        keys.reserve(chunk->data.size());
+        values.reserve(chunk->data.size());
+        for (auto& [pid, pd] : chunk->data) {
+            keys.push_back(pid);
+            values.push_back(std::make_unique<rapidsmpf::PackedData>(std::move(pd)));
+        }
+        chunk->data.clear();
+    }
+
+    void cpp_drain_partition_vector(
+        rapidsmpf::streaming::PartitionVectorChunk* chunk,
+        std::vector<std::unique_ptr<rapidsmpf::PackedData>>& values
+    ) {
+        values.reserve(chunk->data.size());
+        for (auto& pd : chunk->data) {
+            values.push_back(std::make_unique<rapidsmpf::PackedData>(std::move(pd)));
+        }
+        chunk->data.clear();
+    }
+    }  // namespace
+    """
+    void cpp_insert_into_partition_map(
+        cpp_PartitionMapChunk* chunk,
+        uint32_t pid,
+        unique_ptr[cpp_PackedData] packed_data,
+    ) except +ex_handler
+    void cpp_append_to_partition_vector(
+        cpp_PartitionVectorChunk* chunk,
+        unique_ptr[cpp_PackedData] packed_data,
+    ) except +ex_handler
+    void cpp_drain_partition_map(
+        cpp_PartitionMapChunk* chunk,
+        vector[uint32_t]& keys,
+        vector[unique_ptr[cpp_PackedData]]& values,
+    ) except +ex_handler
+    void cpp_drain_partition_vector(
+        cpp_PartitionVectorChunk* chunk,
+        vector[unique_ptr[cpp_PackedData]]& values,
+    ) except +ex_handler
+
+
 cdef class PartitionMapChunk:
     def __init__(self):
         raise ValueError("use the `from_*` factory functions")
@@ -26,6 +94,62 @@ cdef class PartitionMapChunk:
     def __dealloc__(self):
         with nogil:
             self._handle.reset()
+
+    @staticmethod
+    def from_packed_data_map(dict data not None, BufferResource br not None):
+        """
+        Construct a PartitionMapChunk from a mapping of partition ID to PackedData.
+
+        Parameters
+        ----------
+        data
+            Mapping of partition ID to the
+            :class:`~rapidsmpf.memory.packed_data.PackedData` it holds. Each PackedData
+            is consumed and left empty after this call.
+        br
+            Buffer resource kept alive for the lifetime of the chunk.
+
+        Returns
+        -------
+        A new PartitionMapChunk owning the given packed data.
+
+        Raises
+        ------
+        ValueError
+            If any of the provided PackedData objects is empty.
+        """
+        cdef unique_ptr[cpp_PartitionMapChunk] handle = make_unique[
+            cpp_PartitionMapChunk
+        ]()
+        cdef uint32_t pid
+        cdef PackedData pd
+        for key, value in data.items():
+            pid = key
+            pd = <PackedData?>value
+            if not pd.c_obj:
+                raise ValueError("PackedData was empty")
+            cpp_insert_into_partition_map(handle.get(), pid, move(pd.c_obj))
+        return PartitionMapChunk.from_handle(move(handle), br)
+
+    def to_packed_data_map(self):
+        """
+        Extract the partition data as a mapping of partition ID to PackedData.
+
+        The chunk is drained and left empty after this call.
+
+        Returns
+        -------
+        A dict mapping partition ID to the
+        :class:`~rapidsmpf.memory.packed_data.PackedData` it holds.
+        """
+        cdef vector[uint32_t] keys
+        cdef vector[unique_ptr[cpp_PackedData]] values
+        cpp_drain_partition_map(self._handle.get(), keys, values)
+        cdef dict ret = {}
+        cdef size_t i
+        for i in range(values.size()):
+            ret[keys[i]] = PackedData.from_librapidsmpf(move(values[i]), self._br)
+        return ret
 
     @staticmethod
     cdef PartitionMapChunk from_handle(
@@ -146,6 +270,58 @@ cdef class PartitionVectorChunk:
     def __dealloc__(self):
         with nogil:
             self._handle.reset()
+
+    @staticmethod
+    def from_packed_data_list(list data not None, BufferResource br not None):
+        """
+        Construct a PartitionVectorChunk from a sequence of PackedData.
+
+        Parameters
+        ----------
+        data
+            Sequence of :class:`~rapidsmpf.memory.packed_data.PackedData` objects,
+            stored in order. Each PackedData is consumed and left empty after this
+            call.
+        br
+            Buffer resource kept alive for the lifetime of the chunk.
+
+        Returns
+        -------
+        A new PartitionVectorChunk owning the given packed data.
+
+        Raises
+        ------
+        ValueError
+            If any of the provided PackedData objects is empty.
+        """
+        cdef unique_ptr[cpp_PartitionVectorChunk] handle = make_unique[
+            cpp_PartitionVectorChunk
+        ]()
+        cdef PackedData pd
+        for value in data:
+            pd = <PackedData?>value
+            if not pd.c_obj:
+                raise ValueError("PackedData was empty")
+            cpp_append_to_partition_vector(handle.get(), move(pd.c_obj))
+        return PartitionVectorChunk.from_handle(move(handle), br)
+
+    def to_packed_data_list(self):
+        """
+        Extract the partition data as a list of PackedData.
+
+        The chunk is drained and left empty after this call.
+
+        Returns
+        -------
+        A list of :class:`~rapidsmpf.memory.packed_data.PackedData`, in order.
+        """
+        cdef vector[unique_ptr[cpp_PackedData]] values
+        cpp_drain_partition_vector(self._handle.get(), values)
+        cdef list ret = []
+        cdef size_t i
+        for i in range(values.size()):
+            ret.append(PackedData.from_librapidsmpf(move(values[i]), self._br))
+        return ret
 
     @staticmethod
     cdef PartitionVectorChunk from_handle(

--- a/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/chunks/partition.pyx
@@ -96,7 +96,7 @@ cdef class PartitionMapChunk:
             self._handle.reset()
 
     @staticmethod
-    def from_packed_data_map(dict data not None, BufferResource br not None):
+    def from_packed_data_map(data not None, BufferResource br not None):
         """
         Construct a PartitionMapChunk from a mapping of partition ID to PackedData.
 
@@ -272,7 +272,7 @@ cdef class PartitionVectorChunk:
             self._handle.reset()
 
     @staticmethod
-    def from_packed_data_list(list data not None, BufferResource br not None):
+    def from_packed_data_list(data not None, BufferResource br not None):
         """
         Construct a PartitionVectorChunk from a sequence of PackedData.
 

--- a/python/rapidsmpf/rapidsmpf/testing.py
+++ b/python/rapidsmpf/rapidsmpf/testing.py
@@ -127,7 +127,8 @@ def generate_packed_data(
     A ``PackedData`` containing the integer sequence.
     """
     data = np.arange(offset, offset + n_elements, dtype=_DTYPE).tobytes()
-    gpu_data = rmm.DeviceBuffer.to_device(data, stream=stream)
+    gpu_data = rmm.DeviceBuffer(size=len(data), stream=stream, mr=br.device_mr)
+    gpu_data.copy_from_host(data, stream=stream)
     return PackedData.from_device_buffer(gpu_data, data, stream, br)
 
 

--- a/python/rapidsmpf/rapidsmpf/testing.py
+++ b/python/rapidsmpf/rapidsmpf/testing.py
@@ -6,12 +6,22 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pylibcudf
 
+import rmm
 from rmm.pylibrmm.stream import DEFAULT_STREAM
+
+from rapidsmpf.memory.packed_data import PackedData
 
 if TYPE_CHECKING:
     from rmm.pylibrmm.stream import Stream
+
+    from rapidsmpf.memory.buffer_resource import BufferResource
+
+# Element type stored in the synthetic packed payloads. Values are wide enough
+# that any per-shuffle ``base`` offsets used by callers never collide.
+_DTYPE = np.int64
 
 
 def assert_eq(
@@ -63,3 +73,178 @@ def assert_eq(
         )
     if not pylibcudf.table_equality.tables_equal(left, right, stream=stream):
         raise AssertionError(f"Table are not equal with {sort_rows=}")
+
+
+def chunk_indices(count: int, num_chunks: int) -> list[tuple[int, int]]:
+    """
+    Split ``[0, count)`` into ``num_chunks`` contiguous, front-loaded pieces.
+
+    Mirrors ``rapidsmpf::chunk_indices``: when ``count < num_chunks`` the trailing
+    pieces are empty (``start == end``). The returned pieces exactly tile
+    ``[0, count)``.
+
+    Parameters
+    ----------
+    count
+        Size of the range to split.
+    num_chunks
+        Number of pieces to split the range into.
+
+    Returns
+    -------
+    A list of ``(start, end)`` pairs, one per chunk.
+    """
+    chunk_size = -(-count // num_chunks)  # ceil division
+    return [
+        (min(k * chunk_size, count), min((k + 1) * chunk_size, count))
+        for k in range(num_chunks)
+    ]
+
+
+def generate_packed_data(
+    n_elements: int, offset: int, stream: Stream, br: BufferResource
+) -> PackedData:
+    """
+    Build a ``PackedData`` holding the int sequence ``[offset, offset + n_elements)``.
+
+    The sequence is stored as a device buffer payload (and mirrored in the metadata)
+    so it survives a shuffle round-trip and can be validated by
+    :func:`validate_packed_data`.
+
+    Parameters
+    ----------
+    n_elements
+        Number of elements in the sequence.
+    offset
+        Starting value of the sequence.
+    stream
+        CUDA stream used for the device allocation.
+    br
+        Buffer resource used for memory management.
+
+    Returns
+    -------
+    A ``PackedData`` containing the integer sequence.
+    """
+    data = np.arange(offset, offset + n_elements, dtype=_DTYPE).tobytes()
+    gpu_data = rmm.DeviceBuffer.to_device(data, stream=stream)
+    return PackedData.from_device_buffer(gpu_data, data, stream, br)
+
+
+def validate_packed_data(packed_data: PackedData, n_elements: int, offset: int) -> None:
+    """
+    Check that ``packed_data`` holds the sequence ``[offset, offset + n_elements)``.
+
+    Parameters
+    ----------
+    packed_data
+        Packed data to validate.
+    n_elements
+        Expected number of elements.
+    offset
+        Expected starting value of the sequence.
+    """
+    values = np.frombuffer(packed_data.to_host_bytes(), dtype=_DTYPE)
+    np.testing.assert_array_equal(
+        values, np.arange(offset, offset + n_elements, dtype=_DTYPE)
+    )
+
+
+def make_partition_data(
+    total_num_partitions: int,
+    total_num_rows: int,
+    local_pid: int,
+    stream: Stream,
+    br: BufferResource,
+    base: int = 0,
+) -> dict[int, PackedData]:
+    """
+    Produce the non-empty sub-regions of one owned input region ``local_pid``.
+
+    The index range ``[0, total_num_rows)`` is split into ``P * P`` contiguous
+    sub-regions (``P == total_num_partitions``). Sub-region ``(local_pid,
+    split_idx)`` is piece ``local_pid * P + split_idx`` and is routed to
+    destination partition ``split_idx``. Since ``local_partitions()`` across ranks
+    partition ``[0, P)``, every input region is produced exactly once, so rows are
+    not replicated and the total shuffled data equals ``total_num_rows``.
+
+    Parameters
+    ----------
+    total_num_partitions
+        Total number of partitions in the shuffle.
+    total_num_rows
+        Total number of rows tiled across all input regions.
+    local_pid
+        Index of the owned input region to produce.
+    stream
+        CUDA stream used for device allocations.
+    br
+        Buffer resource used for memory management.
+    base
+        Offset added to every value so distinct shuffles carry distinct data.
+
+    Returns
+    -------
+    A map of destination partition ID to its packed sub-region.
+    """
+    P = total_num_partitions
+    pieces = chunk_indices(total_num_rows, P * P)
+
+    chunks: dict[int, PackedData] = {}
+    for split_idx in range(P):
+        start, end = pieces[local_pid * P + split_idx]
+        if end > start:
+            chunks[split_idx] = generate_packed_data(
+                end - start, base + start, stream, br
+            )
+    return chunks
+
+
+def validate_partition_data(
+    received: list[PackedData],
+    total_num_partitions: int,
+    total_num_rows: int,
+    local_pid: int,
+    base: int = 0,
+) -> None:
+    """
+    Verify that the ``received`` chunks for partition ``local_pid`` are as expected.
+
+    Checks the chunks against the non-empty sub-regions expected for partition
+    ``local_pid`` under the conserved, front-loaded data model of
+    :func:`make_partition_data`.
+
+    Parameters
+    ----------
+    received
+        The packed data chunks extracted for partition ``local_pid``.
+    total_num_partitions
+        Total number of partitions in the shuffle.
+    total_num_rows
+        Total number of rows tiled across all input regions.
+    local_pid
+        Partition ID being validated.
+    base
+        Offset that was added to every value when the data was generated.
+    """
+    P = total_num_partitions
+    pieces = chunk_indices(total_num_rows, P * P)
+
+    # Recompute the non-empty (offset, count) sub-regions expected for partition
+    # local_pid, in increasing input-region-index (== increasing offset) order.
+    expected: list[tuple[int, int]] = []
+    for i in range(P):
+        start, end = pieces[i * P + local_pid]
+        if end > start:
+            expected.append((base + start, end - start))
+
+    assert len(received) == len(expected)
+
+    # Decode each received chunk and sort by its first element (== offset) so they
+    # align 1:1 with the expected list, which is already in offset order.
+    decoded = sorted(
+        (np.frombuffer(pd.to_host_bytes(), dtype=_DTYPE) for pd in received),
+        key=lambda arr: int(arr[0]),
+    )
+    for arr, (off, cnt) in zip(decoded, expected, strict=True):
+        np.testing.assert_array_equal(arr, np.arange(off, off + cnt, dtype=_DTYPE))

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
@@ -6,19 +6,33 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 
+from rapidsmpf.shuffler import PartitionAssignment
+from rapidsmpf.streaming.chunks.partition import (
+    PartitionMapChunk,
+    PartitionVectorChunk,
+)
 from rapidsmpf.streaming.coll.shuffler import ShufflerAsync
+from rapidsmpf.streaming.core.actor import define_actor, run_actor_network
+from rapidsmpf.streaming.core.leaf_actor import pull_from_channel
+from rapidsmpf.streaming.core.message import Message
 from rapidsmpf.testing import (
     generate_packed_data,
     make_partition_data,
+    validate_packed_data,
     validate_partition_data,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from rmm.pylibrmm.stream import Stream
 
     from rapidsmpf.communicator.communicator import Communicator
+    from rapidsmpf.streaming.core.actor import CppActor
+    from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
 
 
@@ -95,3 +109,163 @@ def test_shuffler_insert_wait_extract(
 
     assert n_chunks_received == n_inserts * len(local_pids) * comm.nranks
     assert finished_pids == local_pids
+
+
+@define_actor()
+async def generate_inputs(
+    context: Context,
+    ch: Channel[PartitionMapChunk],
+    num_rows: int,
+    num_chunks: int,
+    num_partitions: int,
+) -> None:
+    br = context.br()
+    for i in range(num_chunks):
+        stream = context.get_stream_from_pool()
+        data = {
+            pid: generate_packed_data(
+                num_rows, (i * num_partitions + pid) * num_rows, stream, br
+            )
+            for pid in range(num_partitions)
+        }
+        msg = Message(i, PartitionMapChunk.from_packed_data_map(data, br))
+        await ch.send(context, msg)
+    await ch.drain(context)
+
+
+@define_actor()
+async def do_shuffle(
+    context: Context,
+    comm: Communicator,
+    ch_in: Channel[PartitionMapChunk],
+    ch_out: Channel[PartitionVectorChunk],
+    op_id: int,
+    num_partitions: int,
+    *,
+    partition_assignment: PartitionAssignment = PartitionAssignment.ROUND_ROBIN,
+) -> None:
+    shuffle = ShufflerAsync(
+        context, comm, op_id, num_partitions, partition_assignment=partition_assignment
+    )
+    while (msg := await ch_in.recv(context)) is not None:
+        chunk = PartitionMapChunk.from_message(msg, br=context.br())
+        shuffle.insert(chunk.to_packed_data_map())
+    await shuffle.insert_finished(context)
+    for pid in shuffle.local_partitions():
+        data = shuffle.extract(pid)
+        out_chunk = PartitionVectorChunk.from_packed_data_list(data, context.br())
+        await ch_out.send(context, Message(pid, out_chunk))
+    await ch_out.drain(context)
+
+
+@pytest.mark.parametrize("num_partitions", [4, 8])
+def test_shuffler_runtime_obeys_contiguous_assignment(
+    context: Context,
+    comm: Communicator,
+    num_partitions: int,
+) -> None:
+    if comm.nranks != 1:
+        pytest.skip("Only support single-rank runs")
+
+    actors: list[CppActor | Awaitable[None]] = []
+
+    num_rows = 200
+    num_chunks = 3
+    op_id = 0
+    ch_in: Channel[PartitionMapChunk] = context.create_channel()
+    actors.append(generate_inputs(context, ch_in, num_rows, num_chunks, num_partitions))
+    ch_shuffled: Channel[PartitionVectorChunk] = context.create_channel()
+    actors.append(
+        do_shuffle(
+            context,
+            comm,
+            ch_in,
+            ch_shuffled,
+            op_id,
+            num_partitions,
+            partition_assignment=PartitionAssignment.CONTIGUOUS,
+        )
+    )
+    actor, deferred = pull_from_channel(context, ch_shuffled)
+    actors.append(actor)
+
+    run_actor_network(context, actors=actors)
+    messages = deferred.release()
+    received_pids = [msg.sequence_number for msg in messages]
+
+    # Single rank, so every partition is local to this rank.
+    assert set(received_pids) == set(range(num_partitions))
+
+    # Validate the data routed to each local partition. Across the ``num_chunks``
+    # inputs, partition ``pid`` receives the packed sequence ``generate_inputs``
+    # produced for ``(chunk i, pid)``, which starts at value
+    # ``(i * num_partitions + pid) * num_rows``. The shuffler makes no ordering
+    # guarantee, so match each received chunk to its expected input by start value.
+    for msg in messages:
+        pid = msg.sequence_number
+        packed = PartitionVectorChunk.from_message(
+            msg, br=context.br()
+        ).to_packed_data_list()
+        assert len(packed) == num_chunks
+        by_offset = {
+            int(np.frombuffer(pd.to_host_bytes(), dtype=np.int64)[0]): pd
+            for pd in packed
+        }
+        for i in range(num_chunks):
+            offset = (i * num_partitions + pid) * num_rows
+            validate_packed_data(by_offset[offset], num_rows, offset)
+
+
+def test_shuffler_object_interface(
+    context: Context,
+    comm: Communicator,
+) -> None:
+    if comm.nranks != 1:
+        pytest.skip("Only support single-rank runs")
+    actors: list[CppActor | Awaitable[None]] = []
+
+    num_partitions = 5
+    num_rows = 100
+    num_chunks = 4
+    op_id = 0
+    ch_in: Channel[PartitionMapChunk] = context.create_channel()
+    actors.append(generate_inputs(context, ch_in, num_rows, num_chunks, num_partitions))
+    ch_shuffled: Channel[PartitionVectorChunk] = context.create_channel()
+    actors.append(
+        do_shuffle(
+            context,
+            comm,
+            ch_in,
+            ch_shuffled,
+            op_id,
+            num_partitions,
+        )
+    )
+    actor, deferred = pull_from_channel(context, ch_shuffled)
+    actors.append(actor)
+
+    run_actor_network(context, actors=actors)
+    messages = deferred.release()
+    # TODO: single rank only assertions
+    assert len(messages) == num_partitions
+    assert [msg.sequence_number for msg in messages] == list(range(num_partitions))
+    chunks = [
+        (msg.sequence_number, PartitionVectorChunk.from_message(msg, br=context.br()))
+        for msg in messages
+    ]
+
+    # Each destination partition ``pid`` receives, across the ``num_chunks`` inputs,
+    # the packed sequence generated by ``generate_inputs`` for ``(chunk i, pid)``,
+    # which starts at value ``(i * num_partitions + pid) * num_rows``. The shuffler
+    # makes no ordering guarantee, so match each received chunk to its expected
+    # input chunk by starting value.
+    for pid, vec_chunk in chunks:
+        packed = vec_chunk.to_packed_data_list()
+        assert len(packed) == num_chunks
+        by_offset = {
+            int(np.frombuffer(pd.to_host_bytes(), dtype=np.int64)[0]): pd
+            for pd in packed
+        }
+        for i in range(num_chunks):
+            offset = (i * num_partitions + pid) * num_rows
+            validate_packed_data(by_offset[offset], num_rows, offset)

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
@@ -14,7 +14,7 @@ from rapidsmpf.streaming.chunks.partition import (
     PartitionMapChunk,
     PartitionVectorChunk,
 )
-from rapidsmpf.streaming.coll.shuffler import ShufflerAsync
+from rapidsmpf.streaming.coll.shuffler import ShufflerAsync, shuffler
 from rapidsmpf.streaming.core.actor import define_actor, run_actor_network
 from rapidsmpf.streaming.core.leaf_actor import pull_from_channel
 from rapidsmpf.streaming.core.message import Message
@@ -133,31 +133,6 @@ async def generate_inputs(
     await ch.drain(context)
 
 
-@define_actor()
-async def do_shuffle(
-    context: Context,
-    comm: Communicator,
-    ch_in: Channel[PartitionMapChunk],
-    ch_out: Channel[PartitionVectorChunk],
-    op_id: int,
-    num_partitions: int,
-    *,
-    partition_assignment: PartitionAssignment = PartitionAssignment.ROUND_ROBIN,
-) -> None:
-    shuffle = ShufflerAsync(
-        context, comm, op_id, num_partitions, partition_assignment=partition_assignment
-    )
-    while (msg := await ch_in.recv(context)) is not None:
-        chunk = PartitionMapChunk.from_message(msg, br=context.br())
-        shuffle.insert(chunk.to_packed_data_map())
-    await shuffle.insert_finished(context)
-    for pid in shuffle.local_partitions():
-        data = shuffle.extract(pid)
-        out_chunk = PartitionVectorChunk.from_packed_data_list(data, context.br())
-        await ch_out.send(context, Message(pid, out_chunk))
-    await ch_out.drain(context)
-
-
 @pytest.mark.parametrize("num_partitions", [4, 8])
 def test_shuffler_runtime_obeys_contiguous_assignment(
     context: Context,
@@ -176,7 +151,7 @@ def test_shuffler_runtime_obeys_contiguous_assignment(
     actors.append(generate_inputs(context, ch_in, num_rows, num_chunks, num_partitions))
     ch_shuffled: Channel[PartitionVectorChunk] = context.create_channel()
     actors.append(
-        do_shuffle(
+        shuffler(
             context,
             comm,
             ch_in,
@@ -232,7 +207,7 @@ def test_shuffler_object_interface(
     actors.append(generate_inputs(context, ch_in, num_rows, num_chunks, num_partitions))
     ch_shuffled: Channel[PartitionVectorChunk] = context.create_channel()
     actors.append(
-        do_shuffle(
+        shuffler(
             context,
             comm,
             ch_in,

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
@@ -3,290 +3,95 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
-import cupy as cp
-import numpy as np
-import pylibcudf as plc
 import pytest
 
-pytest.importorskip("cudf_streaming")
-from cudf_streaming.integrations.partition import split_and_pack, unpack_and_concat
-from cudf_streaming.streaming.partition import (
-    partition_and_pack,
-    unpack_and_concat as streaming_unpack_and_concat,
+from rapidsmpf.streaming.coll.shuffler import ShufflerAsync
+from rapidsmpf.testing import (
+    generate_packed_data,
+    make_partition_data,
+    validate_partition_data,
 )
-from cudf_streaming.streaming.table_chunk import TableChunk
-
-from rapidsmpf.shuffler import PartitionAssignment
-from rapidsmpf.streaming.coll.shuffler import (
-    ShufflerAsync,
-    shuffler,
-)
-from rapidsmpf.streaming.core.actor import define_actor, run_actor_network
-from rapidsmpf.streaming.core.leaf_actor import pull_from_channel, push_to_channel
-from rapidsmpf.streaming.core.message import Message
-from rapidsmpf.testing import assert_eq
-
-cudf = pytest.importorskip("cudf")
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
-
     from rmm.pylibrmm.stream import Stream
 
     from rapidsmpf.communicator.communicator import Communicator
-    from rapidsmpf.streaming.chunks.partition import (
-        PartitionMapChunk,
-        PartitionVectorChunk,
-    )
-    from rapidsmpf.streaming.core.actor import CppActor
-    from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
 
 
-@pytest.mark.parametrize("num_partitions", [1, 2, 3, 10])
-def test_single_rank_shuffler(
-    context: Context, comm: Communicator, stream: Stream, num_partitions: int
-) -> None:
-    if comm.nranks != 1:
-        pytest.skip("Only support single-rank runs")
-
-    num_rows = 1000
-    num_chunks = 5
-    chunk_size = num_rows // num_chunks
-    op_id = 0
-    # We start a full dataframe.
-    df = plc.Table(
-        [
-            plc.Column.from_array(cp.arange(num_rows, dtype=cp.int32)),
-            plc.Column.from_array(
-                cp.random.randint(0, 10, size=num_rows, dtype=cp.int32)
-            ),
-        ]
-    )
-
-    # That we slice into chunks and wrap as TableChunk (sequence_number=i).
-    input_chunks: list[Message[TableChunk]] = []
-    for i in range(num_chunks):
-        lo = i * chunk_size
-        hi = (i + 1) * chunk_size
-        df_chunk = plc.copying.slice(df, [lo, hi])[0]
-        chunk = TableChunk.from_pylibcudf_table(
-            table=df_chunk,
-            stream=stream,
-            exclusive_view=False,
-            br=context.br(),
-        )
-        input_chunks.append(Message(i, chunk))
-
-    # Build the streaming pipeline:
-    #   push -> partition/pack -> shuffle -> unpack/concat -> pull.
-    actors = []
-
-    ch1: Channel[TableChunk] = context.create_channel()
-    actors.append(push_to_channel(context, ch1, input_chunks))
-
-    ch2: Channel[PartitionMapChunk] = context.create_channel()
-    actors.append(
-        partition_and_pack(
-            context,
-            ch_in=ch1,
-            ch_out=ch2,
-            columns_to_hash=(1,),
-            num_partitions=num_partitions,
-        )
-    )
-
-    ch3: Channel[PartitionVectorChunk] = context.create_channel()
-    actors.append(
-        shuffler(
-            context,
-            comm,
-            ch_in=ch2,
-            ch_out=ch3,
-            op_id=op_id,
-            total_num_partitions=num_partitions,
-        )
-    )
-
-    ch4: Channel[TableChunk] = context.create_channel()
-    actors.append(streaming_unpack_and_concat(context, ch_in=ch3, ch_out=ch4))
-
-    pull_actor, out_messages = pull_from_channel(context, ch_in=ch4)
-    actors.append(pull_actor)
-
-    run_actor_network(context, actors=actors)
-
-    output_chunks = [
-        TableChunk.from_message(msg, br=context.br()) for msg in out_messages.release()
-    ]
-
-    result = plc.concatenate.concatenate(
-        [chunk.table_view() for chunk in output_chunks]
-    )
-    assert_eq(result, df, sort_rows=0)
-
-
-@define_actor()
-async def generate_inputs(
-    context: Context, ch: Channel[TableChunk], num_rows: int, num_chunks: int
-) -> None:
-    for i in range(num_chunks):
-        stream = context.get_stream_from_pool()
-        table = plc.Table(
-            [
-                plc.Column.from_array(
-                    np.arange(num_rows, dtype=np.int32) + i * num_rows, stream=stream
-                )
-            ]
-        )
-        msg = Message(
-            i,
-            TableChunk.from_pylibcudf_table(
-                table, stream, exclusive_view=True, br=context.br()
-            ),
-        )
-        await ch.send(context, msg)
-    await ch.drain(context)
-
-
-@define_actor()
-async def do_shuffle(
+@pytest.mark.parametrize("total_num_partitions", [1, 2, 5, 10])
+@pytest.mark.parametrize("total_num_rows", [1, 100, 1000])
+def test_shuffler_round_trip(
     context: Context,
     comm: Communicator,
-    ch_in: Channel[TableChunk],
-    ch_out: Channel[TableChunk],
-    op_id: int,
-    num_partitions: int,
-    *,
-    partition_assignment: PartitionAssignment = PartitionAssignment.ROUND_ROBIN,
+    stream: Stream,
+    total_num_partitions: int,
+    total_num_rows: int,
 ) -> None:
-    shuffle = ShufflerAsync(
-        context, comm, op_id, num_partitions, partition_assignment=partition_assignment
-    )
-    while (msg := await ch_in.recv(context)) is not None:
-        chunk = TableChunk.from_message(msg, br=context.br())
-        num_rows = chunk.table_view().num_rows()
-        part_size = num_rows // num_partitions + (num_rows % num_partitions)
-        splits = range(part_size, num_rows, part_size)
-        shuffle.insert(
-            split_and_pack(chunk.table_view(), splits, chunk.stream, context.br())
+    """
+    End-to-end correctness of the async streaming shuffler.
+
+    Each rank inserts the input regions it owns and, after shuffling, every local
+    partition is validated against the conserved data model.
+    """
+    br = context.br()
+    shuffler = ShufflerAsync(context, comm, 0, total_num_partitions)
+
+    for local_pidx in shuffler.local_partitions():
+        chunks = make_partition_data(
+            total_num_partitions, total_num_rows, local_pidx, stream, br
         )
-    await shuffle.insert_finished(context)
-    for pid in shuffle.local_partitions():
-        data = shuffle.extract(pid)
-        stream = context.get_stream_from_pool()
-        unpacked = TableChunk.from_pylibcudf_table(
-            unpack_and_concat(data, stream, context.br()),
-            stream,
-            exclusive_view=True,
-            br=context.br(),
+        if chunks:
+            shuffler.insert(chunks)
+
+    asyncio.run(shuffler.insert_finished(context))
+
+    for local_pidx in shuffler.local_partitions():
+        validate_partition_data(
+            shuffler.extract(local_pidx),
+            total_num_partitions,
+            total_num_rows,
+            local_pidx,
         )
-        await ch_out.send(context, Message(pid, unpacked))
-    await ch_out.drain(context)
 
 
-@pytest.mark.parametrize("num_partitions", [4, 8])
-def test_shuffler_runtime_obeys_contiguous_assignment(
+@pytest.mark.parametrize("n_inserts", [1, 10])
+@pytest.mark.parametrize("n_partitions", [1, 10, 100])
+def test_shuffler_insert_wait_extract(
     context: Context,
     comm: Communicator,
-    num_partitions: int,
+    stream: Stream,
+    n_inserts: int,
+    n_partitions: int,
 ) -> None:
-    if comm.nranks != 1:
-        pytest.skip("Only support single-rank runs")
+    """
+    Each rank inserts ``n_inserts`` full partition maps; after shuffling each local
+    partition must receive exactly ``n_inserts * nranks`` chunks.
+    """
+    n_elements = 100
+    br = context.br()
+    shuffler = ShufflerAsync(context, comm, 0, n_partitions)
 
-    actors: list[CppActor | Awaitable[None]] = []
+    for _ in range(n_inserts):
+        data = {
+            pid: generate_packed_data(n_elements, 0, stream, br)
+            for pid in range(n_partitions)
+        }
+        shuffler.insert(data)
 
-    num_rows = 200
-    num_chunks = 3
-    op_id = 0
-    ch_in: Channel[TableChunk] = context.create_channel()
-    actors.append(generate_inputs(context, ch_in, num_rows, num_chunks))
-    ch_shuffled: Channel[TableChunk] = context.create_channel()
-    actors.append(
-        do_shuffle(
-            context,
-            comm,
-            ch_in,
-            ch_shuffled,
-            op_id,
-            num_partitions,
-            partition_assignment=PartitionAssignment.CONTIGUOUS,
-        )
-    )
-    actor, deferred = pull_from_channel(context, ch_shuffled)
-    actors.append(actor)
+    asyncio.run(shuffler.insert_finished(context))
 
-    run_actor_network(context, actors=actors)
-    messages = deferred.release()
-    received_pids = [msg.sequence_number for msg in messages]
+    local_pids = shuffler.local_partitions()
 
-    nranks = comm.nranks
-    rank = comm.rank
-    expected_local = list(
-        range(
-            rank * num_partitions // nranks,
-            (rank + 1) * num_partitions // nranks,
-        )
-    )
-    assert set(received_pids) == set(expected_local)
-    assert len(received_pids) == len(expected_local)
+    finished_pids = []
+    n_chunks_received = 0
+    for pid in local_pids:
+        chunks = shuffler.extract(pid)
+        n_chunks_received += len(chunks)
+        finished_pids.append(pid)
 
-
-def test_shuffler_object_interface(
-    context: Context,
-    comm: Communicator,
-) -> None:
-    if comm.nranks != 1:
-        pytest.skip("Only support single-rank runs")
-    actors: list[CppActor | Awaitable[None]] = []
-
-    num_partitions = 5
-    num_rows = 100
-    num_chunks = 4
-    op_id = 0
-    ch_in: Channel[TableChunk] = context.create_channel()
-    actors.append(generate_inputs(context, ch_in, num_rows, num_chunks))
-    ch_shuffled: Channel[TableChunk] = context.create_channel()
-    actors.append(
-        do_shuffle(
-            context,
-            comm,
-            ch_in,
-            ch_shuffled,
-            op_id,
-            num_partitions,
-        )
-    )
-    actor, deferred = pull_from_channel(context, ch_shuffled)
-    actors.append(actor)
-
-    run_actor_network(context, actors=actors)
-    messages = deferred.release()
-    # TODO: single rank only assertions
-    assert len(messages) == 5
-    assert [msg.sequence_number for msg in messages] == list(range(num_partitions))
-    chunks = [
-        (msg.sequence_number, TableChunk.from_message(msg, br=context.br()))
-        for msg in messages
-    ]
-
-    full_column = np.arange(num_rows * num_chunks, dtype=np.int32)
-    part_size = num_rows // num_partitions + (num_rows % num_partitions)
-    splits = [*range(0, num_rows, part_size), num_rows]
-    for pid, table in chunks:
-        expect = plc.Column.from_array(
-            np.concat(
-                [
-                    full_column[i * num_rows : (i + 1) * num_rows][
-                        splits[pid] : splits[pid + 1]
-                    ]
-                    for i in range(num_chunks)
-                ]
-            ),
-            stream=table.stream,
-        )
-        got = table.table_view()
-        table.stream.synchronize()
-        assert_eq(plc.Table([expect]), got, sort_rows=0)
+    assert n_chunks_received == n_inserts * len(local_pids) * comm.nranks
+    assert finished_pids == local_pids

--- a/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/streaming/test_shuffler.py
@@ -170,6 +170,7 @@ def test_shuffler_runtime_obeys_contiguous_assignment(
 
     # Single rank, so every partition is local to this rank.
     assert set(received_pids) == set(range(num_partitions))
+    assert len(received_pids) == num_partitions
 
     # Validate the data routed to each local partition. Across the ``num_chunks``
     # inputs, partition ``pid`` receives the packed sequence ``generate_inputs``

--- a/python/rapidsmpf/rapidsmpf/tests/test_shuffler.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_shuffler.py
@@ -2,27 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
-import numpy as np
-import pylibcudf as plc
 import pytest
 
-pytest.importorskip("cudf_streaming")
-from cudf_streaming.integrations.partition import (
-    partition_and_pack,
-    unpack_and_concat,
-)
-
 from rapidsmpf.memory.buffer_resource import BufferResource
-from rapidsmpf.memory.spill import unspill_partitions
-from rapidsmpf.shuffler import (
-    Shuffler,
-)
-from rapidsmpf.testing import assert_eq
-
-cudf = pytest.importorskip("cudf")
+from rapidsmpf.shuffler import Shuffler
+from rapidsmpf.testing import make_partition_data, validate_partition_data
 
 if TYPE_CHECKING:
     import rmm.mr
@@ -31,15 +17,17 @@ if TYPE_CHECKING:
     from rapidsmpf.communicator.communicator import Communicator
 
 
-@pytest.mark.parametrize("total_num_partitions", [1, 2, 3, 10])
-def test_shuffler_single_nonempty_partition(
+@pytest.mark.parametrize("total_num_partitions", [1, 2, 5, 10])
+@pytest.mark.parametrize("total_num_rows", [1, 9, 100, 100_000])
+def test_shuffler_round_trip(
     comm: Communicator,
     device_mr: rmm.mr.CudaMemoryResource,
     stream: Stream,
     total_num_partitions: int,
+    total_num_rows: int,
 ) -> None:
+    """End-to-end shuffle of a conserved, front-loaded data model."""
     br = BufferResource(device_mr)
-
     shuffler = Shuffler(
         comm,
         op_id=0,
@@ -47,145 +35,22 @@ def test_shuffler_single_nonempty_partition(
         br=br,
     )
 
-    df = plc.Table(
-        [
-            plc.Column.from_iterable_of_py(
-                [1, 2, 3], plc.DataType(plc.TypeId.INT64), stream=stream
-            ),
-            plc.Column.from_iterable_of_py(
-                [42, 42, 42], plc.DataType(plc.TypeId.INT64), stream=stream
-            ),
-        ]
-    )
-    packed_inputs = partition_and_pack(
-        df,
-        columns_to_hash=(1,),
-        num_partitions=total_num_partitions,
-        br=br,
-        stream=stream,
-    )
-    shuffler.insert_chunks(packed_inputs)
+    # Insert every owned input region, wait, then extract and validate.
+    for local_pidx in shuffler.local_partitions():
+        chunks = make_partition_data(
+            total_num_partitions, total_num_rows, local_pidx, stream, br
+        )
+        if chunks:
+            shuffler.insert_chunks(chunks)
     shuffler.insert_finished()
-
-    expected_partitions = set(shuffler.local_partitions())
-
-    local_outputs = []
-    extracted_partitions = set()
     shuffler.wait()
-    for partition_id in shuffler.local_partitions():
-        extracted_partitions.add(partition_id)
-        packed_chunks = shuffler.extract(partition_id)
-        partition = unpack_and_concat(
-            unspill_partitions(packed_chunks, br=br, allow_overbooking=True),
-            br=br,
-            stream=stream,
-        )
-        local_outputs.append(partition)
-    shuffler.shutdown()
-    assert extracted_partitions == expected_partitions
-    # Everything should go to a single rank thus we should get the whole dataframe or nothing.
-    if len(local_outputs) == 0:
-        return
-    res = plc.concatenate.concatenate(local_outputs)
-    # Each rank has `df` thus each rank contribute to the rows of `df` to the expected result.
-    expect = plc.concatenate.concatenate([df] * comm.nranks, stream=stream)
-    if res.num_rows() > 0:
-        assert_eq(res, expect, sort_rows=0)
 
-
-@pytest.mark.parametrize("batch_size", [None, 10])
-@pytest.mark.parametrize("total_num_partitions", [1, 2, 3, 10])
-def test_shuffler_uniform(
-    comm: Communicator,
-    device_mr: rmm.mr.CudaMemoryResource,
-    stream: Stream,
-    batch_size: int | None,
-    total_num_partitions: int,
-) -> None:
-    br = BufferResource(device_mr)
-
-    # Every rank creates the full input dataframe and all the expected partitions
-    # (also partitions this rank might not get after the shuffle).
-    num_rows = 100
-    np.random.seed(42)  # Make sure all ranks create the same input dataframe.
-    df = plc.Table(
-        [
-            plc.Column.from_iterable_of_py(
-                range(num_rows), plc.DataType(plc.TypeId.INT64), stream=stream
-            ),
-            plc.Column.from_array(np.random.randint(0, 1000, num_rows), stream=stream),
-            plc.Column.from_iterable_of_py(
-                ["cat", "dog"] * (num_rows // 2),
-                plc.DataType(plc.TypeId.STRING),
-                stream=stream,
-            ),
-        ]
-    )
-    columns_to_hash = (1,)
-
-    expected = {
-        partition_id: unpack_and_concat(
-            [packed],
-            br=br,
-            stream=stream,
-        )
-        for partition_id, packed in partition_and_pack(
-            df,
-            columns_to_hash=columns_to_hash,
-            num_partitions=total_num_partitions,
-            br=br,
-            stream=stream,
-        ).items()
-    }
-
-    shuffler = Shuffler(
-        comm,
-        op_id=0,
-        total_num_partitions=total_num_partitions,
-        br=br,
-    )
-
-    # Slice df and submit local slices to shuffler
-    stride = math.ceil(num_rows / comm.nranks)
-    local_df = plc.copying.slice(
-        df,
-        [comm.rank * stride, min((comm.rank + 1) * stride, num_rows)],
-        stream=stream,
-    )[0]
-    num_rows_local = local_df.num_rows()
-    batch_size = batch_size or num_rows_local
-    for i in range(0, num_rows_local, batch_size):
-        batch = plc.copying.slice(
-            local_df, [i, min(i + batch_size, num_rows_local)], stream=stream
-        )[0]
-        packed_inputs = partition_and_pack(
-            batch,
-            columns_to_hash=columns_to_hash,
-            num_partitions=total_num_partitions,
-            br=br,
-            stream=stream,
-        )
-        shuffler.insert_chunks(packed_inputs)
-
-    # Tell shuffler we are done adding data
-    shuffler.insert_finished()
-
-    expected_partitions = set(shuffler.local_partitions())
-    extracted_partitions = set()
-    shuffler.wait()
-    for partition_id in shuffler.local_partitions():
-        extracted_partitions.add(partition_id)
-        packed_chunks = shuffler.extract(partition_id)
-        partition = unpack_and_concat(
-            unspill_partitions(packed_chunks, br=br, allow_overbooking=True),
-            br=br,
-            stream=stream,
-        )
-        assert_eq(
-            partition,
-            expected[partition_id],
-            sort_rows=0,
+    for local_pidx in shuffler.local_partitions():
+        validate_partition_data(
+            shuffler.extract(local_pidx),
+            total_num_partitions,
+            total_num_rows,
+            local_pidx,
         )
 
     shuffler.shutdown()
-    assert extracted_partitions == expected_partitions


### PR DESCRIPTION
## `[C++]` Make shuffler distributed tests cudf-free

## Summary

The shuffler round-trip tests depended on cudf for input generation and result checking (`random_table_with_index`, `partition_and_pack`/`unpack_and_concat`, `CUDF_TEST_EXPECT_TABLES_EQUIVALENT`, `cudf::test::BaseFixture`), which made them heavy and coupled to the cudf integration. This replaces that with a self-contained, conservation-preserving data model built directly from `PackedData`, so the shuffler tests no longer depend on cudf and run as part of the default (non-`BUILD_CUDF_TESTS`) build.

## Changes

### C++ utilities
- Add `ceil_div` and a `chunk_indices` view to `utils/misc.hpp`. `chunk_indices` tiles `[0, count)` into exactly `num_chunks` contiguous (possibly empty) ranges whose sizes sum to `count`.
- `ceil_div` is computed as `x / y + (x % y != 0)` rather than the naive `(x + y - 1) / y`, which overflows for large unsigned values and is UB on signed overflow near the type maximum.
- Add compile-time edge-case coverage for `ceil_div` in `test_misc.cpp` (`static_assert`s for exact/remainder division, zero numerator, denominator of one, and values at `uint64`/`int64` maxima).

### C++ shuffler tests (now cudf-free)
- Rework the shuffler tests (`test_shuffler.cpp`, `streaming/test_shuffler.cpp`) around `make_partition_data` (produces routed chunks) and `validate_partition_data` (verifies received chunks), dropping all `cudf`/`cudf_test` usage and switching to `rmm::` stream/MR helpers and `::testing::Test`.
- Generalize the test helpers `generate_packed_data`/`validate_packed_data` in `tests/utils.hpp` over the element type and build device buffers via the buffer resource + `cuda_memcpy_async` instead of cudf.
- De-couple `streaming/test_allgather.cpp` from `cudf_streaming/integrations/partition.hpp`.
- `cpp/tests/CMakeLists.txt`: move `test_shuffler.cpp`, `streaming/test_shuffler.cpp`, and `streaming/test_allgather.cpp` out of the `BUILD_CUDF_TESTS` block into the default build; the cudf block now only carries `test_partition.cpp`, `test_shuffler_many_streams.cpp`, and `streaming/test_leaf_actor.cpp`.

### Python (now cudf-free)
- Add a `PackedData.from_device_buffer(gpu_data, metadata, stream, br)` factory (plus `.pyi` stub) so packed data can be built from an rmm `DeviceBuffer` without cudf.
- Add shared, cudf-free shuffle test helpers to `rapidsmpf/testing.py`: `chunk_indices`, `generate_packed_data`, `validate_packed_data`, `make_partition_data`, and `validate_partition_data`.
- Rewrite the Python shuffler tests (`tests/test_shuffler.py`, `tests/streaming/test_shuffler.py`) around those helpers and the `Shuffler`/`ShufflerAsync` object interfaces, removing the `cudf` / `cudf_streaming` / `pylibcudf` dependencies.


Depends on https://github.com/rapidsai/rapidsmpf/pull/1087