### PR TITLE
Fix CudaEvent move assignment

### DIFF
--- a/cpp/include/rapidsmpf/cuda_event.hpp
+++ b/cpp/include/rapidsmpf/cuda_event.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -80,8 +80,14 @@ class CudaEvent {
     /**
      * @brief Move assignment operator.
      *
+     * The destination must be empty, for example because it has previously been
+     * moved from. Move-assigning into a `CudaEvent` that already owns an event is
+     * not allowed.
+     *
      * @param other Source CudaEvent to move from.
      * @return Reference to this object.
+     *
+     * @throws std::invalid_argument if this object already owns an event.
      */
     CudaEvent& operator=(CudaEvent&& other);
 

--- a/cpp/src/cuda_event.cpp
+++ b/cpp/src/cuda_event.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <utility>
+
 #include <rapidsmpf/cuda_event.hpp>
 
 namespace rapidsmpf {
@@ -36,7 +38,7 @@ CudaEvent& CudaEvent::operator=(CudaEvent&& other) {
             "cannot move into an already-initialized CudaEvent",
             std::invalid_argument
         );
-        other.event_ = nullptr;
+        event_ = std::exchange(other.event_, nullptr);
     }
     return *this;
 }

--- a/cpp/tests/test_cuda_stream.cpp
+++ b/cpp/tests/test_cuda_stream.cpp
@@ -6,6 +6,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <utility>
+
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -17,6 +19,22 @@
 
 
 using namespace rapidsmpf;
+
+TEST(CudaEvent, MoveAssignmentTransfersEventHandle) {
+    CudaEvent destination;
+    CudaEvent moved_from_destination{std::move(destination)};
+    CudaEvent source;
+    auto source_event = source.value();
+
+    EXPECT_NE(moved_from_destination.value(), nullptr);
+    EXPECT_EQ(destination.value(), nullptr);
+    ASSERT_NE(source_event, nullptr);
+
+    destination = std::move(source);
+
+    EXPECT_EQ(destination.value(), source_event);
+    EXPECT_EQ(source.value(), nullptr);
+}
 
 TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
     // 3 upstreams write disjoint slices repeatedly (slow), then 3 downstreams

--- a/cpp/tests/test_cuda_stream.cpp
+++ b/cpp/tests/test_cuda_stream.cpp
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <utility>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <utility>
 
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>


### PR DESCRIPTION
## Summary

Fix `CudaEvent::operator=(CudaEvent&&)` so it takes ownership of the source CUDA event handle before clearing the moved-from object.

The move assignment operator kept the existing empty-destination guard, but after the completion-cache removal it only nulled `other.event_`. That left the destination empty and dropped the source handle.

This also adds a focused regression test that moves into an emptied `CudaEvent` and checks that the handle transfers to the destination and is cleared from the source.

## Validation

- `git diff --check`
- Attempted a minimal CMake configure for C++ tests, but this local environment has no CUDA toolkit: CMake stops at `Failed to find nvcc`.