### PR TITLE
refactor: switch to `rapids-artifact-name` for consistent artifact naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,6 +143,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: librapidsmpf
       package-type: cpp
+      publish-wheel-search-key: rapidsmpf_wheel_cpp_librapidsmpf
   wheel-build-rapidsmpf:
     needs: wheel-build-librapidsmpf
     permissions:
@@ -181,7 +182,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: rapidsmpf
       package-type: python
-      publish-wheel-search-key: rapidsmpf_wheel_python_abi3
+      publish-wheel-search-key: rapidsmpf_wheel_python_rapidsmpf
   wheel-build-rapidsmpf-singlecomm:
     needs: wheel-build-rapidsmpf
     permissions:

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -37,3 +37,6 @@ sccache --stop-server >/dev/null 2>&1 || true
 # remove build_cache directory to avoid uploading the entire source tree
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -18,8 +18,8 @@ conda config --set channel_priority strict
 ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name "conda_python" rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")")
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python rapidsmpf rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -15,7 +15,7 @@ rapids-generate-version > ./VERSION
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
 
 RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION)
 export RAPIDS_PACKAGE_VERSION

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -45,5 +45,5 @@ sccache --stop-server >/dev/null 2>&1 || true
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name conda_python rapidsmpf --stable --cuda)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python rapidsmpf rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_librapidsmpf.sh
+++ b/ci/build_wheel_librapidsmpf.sh
@@ -46,3 +46,6 @@ python -m auditwheel repair \
     ${package_dir}/dist/*
 
 ./ci/validate_wheel.sh "${package_dir}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_rapidsmpf.sh
+++ b/ci/build_wheel_rapidsmpf.sh
@@ -11,7 +11,7 @@ source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
-LIBRAPIDSMPF_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="librapidsmpf_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+LIBRAPIDSMPF_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
 echo "librapidsmpf-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBRAPIDSMPF_WHEELHOUSE}"/librapidsmpf_*.whl)" >> "${PIP_CONSTRAINT}"
 
 rapids-logger "Generating build requirements"
@@ -58,5 +58,5 @@ python -m auditwheel repair \
 
 ./ci/validate_wheel.sh "${package_dir}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name wheel_python rapidsmpf --stable --cuda)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python rapidsmpf rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_singlecomm.sh
+++ b/ci/build_wheel_singlecomm.sh
@@ -93,3 +93,6 @@ python -m auditwheel repair \
 # Remove librapidsmpf package before validating rapidsmpf package
 rm "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"/librapidsmpf_*.whl
 ./ci/validate_wheel.sh "${package_dir_py}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python rapidsmpf-singlecomm rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_cpp_memcheck.sh
+++ b/ci/test_cpp_memcheck.sh
@@ -9,7 +9,7 @@ set -xeuo pipefail
 rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -10,8 +10,8 @@ rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name "conda_python" rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")")
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python rapidsmpf rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -9,7 +9,7 @@ source rapids-init-pip
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 CPP_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
-PYTHON_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python rapidsmpf rapidsmpf --pure --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python rapidsmpf rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -8,8 +8,8 @@ source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
-PYTHON_WHEELHOUSE=$(rapids-download-from-github "$(rapids-package-name "wheel_python" rapidsmpf --stable --cuda "$RAPIDS_CUDA_VERSION")")
-CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="librapidsmpf_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+CPP_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp librapidsmpf rapidsmpf --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python rapidsmpf rapidsmpf --pure --cuda "$RAPIDS_CUDA_VERSION")")
 
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"


### PR DESCRIPTION
This PR swaps in `rapids-artifact-name` for `rapids-package-name` everywhere, and also removes any legacy named artifacts. All artifacts now follow the same naming convention (and that convention can be updated/expanded from a central location). Part of rapidsai/build-planning#270