### PR TITLE
Update docs to use NVIDIA Sphinx theme

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -41,7 +41,6 @@ dependencies:
 - openmpi >=5.0
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0
@@ -54,4 +53,6 @@ dependencies:
 - sysroot_linux-aarch64=2.28
 - ucxx==0.51.*,>=0.0.0a0
 - valgrind
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -41,7 +41,6 @@ dependencies:
 - openmpi >=5.0
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0
@@ -54,4 +53,6 @@ dependencies:
 - sysroot_linux-64=2.28
 - ucxx==0.51.*,>=0.0.0a0
 - valgrind
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -41,7 +41,6 @@ dependencies:
 - openmpi >=5.0
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0
@@ -54,4 +53,6 @@ dependencies:
 - sysroot_linux-aarch64=2.28
 - ucxx==0.51.*,>=0.0.0a0
 - valgrind
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -41,7 +41,6 @@ dependencies:
 - openmpi >=5.0
 - pre-commit
 - psutil
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - python>=3.11
 - rapids-build-backend>=0.4.0,<0.5.0
@@ -54,4 +53,6 @@ dependencies:
 - sysroot_linux-64=2.28
 - ucxx==0.51.*,>=0.0.0a0
 - valgrind
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -526,7 +526,8 @@ dependencies:
           - myst-parser
           - numpydoc
           - openmpi >=5.0  # See <https://github.com/rapidsai/rapidsmpf/issues/17>
-          - pydata-sphinx-theme>=0.15.4
+          - pip:
+              - nvidia-sphinx-theme
           - sphinx>=8.1.0
           - sphinx-autobuild
           - sphinx-copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,13 +10,15 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 from __future__ import annotations
 
+import datetime
+
 from enum import IntEnum, IntFlag
 from typing import Any
 
 from sphinx.ext.autodoc import ClassDocumenter
 
-project = "rapidsmpf"
-copyright = "2025-2026, NVIDIA Corporation"
+project = "NVIDIA RapidsMPF"
+copyright = f"2025-{datetime.datetime.today().year}, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,10 +55,14 @@ html_css_files = ["custom.css"]
 
 html_theme_options = {
     "external_links": [],
-    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
-    "icon_links": [],
-    "github_url": "https://github.com/rapidsai/rapidsmpf",
-    "twitter_url": "https://twitter.com/rapidsai",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/rapidsai/rapidsmpf",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+    ],
     "show_toc_level": 2,
     "navbar_align": "right",
     "navigation_with_keys": True,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,8 +67,7 @@ html_theme_options = {
 # a list of builtin themes.
 #
 
-html_theme = "pydata_sphinx_theme"
-html_logo = "_static/RAPIDS-logo-purple.png"
+html_theme = "nvidia_sphinx_theme"
 
 numpydoc_class_members_toctree = False
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,7 +1,7 @@
-# RapidsMPF documentation
+# NVIDIA RapidsMPF Documentation
 
 Building high-performance GPU pipelines is hard. Each stage must move data efficiently between GPUs and processes, synchronize work, and manage limited device memory.
-RapidsMPF, including its nascent Streaming Engine and Out-of-Core (OOC) shuffle, provides a unified framework for asynchronous, multi-GPU pipelines using simple streaming primitives — {term}`Channel`s, {term}`Actor`s, and {term}`Message`s — built on RAPIDS components: [rmm](https://docs.rapids.ai/api/rmm/nightly) and [ucxx](https://docs.rapids.ai/api/ucxx/nightly/).
+NVIDIA RapidsMPF, including its nascent Streaming Engine and Out-of-Core (OOC) shuffle, provides a unified framework for asynchronous, multi-GPU pipelines using simple streaming primitives — {term}`Channel`s, {term}`Actor`s, and {term}`Message`s — built on RAPIDS components: [rmm](https://docs.rapids.ai/api/rmm/nightly) and [ucxx](https://docs.rapids.ai/api/ucxx/nightly/).
 
 RapidsMPF's design leverages Explicit Data Parallelism (SPMD-style coordination) combined with a local CSP-style streaming model, enabling the engine to overlap I/O, computation, and communication. This makes it possible to handle out-of-core processing efficiently (via {term}`Spilling`) and integrate seamlessly with frontend query engines such as Polars.
 The result is clean, composable, and scalable GPU streaming — from single-node prototypes to large-scale, multi-GPU deployments. See the {doc}`glossary` for definitions of key concepts.


### PR DESCRIPTION
## Description

Updates the Sphinx documentation to use `nvidia_sphinx_theme` with the theme's default left navigation.

This replaces the previous Sphinx theme dependency, removes the legacy shared RAPIDS CSS/JavaScript injection where present, and regenerates dependency manifests.

Contributes to rapidsai/build-planning#300.

## Validation

- Commit-time pre-commit hooks passed, including generated dependency files.
- Doxygen completed and `make dirhtml O="-j 8"` passed in the CUDA 13.3 devcontainer.
- Rendered HTML loads the NVIDIA theme, uses the default left navigation, and contains no legacy shared RAPIDS asset URLs.

