### PR TITLE
Revert "Make CUDA::cupti a PUBLIC link dependency"

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -307,11 +307,12 @@ endif()
 target_link_libraries(
   rapidsmpf
   PUBLIC rmm::rmm CCCL::CCCL $<TARGET_NAME_IF_EXISTS:ucxx::ucxx> $<TARGET_NAME_IF_EXISTS:libcoro>
-         CUDA::cudart_static $<$<BOOL:${RAPIDSMPF_HAVE_CUPTI}>:CUDA::cupti>
+         CUDA::cudart_static
   PRIVATE cuco::cuco
           cuCascade::cucascade_topology_discovery
           $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa>
           $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
+          $<$<BOOL:${RAPIDSMPF_HAVE_CUPTI}>:CUDA::cupti>
           $<TARGET_NAME_IF_EXISTS:PMIx::PMIx>
           $<TARGET_NAME_IF_EXISTS:conda_env>
           maybe_asan


### PR DESCRIPTION
Reverts rapidsai/rapidsmpf#1095

My fault, I meant for that PR to be a draft, I hadn't had a chance to go through and ensure that we were including cupti in consumers and now this is breaking cudf.