### PR TITLE
Hide CUPTI types behind CuptiMonitor PImpl

### DIFF
--- a/cpp/include/rapidsmpf/cupti.hpp
+++ b/cpp/include/rapidsmpf/cupti.hpp
@@ -1,22 +1,19 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 
 #ifdef RAPIDSMPF_HAVE_CUPTI
 
-#include <atomic>
 #include <chrono>
 #include <cstddef>
-#include <mutex>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <vector>
-
-#include <cuda_runtime.h>
-#include <cupti.h>
 
 namespace rapidsmpf {
 
@@ -29,6 +26,45 @@ struct MemoryDataPoint {
     std::size_t total_memory;  ///< Total GPU memory in bytes
     std::size_t used_memory;  ///< Used GPU memory in bytes
 };
+
+/**
+ * @brief Public wrapper for a CUPTI callback identifier.
+ *
+ * Keeps CUPTI types out of the public RapidsMPF API while preserving the
+ * numeric callback identifier for callers that inspect callback counters.
+ */
+class CuptiCallbackId {
+  public:
+    using value_type = std::int32_t;
+
+    constexpr CuptiCallbackId() noexcept = default;
+
+    explicit constexpr CuptiCallbackId(value_type value) noexcept : value_(value) {}
+
+    [[nodiscard]] constexpr value_type underlying() const noexcept {
+        return value_;
+    }
+
+    friend constexpr bool operator==(
+        CuptiCallbackId const&, CuptiCallbackId const&
+    ) noexcept = default;
+
+  private:
+    value_type value_{};
+};
+
+}  // namespace rapidsmpf
+
+template <>
+struct std::hash<rapidsmpf::CuptiCallbackId> {
+    std::size_t operator()(rapidsmpf::CuptiCallbackId callback_id) const noexcept {
+        return std::hash<rapidsmpf::CuptiCallbackId::value_type>{}(
+            callback_id.underlying()
+        );
+    }
+};
+
+namespace rapidsmpf {
 
 /**
  * @brief CUDA memory monitoring using CUPTI (CUDA Profiling Tools Interface).
@@ -133,12 +169,12 @@ class CuptiMonitor {
     /**
      * @brief Get callback counters for all monitored CUPTI callbacks.
      *
-     * Returns a map where keys are CUPTI callback IDs and values are the number
-     * of times each callback was triggered during monitoring.
+     * Returns a map where keys are RapidsMPF callback ID wrappers and values are
+     * the number of times each callback was triggered during monitoring.
      *
-     * @return unordered_map from CUpti_CallbackId to call count.
+     * @return unordered_map from CuptiCallbackId to call count.
      */
-    std::unordered_map<CUpti_CallbackId, std::size_t> get_callback_counters() const;
+    std::unordered_map<CuptiCallbackId, std::size_t> get_callback_counters() const;
 
     /**
      * @brief Clear all callback counters.
@@ -164,55 +200,8 @@ class CuptiMonitor {
     std::string get_callback_summary() const;
 
   private:
-    // Boolean fields grouped together at beginning to reduce padding
-    bool enable_periodic_sampling_;
-    std::atomic<bool> monitoring_active_;
-    bool debug_output_enabled_{false};
-
-    std::chrono::milliseconds sampling_interval_ms_;
-    std::size_t debug_threshold_bytes_;
-    std::size_t last_used_mem_for_debug_{0};
-    CUpti_SubscriberHandle cupti_subscriber_;
-    std::thread sampling_thread_;
-
-    std::unordered_map<CUpti_CallbackId, std::size_t> callback_counters_;
-    mutable std::mutex mutex_;
-    std::vector<MemoryDataPoint> memory_samples_;
-
-    /**
-     * @brief Internal method to capture memory usage without locking.
-     */
-    void capture_memory_usage_impl();
-
-    /**
-     * @brief Periodic memory sampling thread function.
-     */
-    void periodic_memory_sampling();
-
-    /**
-     * @brief Subscribe to CUPTI callbacks.
-     */
-    CUptiResult subscribe();
-
-    /**
-     * @brief Unsubscribe from CUPTI callbacks.
-     */
-    void unsubscribe();
-
-    /**
-     * @brief Static wrapper function for CUPTI callback.
-     */
-    static void CUPTIAPI callback_wrapper(
-        void* userdata,
-        CUpti_CallbackDomain domain,
-        CUpti_CallbackId cbid,
-        void const* cbdata
-    );
-
-    /**
-     * @brief Instance method for CUPTI callback.
-     */
-    void callback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid, void const* cbdata);
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/cupti.hpp
+++ b/cpp/include/rapidsmpf/cupti.hpp
@@ -121,7 +121,7 @@ class CuptiMonitor {
      *
      * @return true if monitoring is active, false otherwise.
      */
-    bool is_monitoring() const noexcept;
+    [[nodiscard]] bool is_monitoring() const noexcept;
 
     /**
      * @brief Manually capture current memory usage.
@@ -136,7 +136,7 @@ class CuptiMonitor {
      *
      * @return const reference to vector of memory data points.
      */
-    std::vector<MemoryDataPoint> const& get_memory_samples() const noexcept;
+    [[nodiscard]] std::vector<MemoryDataPoint> const& get_memory_samples() const noexcept;
 
     /**
      * @brief Clear all collected memory samples.
@@ -148,7 +148,7 @@ class CuptiMonitor {
      *
      * @return number of samples.
      */
-    std::size_t get_sample_count() const noexcept;
+    [[nodiscard]] std::size_t get_sample_count() const noexcept;
 
     /**
      * @brief Write memory samples to CSV file.
@@ -174,7 +174,8 @@ class CuptiMonitor {
      *
      * @return unordered_map from CuptiCallbackId to call count.
      */
-    std::unordered_map<CuptiCallbackId, std::size_t> get_callback_counters() const;
+    [[nodiscard]] std::unordered_map<CuptiCallbackId, std::size_t>
+    get_callback_counters() const;
 
     /**
      * @brief Clear all callback counters.
@@ -188,7 +189,7 @@ class CuptiMonitor {
      *
      * @return total number of callbacks.
      */
-    std::size_t get_total_callback_count() const;
+    [[nodiscard]] std::size_t get_total_callback_count() const;
 
     /**
      * @brief Get a human-readable summary of callback counters.
@@ -197,7 +198,7 @@ class CuptiMonitor {
      *
      * @return string containing callback counter summary.
      */
-    std::string get_callback_summary() const;
+    [[nodiscard]] std::string get_callback_summary() const;
 
   private:
     struct Impl;

--- a/cpp/src/cupti.cpp
+++ b/cpp/src/cupti.cpp
@@ -145,7 +145,7 @@ void CuptiMonitor::stop_monitoring() {
     impl_->stop_monitoring();
 }
 
-bool CuptiMonitor::is_monitoring() const noexcept {
+[[nodiscard]] bool CuptiMonitor::is_monitoring() const noexcept {
     return impl_->is_monitoring();
 }
 
@@ -153,7 +153,8 @@ void CuptiMonitor::capture_memory_sample() {
     impl_->capture_memory_sample();
 }
 
-std::vector<MemoryDataPoint> const& CuptiMonitor::get_memory_samples() const noexcept {
+[[nodiscard]] std::vector<MemoryDataPoint> const&
+CuptiMonitor::get_memory_samples() const noexcept {
     return impl_->get_memory_samples();
 }
 
@@ -161,7 +162,7 @@ void CuptiMonitor::clear_samples() {
     impl_->clear_samples();
 }
 
-std::size_t CuptiMonitor::get_sample_count() const noexcept {
+[[nodiscard]] std::size_t CuptiMonitor::get_sample_count() const noexcept {
     return impl_->get_sample_count();
 }
 
@@ -173,7 +174,7 @@ void CuptiMonitor::set_debug_output(bool enabled, std::size_t threshold_mb) {
     impl_->set_debug_output(enabled, threshold_mb);
 }
 
-std::unordered_map<CuptiCallbackId, std::size_t>
+[[nodiscard]] std::unordered_map<CuptiCallbackId, std::size_t>
 CuptiMonitor::get_callback_counters() const {
     return impl_->get_callback_counters();
 }
@@ -182,11 +183,11 @@ void CuptiMonitor::clear_callback_counters() {
     impl_->clear_callback_counters();
 }
 
-std::size_t CuptiMonitor::get_total_callback_count() const {
+[[nodiscard]] std::size_t CuptiMonitor::get_total_callback_count() const {
     return impl_->get_total_callback_count();
 }
 
-std::string CuptiMonitor::get_callback_summary() const {
+[[nodiscard]] std::string CuptiMonitor::get_callback_summary() const {
     return impl_->get_callback_summary();
 }
 

--- a/cpp/src/cupti.cpp
+++ b/cpp/src/cupti.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,18 +7,36 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <cstdio>
 #include <fstream>
 #include <iomanip>
-#include <iostream>
+#include <memory>
+#include <mutex>
 #include <ranges>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
+#include <unordered_map>
+
+#include <cuda_runtime.h>
+#include <cupti.h>
 
 #include <rapidsmpf/cupti.hpp>
 
 namespace rapidsmpf {
 
 namespace {
+
+[[nodiscard]] CuptiCallbackId make_callback_id(CUpti_CallbackId cbid) noexcept {
+    return CuptiCallbackId{static_cast<CuptiCallbackId::value_type>(cbid)};
+}
+
+[[nodiscard]] CUpti_CallbackId to_cupti_callback_id(
+    CuptiCallbackId callback_id
+) noexcept {
+    return static_cast<CUpti_CallbackId>(callback_id.underlying());
+}
 
 // List of CUDA Runtime API callbacks we want to monitor. We don't monitor any runtime
 // callbacks by default because they are redundant with the driver API callbacks.
@@ -56,7 +74,123 @@ bool is_monitored_callback(
 
 }  // namespace
 
+struct CuptiMonitor::Impl {
+    Impl(bool enable_periodic_sampling, std::chrono::milliseconds sampling_interval_ms);
+
+    ~Impl();
+
+    Impl(Impl const&) = delete;
+    Impl& operator=(Impl const&) = delete;
+    Impl(Impl&&) = delete;
+    Impl& operator=(Impl&&) = delete;
+
+    void start_monitoring();
+    void stop_monitoring();
+    [[nodiscard]] bool is_monitoring() const noexcept;
+    void capture_memory_sample();
+    [[nodiscard]] std::vector<MemoryDataPoint> const& get_memory_samples() const noexcept;
+    void clear_samples();
+    [[nodiscard]] std::size_t get_sample_count() const noexcept;
+    void write_csv(std::string const& filename) const;
+    void set_debug_output(bool enabled, std::size_t threshold_mb);
+    [[nodiscard]] std::unordered_map<CuptiCallbackId, std::size_t>
+    get_callback_counters() const;
+    void clear_callback_counters();
+    [[nodiscard]] std::size_t get_total_callback_count() const;
+    [[nodiscard]] std::string get_callback_summary() const;
+
+  private:
+    // Boolean fields grouped together at beginning to reduce padding.
+    bool enable_periodic_sampling_;
+    std::atomic<bool> monitoring_active_;
+    bool debug_output_enabled_{false};
+
+    std::chrono::milliseconds sampling_interval_ms_;
+    std::size_t debug_threshold_bytes_;
+    std::size_t last_used_mem_for_debug_{0};
+    CUpti_SubscriberHandle cupti_subscriber_{};
+    std::thread sampling_thread_;
+
+    std::unordered_map<CuptiCallbackId, std::size_t> callback_counters_;
+    mutable std::mutex mutex_;
+    std::vector<MemoryDataPoint> memory_samples_;
+
+    void capture_memory_usage_impl();
+    void periodic_memory_sampling();
+    CUptiResult subscribe();
+    void unsubscribe();
+
+    static void CUPTIAPI callback_wrapper(
+        void* userdata,
+        CUpti_CallbackDomain domain,
+        CUpti_CallbackId cbid,
+        void const* cbdata
+    );
+
+    void callback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid, void const* cbdata);
+};
+
 CuptiMonitor::CuptiMonitor(
+    bool enable_periodic_sampling, std::chrono::milliseconds sampling_interval_ms
+)
+    : impl_(std::make_unique<Impl>(enable_periodic_sampling, sampling_interval_ms)) {}
+
+CuptiMonitor::~CuptiMonitor() = default;
+
+void CuptiMonitor::start_monitoring() {
+    impl_->start_monitoring();
+}
+
+void CuptiMonitor::stop_monitoring() {
+    impl_->stop_monitoring();
+}
+
+bool CuptiMonitor::is_monitoring() const noexcept {
+    return impl_->is_monitoring();
+}
+
+void CuptiMonitor::capture_memory_sample() {
+    impl_->capture_memory_sample();
+}
+
+std::vector<MemoryDataPoint> const& CuptiMonitor::get_memory_samples() const noexcept {
+    return impl_->get_memory_samples();
+}
+
+void CuptiMonitor::clear_samples() {
+    impl_->clear_samples();
+}
+
+std::size_t CuptiMonitor::get_sample_count() const noexcept {
+    return impl_->get_sample_count();
+}
+
+void CuptiMonitor::write_csv(std::string const& filename) const {
+    impl_->write_csv(filename);
+}
+
+void CuptiMonitor::set_debug_output(bool enabled, std::size_t threshold_mb) {
+    impl_->set_debug_output(enabled, threshold_mb);
+}
+
+std::unordered_map<CuptiCallbackId, std::size_t>
+CuptiMonitor::get_callback_counters() const {
+    return impl_->get_callback_counters();
+}
+
+void CuptiMonitor::clear_callback_counters() {
+    impl_->clear_callback_counters();
+}
+
+std::size_t CuptiMonitor::get_total_callback_count() const {
+    return impl_->get_total_callback_count();
+}
+
+std::string CuptiMonitor::get_callback_summary() const {
+    return impl_->get_callback_summary();
+}
+
+CuptiMonitor::Impl::Impl(
     bool enable_periodic_sampling, std::chrono::milliseconds sampling_interval_ms
 )
     : enable_periodic_sampling_(enable_periodic_sampling),
@@ -64,11 +198,11 @@ CuptiMonitor::CuptiMonitor(
       sampling_interval_ms_(sampling_interval_ms),
       debug_threshold_bytes_(10 * 1024 * 1024) {}  // 10MB default
 
-CuptiMonitor::~CuptiMonitor() {
+CuptiMonitor::Impl::~Impl() {
     stop_monitoring();
 }
 
-void CuptiMonitor::start_monitoring() {
+void CuptiMonitor::Impl::start_monitoring() {
     if (monitoring_active_.load()) {
         return;
     }
@@ -92,12 +226,13 @@ void CuptiMonitor::start_monitoring() {
         capture_memory_usage_impl();
 
         if (enable_periodic_sampling_) {
-            sampling_thread_ = std::thread(&CuptiMonitor::periodic_memory_sampling, this);
+            sampling_thread_ =
+                std::thread(&CuptiMonitor::Impl::periodic_memory_sampling, this);
         }
     }
 }
 
-void CuptiMonitor::stop_monitoring() {
+void CuptiMonitor::Impl::stop_monitoring() {
     if (!monitoring_active_.load()) {
         return;
     }
@@ -117,33 +252,34 @@ void CuptiMonitor::stop_monitoring() {
     unsubscribe();
 }
 
-bool CuptiMonitor::is_monitoring() const noexcept {
+bool CuptiMonitor::Impl::is_monitoring() const noexcept {
     return monitoring_active_.load();
 }
 
-void CuptiMonitor::capture_memory_sample() {
+void CuptiMonitor::Impl::capture_memory_sample() {
     if (monitoring_active_.load()) {
         std::lock_guard<std::mutex> lock(mutex_);
         capture_memory_usage_impl();
     }
 }
 
-std::vector<MemoryDataPoint> const& CuptiMonitor::get_memory_samples() const noexcept {
+std::vector<MemoryDataPoint> const&
+CuptiMonitor::Impl::get_memory_samples() const noexcept {
     std::lock_guard<std::mutex> lock(mutex_);
     return memory_samples_;
 }
 
-void CuptiMonitor::clear_samples() {
+void CuptiMonitor::Impl::clear_samples() {
     std::lock_guard<std::mutex> lock(mutex_);
     memory_samples_.clear();
 }
 
-std::size_t CuptiMonitor::get_sample_count() const noexcept {
+std::size_t CuptiMonitor::Impl::get_sample_count() const noexcept {
     std::lock_guard<std::mutex> lock(mutex_);
     return memory_samples_.size();
 }
 
-void CuptiMonitor::write_csv(std::string const& filename) const {
+void CuptiMonitor::Impl::write_csv(std::string const& filename) const {
     std::lock_guard<std::mutex> lock(mutex_);
 
     std::ofstream file(filename);
@@ -162,24 +298,24 @@ void CuptiMonitor::write_csv(std::string const& filename) const {
     }
 }
 
-void CuptiMonitor::set_debug_output(bool enabled, std::size_t threshold_mb) {
+void CuptiMonitor::Impl::set_debug_output(bool enabled, std::size_t threshold_mb) {
     std::lock_guard<std::mutex> lock(mutex_);
     debug_output_enabled_ = enabled;
     debug_threshold_bytes_ = threshold_mb * 1024 * 1024;  // Convert MB to bytes
 }
 
-std::unordered_map<CUpti_CallbackId, std::size_t>
-CuptiMonitor::get_callback_counters() const {
+std::unordered_map<CuptiCallbackId, std::size_t>
+CuptiMonitor::Impl::get_callback_counters() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return callback_counters_;
 }
 
-void CuptiMonitor::clear_callback_counters() {
+void CuptiMonitor::Impl::clear_callback_counters() {
     std::lock_guard<std::mutex> lock(mutex_);
     callback_counters_.clear();
 }
 
-std::size_t CuptiMonitor::get_total_callback_count() const {
+std::size_t CuptiMonitor::Impl::get_total_callback_count() const {
     std::lock_guard<std::mutex> lock(mutex_);
     std::size_t total = 0;
     for (auto const& [cbid, count] : callback_counters_) {
@@ -189,8 +325,8 @@ std::size_t CuptiMonitor::get_total_callback_count() const {
 }
 
 // Helper function to get human-readable name for callback ID
-std::string get_callback_name(CUpti_CallbackId cbid) {
-    switch (cbid) {
+std::string get_callback_name(CuptiCallbackId cbid) {
+    switch (to_cupti_callback_id(cbid)) {
     // Runtime API callbacks
     case CUPTI_RUNTIME_TRACE_CBID_cudaMalloc_v3020:
         return "cudaMalloc";
@@ -266,11 +402,11 @@ std::string get_callback_name(CUpti_CallbackId cbid) {
         return "cuMemFreeAsync_ptsz";
 
     default:
-        return "Unknown_" + std::to_string(cbid);
+        return "Unknown_" + std::to_string(cbid.underlying());
     }
 }
 
-std::string CuptiMonitor::get_callback_summary() const {
+std::string CuptiMonitor::Impl::get_callback_summary() const {
     std::lock_guard<std::mutex> lock(mutex_);
 
     if (callback_counters_.empty()) {
@@ -284,7 +420,7 @@ std::string CuptiMonitor::get_callback_summary() const {
     std::size_t total = 0;
 
     // Sort callbacks by count (descending) for better readability
-    std::vector<std::pair<CUpti_CallbackId, std::size_t>> sorted_callbacks(
+    std::vector<std::pair<CuptiCallbackId, std::size_t>> sorted_callbacks(
         callback_counters_.begin(), callback_counters_.end()
     );
     std::ranges::sort(sorted_callbacks, std::greater{}, [](auto const& v) {
@@ -304,7 +440,7 @@ std::string CuptiMonitor::get_callback_summary() const {
     return ss.str();
 }
 
-void CuptiMonitor::capture_memory_usage_impl() {
+void CuptiMonitor::Impl::capture_memory_usage_impl() {
     std::size_t free_mem, total_mem;
     cudaError_t cuda_status = cudaMemGetInfo(&free_mem, &total_mem);
 
@@ -345,14 +481,14 @@ void CuptiMonitor::capture_memory_usage_impl() {
     }
 }
 
-void CuptiMonitor::periodic_memory_sampling() {
+void CuptiMonitor::Impl::periodic_memory_sampling() {
     while (monitoring_active_.load()) {
         capture_memory_sample();
         std::this_thread::sleep_for(sampling_interval_ms_);
     }
 }
 
-CUptiResult CuptiMonitor::subscribe() {
+CUptiResult CuptiMonitor::Impl::subscribe() {
     CUptiResult cupti_err;
 
     cupti_err = cuptiSubscribe(&cupti_subscriber_, callback_wrapper, this);
@@ -381,18 +517,18 @@ CUptiResult CuptiMonitor::subscribe() {
     return cupti_err;
 }
 
-void CuptiMonitor::unsubscribe() {
+void CuptiMonitor::Impl::unsubscribe() {
     cuptiUnsubscribe(cupti_subscriber_);
 }
 
-void CUPTIAPI CuptiMonitor::callback_wrapper(
+void CUPTIAPI CuptiMonitor::Impl::callback_wrapper(
     void* userdata, CUpti_CallbackDomain domain, CUpti_CallbackId cbid, void const* cbdata
 ) {
-    auto* monitor = static_cast<CuptiMonitor*>(userdata);
+    auto* monitor = static_cast<CuptiMonitor::Impl*>(userdata);
     monitor->callback(domain, cbid, cbdata);
 }
 
-void CuptiMonitor::callback(
+void CuptiMonitor::Impl::callback(
     CUpti_CallbackDomain domain, CUpti_CallbackId cbid, void const* cbdata
 ) {
     if (!monitoring_active_.load())
@@ -411,7 +547,7 @@ void CuptiMonitor::callback(
     if (should_monitor && cbInfo->callbackSite == CUPTI_API_EXIT) {
         {
             std::lock_guard<std::mutex> lock(mutex_);
-            callback_counters_[cbid]++;
+            callback_counters_[make_callback_id(cbid)]++;
         }
 
         capture_memory_sample();

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -235,6 +235,23 @@ target_sources(single_tests PRIVATE test_nvtx.cpp)
 disable_sign_conversion_warning(single_tests)
 add_test(NAME single_tests COMMAND "gtests/single_tests")
 
+add_executable(cupti_public_api_test test_cupti_public_api.cpp)
+set_target_properties(
+  cupti_public_api_test
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${RAPIDSMPF_BINARY_DIR}/gtests"
+             CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED ON
+             CXX_EXTENSIONS ON
+             COMPONENT testing
+)
+target_include_directories(cupti_public_api_test PRIVATE "${PROJECT_SOURCE_DIR}/include")
+target_compile_definitions(cupti_public_api_test PRIVATE RAPIDSMPF_HAVE_CUPTI)
+target_compile_options(
+  cupti_public_api_test PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
+)
+disable_sign_conversion_warning(cupti_public_api_test)
+add_test(NAME cupti_public_api_test COMMAND "gtests/cupti_public_api_test")
+
 # bootstrap_tests — standalone; compiles bootstrap sources directly so it does not depend on the
 # full rapidsmpf library (and its CUDA sources).
 add_executable(

--- a/cpp/tests/test_cupti_public_api.cpp
+++ b/cpp/tests/test_cupti_public_api.cpp
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstddef>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include <rapidsmpf/cupti.hpp>
+
+static_assert(
+    std::is_same_v<
+        decltype(std::declval<rapidsmpf::CuptiMonitor const&>().get_callback_counters()),
+        std::unordered_map<rapidsmpf::CuptiCallbackId, std::size_t>>
+);
+
+int main() {
+    return 0;
+}

--- a/python/rapidsmpf/rapidsmpf/cupti.pxd
+++ b/python/rapidsmpf/rapidsmpf/cupti.pxd
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stddef cimport size_t
+from libc.stdint cimport int32_t
 from libcpp cimport bool as bool_t
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -15,12 +16,11 @@ cdef extern from "<chrono>" namespace "std::chrono" nogil:
     cdef cppclass milliseconds:
         milliseconds(long long) except +ex_handler
 
-cdef extern from "<cupti.h>" nogil:
-    ctypedef enum CUpti_CallbackId:
-        pass
-
 
 cdef extern from "<rapidsmpf/cupti.hpp>" nogil:
+    cdef cppclass cpp_CuptiCallbackId "rapidsmpf::CuptiCallbackId":
+        int32_t underlying() const
+
     cdef struct cpp_MemoryDataPoint "rapidsmpf::MemoryDataPoint":
         double timestamp
         size_t free_memory
@@ -41,7 +41,7 @@ cdef extern from "<rapidsmpf/cupti.hpp>" nogil:
         size_t get_sample_count() except +ex_handler
         void write_csv(const string& filename) except +ex_handler
         void set_debug_output(bool_t enabled, size_t threshold_mb) except +ex_handler
-        unordered_map[CUpti_CallbackId, size_t] get_callback_counters() \
+        unordered_map[cpp_CuptiCallbackId, size_t] get_callback_counters() \
             except +ex_handler
         void clear_callback_counters() except +ex_handler
         size_t get_total_callback_count() except +ex_handler

--- a/python/rapidsmpf/rapidsmpf/cupti.pyx
+++ b/python/rapidsmpf/rapidsmpf/cupti.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -214,14 +214,14 @@ cdef class CuptiMonitor:
         -------
         Dictionary from CUPTI callback ID to call count
         """
-        cdef unordered_map[CUpti_CallbackId, size_t] counters
+        cdef unordered_map[cpp_CuptiCallbackId, size_t] counters
         with nogil:
             counters = self._handle.get().get_callback_counters()
 
         cdef dict ret = {}
-        cdef unordered_map[CUpti_CallbackId, size_t].iterator it = counters.begin()
+        cdef unordered_map[cpp_CuptiCallbackId, size_t].iterator it = counters.begin()
         while it != counters.end():
-            ret[<int>deref(it).first] = <int>deref(it).second
+            ret[<int>deref(it).first.underlying()] = <int>deref(it).second
             postincrement(it)
         return ret
 


### PR DESCRIPTION
List of changes:
- move `CuptiMonitor` implementation details into a private PImpl
- remove `cuda_runtime.h` and `cupti.h` from the public `rapidsmpf/cupti.hpp` header
- add `rapidsmpf::CuptiCallbackId` as the public callback counter key wrapper
- update Cython CUPTI bindings to avoid importing `<cupti.h>`
- add a compile-only public header regression test that does not inherit CUDA/CUPTI include paths