### PR TITLE
build: remove stale NVCC -diag-suppress=1407

### DIFF
--- a/cmake/Modules/ConfigureCUDA.cmake
+++ b/cmake/Modules/ConfigureCUDA.cmake
@@ -31,11 +31,6 @@ list(
   RAPIDSMPF_CUDA_FLAGS
   -Xcompiler=-Wall,-Werror,-Wextra,-Wsign-conversion,-Wno-unknown-pragmas,-Wno-missing-field-initializers,-Wno-error=deprecated-declarations
 )
-# This warning needs to be suppressed because some parts of rapidsmpf instantiate templated CCCL
-# functions in contexts where the resulting instantiations would have internal linkage (e.g. in
-# anonymous namespaces). In such contexts, the visibility attribute on the template is ignored, and
-# the compiler issues a warning. This is not a problem and will be fixed in future versions of CCCL.
-list(APPEND RAPIDSMPF_CUDA_FLAGS -diag-suppress=1407)
 
 if(DISABLE_DEPRECATION_WARNINGS)
   list(APPEND RAPIDSMPF_CXX_FLAGS -Wno-deprecated-declarations)


### PR DESCRIPTION
This PR removes the `-diag-suppress=1407` NVCC flag from `cmake/Modules/ConfigureCUDA.cmake`.

## Background

The suppression was added in the initial commit ~2 years ago to silence NVCC warning 1407, which fires when CCCL templates are instantiated in contexts with internal linkage (e.g. anonymous namespaces). The comment noted: *"This is not a problem and will be fixed in future versions of CCCL."*

The item was tracked as a follow-up in [rapidsai/cudf#22771](https://github.com/rapidsai/cudf/issues/22771), referenced from [PR #1083 discussion](https://github.com/rapidsai/rapidsmpf/pull/1083#discussion_r3370651625).

## Why it's safe to remove

1. **The library has zero `.cu` files** — all source under `cpp/src/` is `.cpp`, so the NVCC-specific flag never applied to library compilation.
2. **The only `.cu` file is `cpp/tests/test_allreduce.cu`**, which uses CCCL templates (`cuda::std::plus`, `cuda::minimum`, etc.) inside an anonymous namespace — exactly the pattern that used to trigger the warning.
3. **Verified empirically**: compiling `test_allreduce.cu` with `-Werror=all-warnings` and **without** `-diag-suppress=1407` using CUDA 12.9 (nvcc V12.9.86) produces **zero** warning 1407 instances. CCCL has fixed the underlying visibility attribute issue.

## Addresses

- Partial fix for [rapidsai/cudf#22771](https://github.com/rapidsai/cudf/issues/22771) (the rapidsmpf follow-up item)