### PR TITLE
Re-enable rrun tests in CI

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -64,9 +64,8 @@ rapids-logger "Run tools smoketests"
 ./run_cpp_tools_smoketests.sh
 
 # Ensure rrun is runnable
-# TODO: Reenable. Disabled to unblock CI while "terminated by signal 11" were raised.
-# rapids-logger "Run rrun gtests"
-# ./run_rrun_tests.sh
+rapids-logger "Run rrun gtests"
+./run_rrun_tests.sh
 
 BENCHMARKS_DIR=$CONDA_PREFIX/bin/benchmarks/librapidsmpf
 


### PR DESCRIPTION
Several changes to topology discovery code have been made recently in both cuCascade and RapidsMPF. While unclear exactly which change resolved the issue that led to it being disabled, it is not reproducible in CI anymore, thus re-enable the tests in CI.

Closes #1041 .