### PR TITLE
Report the value that failed to cast in safe_cast error message

### DIFF
--- a/cpp/include/rapidsmpf/utils/misc.hpp
+++ b/cpp/include/rapidsmpf/utils/misc.hpp
@@ -401,8 +401,8 @@ constexpr To safe_cast(
         if (!std::in_range<To>(value)) {
             throw std::overflow_error(
                 "RapidsMPF cast error at: " + std::string(loc.file_name()) + ":"
-                + std::to_string(loc.line()) + ", value out of range (value="
-                + std::to_string(value) + ")"
+                + std::to_string(loc.line())
+                + ", value out of range (value=" + std::to_string(value) + ")"
             );
         }
         return static_cast<To>(value);

--- a/cpp/include/rapidsmpf/utils/misc.hpp
+++ b/cpp/include/rapidsmpf/utils/misc.hpp
@@ -399,19 +399,10 @@ constexpr To safe_cast(
     } else if constexpr (std::is_integral_v<From> && std::is_integral_v<To>) {
         // Integer to integer.
         if (!std::in_range<To>(value)) {
-            auto const source_value = [&]() {
-                if constexpr (std::is_same_v<std::remove_cv_t<From>, bool>) {
-                    return std::string{value ? "true" : "false"};
-                } else if constexpr (std::is_signed_v<From>) {
-                    return std::to_string(static_cast<long long>(value));
-                } else {
-                    return std::to_string(static_cast<unsigned long long>(value));
-                }
-            }();
             throw std::overflow_error(
                 "RapidsMPF cast error at: " + std::string(loc.file_name()) + ":"
                 + std::to_string(loc.line()) + ", value out of range (value="
-                + source_value + ")"
+                + std::to_string(value) + ")"
             );
         }
         return static_cast<To>(value);

--- a/cpp/include/rapidsmpf/utils/misc.hpp
+++ b/cpp/include/rapidsmpf/utils/misc.hpp
@@ -399,9 +399,19 @@ constexpr To safe_cast(
     } else if constexpr (std::is_integral_v<From> && std::is_integral_v<To>) {
         // Integer to integer.
         if (!std::in_range<To>(value)) {
+            auto const source_value = [&]() {
+                if constexpr (std::is_same_v<std::remove_cv_t<From>, bool>) {
+                    return std::string{value ? "true" : "false"};
+                } else if constexpr (std::is_signed_v<From>) {
+                    return std::to_string(static_cast<long long>(value));
+                } else {
+                    return std::to_string(static_cast<unsigned long long>(value));
+                }
+            }();
             throw std::overflow_error(
                 "RapidsMPF cast error at: " + std::string(loc.file_name()) + ":"
-                + std::to_string(loc.line()) + ", value out of range"
+                + std::to_string(loc.line()) + ", value out of range (value="
+                + source_value + ")"
             );
         }
         return static_cast<To>(value);

--- a/cpp/tests/test_misc.cpp
+++ b/cpp/tests/test_misc.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -212,6 +213,41 @@ TEST(MiscTest, SafeCastErrorMessageContainsLocation) {
         EXPECT_TRUE(msg.find("RapidsMPF cast error") != std::string::npos)
             << "Error message should contain 'RapidsMPF cast error': " << msg;
     }
+}
+
+// Test that error messages include the offending source value.
+TEST(MiscTest, SafeCastErrorMessageContainsValue) {
+    std::string msg;
+    int const cast_line = __LINE__ + 1;
+    try {
+        safe_cast<unsigned>(-1);
+        FAIL() << "Expected std::overflow_error";
+    } catch (const std::overflow_error& e) {
+        msg = e.what();
+    }
+
+    std::string const expected = "RapidsMPF cast error at: "
+                                 + std::string(__FILE__) + ":" + std::to_string(cast_line)
+                                 + ", value out of range (value=-1)";
+    EXPECT_EQ(msg, expected);
+}
+
+// Test that error messages include large unsigned source values.
+TEST(MiscTest, SafeCastErrorMessageContainsLargeUnsignedValue) {
+    std::string msg;
+    int const cast_line = __LINE__ + 1;
+    try {
+        safe_cast<std::int64_t>(UINT64_MAX);
+        FAIL() << "Expected std::overflow_error";
+    } catch (const std::overflow_error& e) {
+        msg = e.what();
+    }
+
+    std::string const expected = "RapidsMPF cast error at: "
+                                 + std::string(__FILE__) + ":" + std::to_string(cast_line)
+                                 + ", value out of range (value="
+                                 + std::to_string(UINT64_MAX) + ")";
+    EXPECT_EQ(msg, expected);
 }
 
 // Test zero and boundary values

--- a/cpp/tests/test_misc.cpp
+++ b/cpp/tests/test_misc.cpp
@@ -200,7 +200,7 @@ TEST(MiscTest, SafeCastFloatingPointConversions) {
     EXPECT_EQ(safe_cast<int>(-2.7), -2);
 }
 
-// Test that error messages include source location
+// Test that error messages include source location & value.
 TEST(MiscTest, SafeCastErrorMessageContainsLocation) {
     try {
         safe_cast<unsigned>(-1);
@@ -212,42 +212,22 @@ TEST(MiscTest, SafeCastErrorMessageContainsLocation) {
             << "Error message should contain file name: " << msg;
         EXPECT_TRUE(msg.find("RapidsMPF cast error") != std::string::npos)
             << "Error message should contain 'RapidsMPF cast error': " << msg;
+        EXPECT_TRUE(msg.find("value=-1") != std::string::npos)
+            << "Error message should contain 'value=-1': " << msg;
     }
-}
-
-// Test that error messages include the offending source value.
-TEST(MiscTest, SafeCastErrorMessageContainsValue) {
-    std::string msg;
-    int const cast_line = __LINE__ + 1;
-    try {
-        safe_cast<unsigned>(-1);
-        FAIL() << "Expected std::overflow_error";
-    } catch (const std::overflow_error& e) {
-        msg = e.what();
-    }
-
-    std::string const expected = "RapidsMPF cast error at: "
-                                 + std::string(__FILE__) + ":" + std::to_string(cast_line)
-                                 + ", value out of range (value=-1)";
-    EXPECT_EQ(msg, expected);
 }
 
 // Test that error messages include large unsigned source values.
 TEST(MiscTest, SafeCastErrorMessageContainsLargeUnsignedValue) {
     std::string msg;
-    int const cast_line = __LINE__ + 1;
     try {
         safe_cast<std::int64_t>(UINT64_MAX);
         FAIL() << "Expected std::overflow_error";
     } catch (const std::overflow_error& e) {
         msg = e.what();
     }
-
-    std::string const expected = "RapidsMPF cast error at: "
-                                 + std::string(__FILE__) + ":" + std::to_string(cast_line)
-                                 + ", value out of range (value="
-                                 + std::to_string(UINT64_MAX) + ")";
-    EXPECT_EQ(msg, expected);
+    EXPECT_TRUE(msg.find("value=" + std::to_string(UINT64_MAX)) != std::string::npos)
+        << "Error message should contain large unsigned value: " << msg;
 }
 
 // Test zero and boundary values


### PR DESCRIPTION
https://github.com/rapidsai/cudf/issues/22964 is a cudf-polars issue with
a traceback pointing to rapidsmpf's safe_cast. To help with debugging that,
we'll include the value that failed to cast in the error message.