### PR TITLE
Fix Buffer exclusive access ordering

### DIFF
--- a/cpp/src/memory/buffer.cpp
+++ b/cpp/src/memory/buffer.cpp
@@ -75,8 +75,6 @@ std::byte const* Buffer::data() const {
 }
 
 std::byte* Buffer::exclusive_data_access() {
-    RAPIDSMPF_EXPECTS(is_latest_write_done(), "the latest write isn't done");
-
     bool expected = false;
     RAPIDSMPF_EXPECTS(
         lock_.compare_exchange_strong(
@@ -84,6 +82,17 @@ std::byte* Buffer::exclusive_data_access() {
         ),
         "the buffer is already locked"
     );
+    bool latest_write_done;
+    try {
+        latest_write_done = size == 0 || latest_write_event_.is_ready();
+    } catch (...) {
+        unlock();
+        throw;
+    }
+    if (!latest_write_done) {
+        unlock();
+        RAPIDSMPF_FAIL("the latest write isn't done");
+    }
     return std::visit(
         [](auto&& storage) -> std::byte* {
             return reinterpret_cast<std::byte*>(storage->data());

--- a/cpp/tests/test_buffer.cpp
+++ b/cpp/tests/test_buffer.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <cstring>
+#include <future>
 #include <memory>
 #include <random>
 #include <vector>
@@ -232,4 +233,41 @@ TEST_P(BufferRebindStreamTest, ThrowsWhenLocked) {
 
     EXPECT_NO_THROW(buffer->rebind_stream(stream2));
     EXPECT_EQ(buffer->stream().value(), stream2.value());
+}
+
+TEST_P(BufferRebindStreamTest, ExclusiveDataAccessReleasesLockIfLatestWriteIsPending) {
+    MemoryType mem_type = GetParam();
+    auto stream = stream_pool->get_stream();
+
+    constexpr std::size_t test_size = 1_MiB;
+    auto [reserve, overbooking] = br->reserve(mem_type, test_size, AllowOverbooking::YES);
+    auto buffer = br->make_buffer(test_size, stream, reserve);
+    EXPECT_EQ(buffer->mem_type(), mem_type);
+
+    struct Gate {
+        std::promise<void> promise{};
+        std::future<void> future{promise.get_future()};
+
+        static void CUDART_CB wait_cb(void* data) noexcept {
+            static_cast<Gate*>(data)->future.wait();
+        }
+
+        void open() {
+            promise.set_value();
+        }
+    };
+
+    Gate gate;
+    buffer->write_access([&](std::byte*, rmm::cuda_stream_view op_stream) {
+        RAPIDSMPF_CUDA_TRY(cudaLaunchHostFunc(op_stream.value(), Gate::wait_cb, &gate));
+    });
+
+    EXPECT_THROW(buffer->exclusive_data_access(), std::logic_error);
+    EXPECT_NO_THROW(static_cast<void>(buffer->data()));
+
+    gate.open();
+    stream.synchronize();
+    auto* ptr = buffer->exclusive_data_access();
+    EXPECT_NE(ptr, nullptr);
+    buffer->unlock();
 }


### PR DESCRIPTION
## Summary

Fix `Buffer::exclusive_data_access()` so it acquires the Buffer lock before checking whether the latest stream-ordered write is complete.

Previously the readiness check happened first through `is_latest_write_done()`, then the exclusive lock was acquired. A concurrent `write_access()` could pass its lock check and enqueue/record a newer write in between, allowing exclusive access based on a stale completed event.

The new ordering acquires `lock_` first, checks `latest_write_event_` while the lock blocks other Buffer API access, and releases the lock again if the readiness check fails or throws.

This also adds a regression test that blocks the buffer stream with a host callback, verifies `exclusive_data_access()` rejects the pending write, and confirms the failed attempt does not leave the buffer locked.

## Validation

- `git diff --check`
- Attempted a minimal CMake configure for C++ tests, but this local environment has no CUDA toolkit: CMake stops at `Failed to find nvcc`.