### PR TITLE
Wait for UCXX listener addresses before distribution

### DIFF
--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -445,8 +445,7 @@ class SharedResources {
 
     void barrier() {
         // The root needs to have endpoints to all other ranks to continue.
-        while (rank_ == 0 && rank_endpoint_count() != safe_cast<std::size_t>(nranks()))
-        {
+        while (rank_ == 0 && rank_endpoint_count() != safe_cast<std::size_t>(nranks())) {
             progress_worker();
         }
 

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -361,9 +361,11 @@ class SharedResources {
         futures_.push_back(std::move(future));
     }
 
-    [[nodiscard]] std::size_t rank_endpoint_count() {
-        std::lock_guard<std::mutex> lock(endpoints_mutex_);
-        return rank_to_endpoint_.size();
+    [[nodiscard]] bool all_barrier_maps_registered() {
+        std::scoped_lock lock(endpoints_mutex_, listener_mutex_);
+        auto const expected_size = safe_cast<std::size_t>(nranks());
+        return rank_to_endpoint_.size() == expected_size
+               && rank_to_listener_address_.size() == expected_size;
     }
 
     [[nodiscard]] RankToEndpointMap rank_to_endpoint_snapshot() {
@@ -380,7 +382,8 @@ class SharedResources {
      * worker may no longer be progressed when a peer attempts lazy endpoint
      * creation.
      *
-     * Must only be called on the root rank, after all ranks have connected.
+     * Must only be called on the root rank, after all ranks have connected and
+     * registered listener addresses.
      */
     void distribute_listener_addresses() {
         RankToEndpointMap rank_to_endpoint;
@@ -390,9 +393,19 @@ class SharedResources {
             if (listener_addresses_distributed_) {
                 return;
             }
-            listener_addresses_distributed_ = true;
+            auto const expected_size = safe_cast<std::size_t>(nranks());
+            RAPIDSMPF_EXPECTS(
+                rank_to_endpoint_.size() == expected_size,
+                "cannot distribute listener addresses before all endpoints are registered"
+            );
+            RAPIDSMPF_EXPECTS(
+                rank_to_listener_address_.size() == expected_size,
+                "cannot distribute listener addresses before all listener addresses are "
+                "registered"
+            );
             rank_to_endpoint = rank_to_endpoint_;
             rank_to_listener_address = rank_to_listener_address_;
+            listener_addresses_distributed_ = true;
         }
 
         // Pack all listener addresses (except the destination's own) into a
@@ -444,8 +457,8 @@ class SharedResources {
     }
 
     void barrier() {
-        // The root needs to have endpoints to all other ranks to continue.
-        while (rank_ == 0 && rank_endpoint_count() != safe_cast<std::size_t>(nranks())) {
+        // The root needs endpoints and listener addresses for all ranks to continue.
+        while (rank_ == 0 && !all_barrier_maps_registered()) {
             progress_worker();
         }
 

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -368,11 +368,6 @@ class SharedResources {
                && rank_to_listener_address_.size() == expected_size;
     }
 
-    [[nodiscard]] RankToEndpointMap rank_to_endpoint_snapshot() {
-        std::lock_guard<std::mutex> lock(endpoints_mutex_);
-        return rank_to_endpoint_;
-    }
-
     /**
      * @brief Distribute all listener addresses from root to every non-root rank.
      *
@@ -386,8 +381,6 @@ class SharedResources {
      * registered listener addresses.
      */
     void distribute_listener_addresses() {
-        RankToEndpointMap rank_to_endpoint;
-        RankToListenerAddressMap rank_to_listener_address;
         {
             std::scoped_lock lock(endpoints_mutex_, listener_mutex_);
             if (listener_addresses_distributed_) {
@@ -403,8 +396,6 @@ class SharedResources {
                 "cannot distribute listener addresses before all listener addresses are "
                 "registered"
             );
-            rank_to_endpoint = rank_to_endpoint_;
-            rank_to_listener_address = rank_to_listener_address_;
             listener_addresses_distributed_ = true;
         }
 
@@ -413,7 +404,7 @@ class SharedResources {
         // Format: [ControlMessage][count][addr1_size][addr1]...[addrN_size][addrN]
         std::vector<std::shared_ptr<::ucxx::Request>> reqs;
         std::vector<std::unique_ptr<std::vector<std::uint8_t>>> bufs;
-        for (auto const& [dst, ep] : rank_to_endpoint) {
+        for (auto const& [dst, ep] : rank_to_endpoint_) {
             if (dst == 0) {
                 continue;
             }
@@ -421,7 +412,7 @@ class SharedResources {
             auto const control = ControlMessage::DistributeListenerAddresses;
             std::size_t count{0};
             std::size_t total = sizeof(control) + sizeof(count);
-            for (auto const& [src, addr] : rank_to_listener_address) {
+            for (auto const& [src, addr] : rank_to_listener_address_) {
                 if (src == dst) {
                     continue;
                 }
@@ -433,7 +424,7 @@ class SharedResources {
             std::size_t off{0};
             encode(packed->data(), &control, sizeof(control), off);
             encode(packed->data(), &count, sizeof(count), off);
-            for (auto const& [src, addr] : rank_to_listener_address) {
+            for (auto const& [src, addr] : rank_to_listener_address_) {
                 if (src == dst) {
                     continue;
                 }
@@ -463,11 +454,10 @@ class SharedResources {
         }
 
         if (rank_ == 0) {
-            auto const rank_to_endpoint = rank_to_endpoint_snapshot();
             std::vector<std::shared_ptr<::ucxx::Request>> requests;
             requests.reserve(safe_cast<std::size_t>(nranks() - 1));
             // send to all other ranks
-            for (auto const& [rank, endpoint] : rank_to_endpoint) {
+            for (auto const& [rank, endpoint] : rank_to_endpoint_) {
                 if (rank == 0) {
                     continue;
                 }
@@ -482,7 +472,7 @@ class SharedResources {
             requests.clear();
 
             // receive from all other ranks
-            for (auto const& [rank, endpoint] : rank_to_endpoint) {
+            for (auto const& [rank, endpoint] : rank_to_endpoint_) {
                 if (rank == 0) {
                     continue;
                 }
@@ -499,7 +489,7 @@ class SharedResources {
             distribute_listener_addresses();
 
             // Everyone has reported, release other ranks.
-            for (auto const& [rank, endpoint] : rank_to_endpoint) {
+            for (auto const& [rank, endpoint] : rank_to_endpoint_) {
                 if (rank == 0) {
                     continue;
                 }

--- a/cpp/src/communicator/ucxx.cpp
+++ b/cpp/src/communicator/ucxx.cpp
@@ -361,6 +361,16 @@ class SharedResources {
         futures_.push_back(std::move(future));
     }
 
+    [[nodiscard]] std::size_t rank_endpoint_count() {
+        std::lock_guard<std::mutex> lock(endpoints_mutex_);
+        return rank_to_endpoint_.size();
+    }
+
+    [[nodiscard]] RankToEndpointMap rank_to_endpoint_snapshot() {
+        std::lock_guard<std::mutex> lock(endpoints_mutex_);
+        return rank_to_endpoint_;
+    }
+
     /**
      * @brief Distribute all listener addresses from root to every non-root rank.
      *
@@ -373,17 +383,24 @@ class SharedResources {
      * Must only be called on the root rank, after all ranks have connected.
      */
     void distribute_listener_addresses() {
-        if (listener_addresses_distributed_) {
-            return;
+        RankToEndpointMap rank_to_endpoint;
+        RankToListenerAddressMap rank_to_listener_address;
+        {
+            std::scoped_lock lock(endpoints_mutex_, listener_mutex_);
+            if (listener_addresses_distributed_) {
+                return;
+            }
+            listener_addresses_distributed_ = true;
+            rank_to_endpoint = rank_to_endpoint_;
+            rank_to_listener_address = rank_to_listener_address_;
         }
-        listener_addresses_distributed_ = true;
 
         // Pack all listener addresses (except the destination's own) into a
         // single DistributeListenerAddresses message per non-root rank.
         // Format: [ControlMessage][count][addr1_size][addr1]...[addrN_size][addrN]
         std::vector<std::shared_ptr<::ucxx::Request>> reqs;
         std::vector<std::unique_ptr<std::vector<std::uint8_t>>> bufs;
-        for (auto& [dst, ep] : rank_to_endpoint_) {
+        for (auto const& [dst, ep] : rank_to_endpoint) {
             if (dst == 0) {
                 continue;
             }
@@ -391,7 +408,7 @@ class SharedResources {
             auto const control = ControlMessage::DistributeListenerAddresses;
             std::size_t count{0};
             std::size_t total = sizeof(control) + sizeof(count);
-            for (auto& [src, addr] : rank_to_listener_address_) {
+            for (auto const& [src, addr] : rank_to_listener_address) {
                 if (src == dst) {
                     continue;
                 }
@@ -403,7 +420,7 @@ class SharedResources {
             std::size_t off{0};
             encode(packed->data(), &control, sizeof(control), off);
             encode(packed->data(), &count, sizeof(count), off);
-            for (auto& [src, addr] : rank_to_listener_address_) {
+            for (auto const& [src, addr] : rank_to_listener_address) {
                 if (src == dst) {
                     continue;
                 }
@@ -428,16 +445,17 @@ class SharedResources {
 
     void barrier() {
         // The root needs to have endpoints to all other ranks to continue.
-        while (rank_ == 0 && rank_to_endpoint_.size() != safe_cast<std::size_t>(nranks()))
+        while (rank_ == 0 && rank_endpoint_count() != safe_cast<std::size_t>(nranks()))
         {
             progress_worker();
         }
 
         if (rank_ == 0) {
+            auto const rank_to_endpoint = rank_to_endpoint_snapshot();
             std::vector<std::shared_ptr<::ucxx::Request>> requests;
             requests.reserve(safe_cast<std::size_t>(nranks() - 1));
             // send to all other ranks
-            for (auto& [rank, endpoint] : rank_to_endpoint_) {
+            for (auto const& [rank, endpoint] : rank_to_endpoint) {
                 if (rank == 0) {
                     continue;
                 }
@@ -452,7 +470,7 @@ class SharedResources {
             requests.clear();
 
             // receive from all other ranks
-            for (auto& [rank, endpoint] : rank_to_endpoint_) {
+            for (auto const& [rank, endpoint] : rank_to_endpoint) {
                 if (rank == 0) {
                     continue;
                 }
@@ -469,7 +487,7 @@ class SharedResources {
             distribute_listener_addresses();
 
             // Everyone has reported, release other ranks.
-            for (auto& [rank, endpoint] : rank_to_endpoint_) {
+            for (auto const& [rank, endpoint] : rank_to_endpoint) {
                 if (rank == 0) {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Fix UCXX root barrier setup so listener-address distribution only starts after the root has both the endpoint and listener address for every rank.

In the `HostPortPair` path, endpoint registration and listener-address registration are separate: `listener_callback()` records the endpoint when a rank connects, and `RegisterListenerAddress` can be handled later. Previously the root barrier waited only for `rank_to_endpoint_` to reach `nranks()`, so `distribute_listener_addresses()` could run with a partial `rank_to_listener_address_`, mark distribution complete, and skip late addresses.

This change makes the root wait for both maps to reach `nranks()`, documents the stronger precondition, and checks the invariants under the existing map mutexes before setting `listener_addresses_distributed_`.

## Validation

- `git diff --check`
- `pre-commit run --files cpp/src/communicator/ucxx.cpp`
- Attempted a minimal CMake configure for C++ tests, but this local environment has no CUDA toolkit: CMake stops at `Failed to find nvcc`.