### PR TITLE
Use `rapids_test_add()` again

### DIFF
--- a/ci/run_rrun_tests.sh
+++ b/ci/run_rrun_tests.sh
@@ -17,7 +17,7 @@ timeout_secs=15
 # rrun_tests case, these need to run with rrun and not ctest/mpirun.
 for nrank in 1 2 3 4 5 8; do
   python "${TIMEOUT_TOOL_PATH}" "${timeout_secs}" \
-      rrun -n "${nrank}" --bind-to all ./gtests/rrun_tests "${EXTRA_ARGS[@]}"
+      rrun -n "${nrank}" --bind-to all ./rrun_tests "${EXTRA_ARGS[@]}"
 done
 
 # rrun tests should also work when not running with `rrun` CLI. E.g., resource bindings

--- a/ci/run_rrun_tests.sh
+++ b/ci/run_rrun_tests.sh
@@ -23,4 +23,4 @@ done
 # rrun tests should also work when not running with `rrun` CLI. E.g., resource bindings
 # need to work outside of `rrun`, which is the intended use case for
 # `rapidsmpf::rrun::bind()`.
-./gtests/rrun_tests "${EXTRA_ARGS[@]}"
+./rrun_tests "${EXTRA_ARGS[@]}"

--- a/ci/test_cpp_memcheck.sh
+++ b/ci/test_cpp_memcheck.sh
@@ -49,7 +49,7 @@ set +e
 cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/tests/librapidsmpf/"
 
 rapids-logger "Run librapidsmpf gtests with compute-sanitizer (Single Node)"
-compute-sanitizer --tool memcheck --track-stream-ordered-races=all gtests/single_tests --gtest_filter=-CuptiMonitorTest.*
+compute-sanitizer --tool memcheck --track-stream-ordered-races=all ./single_tests --gtest_filter=-CuptiMonitorTest.*
 
 rapids-logger "Test script exiting with exit code: $EXITCODE"
 exit ${EXITCODE}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -214,6 +214,12 @@ target_link_libraries(
           $<TARGET_NAME_IF_EXISTS:conda_env> maybe_asan $<$<BOOL:${RAPIDSMPF_HAVE_NUMA}>:numa>
 )
 disable_sign_conversion_warning(rrun_tests)
+install(
+  TARGETS rrun_tests
+  DESTINATION bin/tests/librapidsmpf
+  COMPONENT testing
+  EXCLUDE_FROM_ALL
+)
 
 add_executable(single_tests main/single.cpp)
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -10,6 +10,9 @@
 # ##################################################################################################
 enable_testing()
 
+include(rapids-test)
+rapids_test_init()
+
 # Create separate test case for each of this n_ranks
 set(nranks_to_run 1 2 3 4 5 8)
 
@@ -30,9 +33,12 @@ function(rapidsmpf_mpirun_test_add)
   message(STATUS "Adding mpirun test: ${_MPIRUN_TEST_TEST_TARGET} nranks: ${nranks_to_run}")
   foreach(np IN ITEMS ${nranks_to_run})
     # add the test using the relative path of the target
-    add_test(
-      NAME "${_MPIRUN_TEST_TEST_TARGET}_${np}" COMMAND mpirun --map-by node --bind-to none -np
-                                                       ${np} "gtests/${_MPIRUN_TEST_TEST_TARGET}"
+    rapids_test_add(
+      NAME "${_MPIRUN_TEST_TEST_TARGET}_${np}"
+      COMMAND mpirun --map-by node --bind-to none -np ${np}
+              "$<TARGET_FILE:${_MPIRUN_TEST_TEST_TARGET}>"
+      GPUS 0
+      INSTALL_COMPONENT_SET testing INSTALL_TARGET ${_MPIRUN_TEST_TEST_TARGET}
     )
   endforeach(np)
 endfunction(rapidsmpf_mpirun_test_add)
@@ -233,7 +239,11 @@ target_link_libraries(
 )
 target_sources(single_tests PRIVATE test_nvtx.cpp)
 disable_sign_conversion_warning(single_tests)
-add_test(NAME single_tests COMMAND "gtests/single_tests")
+rapids_test_add(
+  NAME single_tests
+  COMMAND "single_tests"
+  INSTALL_COMPONENT_SET testing
+)
 
 add_executable(cupti_public_api_test test_cupti_public_api.cpp)
 set_target_properties(
@@ -250,7 +260,11 @@ target_compile_options(
   cupti_public_api_test PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RAPIDSMPF_CXX_FLAGS}>"
 )
 disable_sign_conversion_warning(cupti_public_api_test)
-add_test(NAME cupti_public_api_test COMMAND "gtests/cupti_public_api_test")
+rapids_test_add(
+  NAME cupti_public_api_test
+  COMMAND "cupti_public_api_test"
+  INSTALL_COMPONENT_SET testing
+)
 
 # bootstrap_tests — standalone; compiles bootstrap sources directly so it does not depend on the
 # full rapidsmpf library (and its CUDA sources).
@@ -283,63 +297,10 @@ target_link_libraries(
   bootstrap_tests PRIVATE GTest::gmock GTest::gtest $<TARGET_NAME_IF_EXISTS:conda_env> maybe_asan
                           $<TARGET_NAME_IF_EXISTS:PMIx::PMIx> ${CMAKE_DL_LIBS}
 )
-add_test(NAME bootstrap_tests COMMAND "gtests/bootstrap_tests")
-
-# Create a list of targets that contains property KEY:VALUE.
-function(rapidsmpf_targets_with_property)
-  set(options)
-  set(one_value KEY VALUE OUTPUT)
-  set(multi_value COMMAND)
-  cmake_parse_arguments(_RAPIDSMPF_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
-
-  if(NOT DEFINED _RAPIDSMPF_TEST_KEY)
-    message(FATAL_ERROR "rapidsmpf_targets_with_property called without a KEY")
-  endif()
-
-  if(NOT DEFINED _RAPIDSMPF_TEST_VALUE)
-    message(FATAL_ERROR "rapidsmpf_targets_with_property called without a VALUE")
-  endif()
-
-  if(NOT DEFINED _RAPIDSMPF_TEST_OUTPUT)
-    message(FATAL_ERROR "rapidsmpf_targets_with_property called without a OUTPUT")
-  endif()
-
-  # get all targets
-  get_property(
-    all_targets
-    DIRECTORY
-    PROPERTY BUILDSYSTEM_TARGETS
-  )
-
-  set(targets_with_property "")
-  foreach(target ${all_targets})
-    get_target_property(prop_value ${target} ${_RAPIDSMPF_TEST_KEY})
-    if(prop_value STREQUAL ${_RAPIDSMPF_TEST_VALUE})
-      list(APPEND targets_with_property ${target})
-    endif()
-  endforeach()
-
-  set(${_RAPIDSMPF_TEST_OUTPUT}
-      ${targets_with_property}
-      PARENT_SCOPE
-  )
-endfunction(rapidsmpf_targets_with_property)
-
-# Search for all targets that has COMPONENT:testing property
-rapidsmpf_targets_with_property(KEY COMPONENT VALUE testing OUTPUT testing_targets)
-
-# Install testing targets to bin/tests/librapidsmpf/gtests
-install(
-  TARGETS ${testing_targets}
-  DESTINATION bin/tests/librapidsmpf/gtests
-  COMPONENT testing
-  EXCLUDE_FROM_ALL
+rapids_test_add(
+  NAME bootstrap_tests
+  COMMAND "bootstrap_tests"
+  INSTALL_COMPONENT_SET testing
 )
 
-# Install the CTestTestfile.cmake to bin/tests/librapidsmpf
-install(
-  FILES "${RAPIDSMPF_BINARY_DIR}/tests/CTestTestfile.cmake"
-  DESTINATION bin/tests/librapidsmpf
-  COMPONENT testing
-  EXCLUDE_FROM_ALL
-)
+rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing DESTINATION bin/tests/librapidsmpf)


### PR DESCRIPTION
As of https://github.com/rapidsai/rapids-cmake/pull/1050, `rapids_test_install_relocatable()` correctly relocates tests with arguments, so we can use `rapids_test_add()` again.