### PR TITLE
Adding `-Wno-ignored-optimization-argument`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -389,12 +389,14 @@ if(RAPIDSMPF_CLANG_TIDY)
       "^-?(${CMAKE_SOURCE_DIR}/src|${CMAKE_SOURCE_DIR}/include|${CMAKE_SOURCE_DIR}/benchmarks|${CMAKE_SOURCE_DIR}/tests)/.*"
   )
 
-  # adding `-Qunused-arguments`, otherwise clang complains about unused link libraries.
+  # adding `-Qunused-arguments`, otherwise clang complains about unused link libraries. adding
+  # `-Wno-ignored-optimization-argument`, otherwise clang-tidy errors on GCC-only optimization flags
+  # (e.g. `-fno-merge-constants`) injected by the conda compiler activation scripts.
   set_target_properties(
     rapidsmpf
     PROPERTIES
       CXX_CLANG_TIDY
-      "${CLANG_TIDY_EXE};--header-filter=${CLANG_TIDY_HEADER_FILTER};--extra-arg=-Qunused-arguments"
+      "${CLANG_TIDY_EXE};--header-filter=${CLANG_TIDY_HEADER_FILTER};--extra-arg=-Qunused-arguments;--extra-arg=-Wno-ignored-optimization-argument"
   )
 endif()
 


### PR DESCRIPTION
Recent gcc upgrade in conda seems to have added `-fno-merge-constants` to `CXXFLAGS`, and this conflicts with clang-tidy. 
```bash
[ 36%] Building CXX object _deps/gtest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
error: optimization flag '-fno-merge-constants' is not supported [clang-diagnostic-ignored-optimization-argument]
4570 warnings and 1 error generated.
Error while processing /home/nperera/git/rapidsmpf/cpp/src/bootstrap/bootstrap.cpp.
Suppressed 4570 warnings (4570 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
```

This PR adds  `-Wno-ignored-optimization-argument` to counter the clang-tidy error. 