### PR TITLE
dnm: test wheel ci on cuda base

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,18 +22,18 @@ jobs:
     needs:
       - changed-files
       - checks
-      - conda-cpp-build
-      - conda-cpp-linters
-      - conda-cpp-tests
-      - conda-cpp-memcheck
-      - conda-python-build
-      - conda-python-tests
-      - docs-build
+      # - conda-cpp-build
+      # - conda-cpp-linters
+      # - conda-cpp-tests
+      # - conda-cpp-memcheck
+      # - conda-python-build
+      # - conda-python-tests
+      # - docs-build
       - wheel-build-librapidsmpf
       - wheel-build-rapidsmpf
-      - wheel-build-rapidsmpf-singlecomm
+      # - wheel-build-rapidsmpf-singlecomm
       - wheel-test
-      - devcontainer
+      # - devcontainer
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     if: always()
@@ -143,7 +143,7 @@ jobs:
           - '!conda/**'
           - '!cpp/.clang-format'
           - '!cpp/doxygen/**'
-          - '!docs/**''
+          - '!docs/**'
   checks:
     permissions:
       actions: read
@@ -189,24 +189,24 @@ jobs:
       package-type: python
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-  wheel-build-rapidsmpf-singlecomm:
-    needs: [checks, wheel-build-librapidsmpf]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
-    with:
-      build_type: pull-request
-      node_type: cpu8
-      script: ci/build_wheel_singlecomm.sh
-      package-name: rapidsmpf-singlecomm
-      package-type: python
-      # Build a wheel for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  # wheel-build-rapidsmpf-singlecomm:
+  #   needs: [checks, wheel-build-librapidsmpf]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     node_type: cpu8
+  #     script: ci/build_wheel_singlecomm.sh
+  #     package-name: rapidsmpf-singlecomm
+  #     package-type: python
+  #     # Build a wheel for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-test:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     needs: [changed-files, wheel-build-rapidsmpf]
@@ -217,143 +217,143 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@smaller_citestwheel
     with:
       build_type: pull-request
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       script: ci/test_wheel.sh
-  conda-cpp-build:
-    needs: checks
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
-    with:
-      build_type: pull-request
-      node_type: cpu8
-      script: ci/build_cpp.sh
-  conda-cpp-linters:
-    needs: checks
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    with:
-      build_type: pull-request
-      script: "ci/cpp_linters.sh"
-      node_type: "cpu16"
-  conda-cpp-tests:
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    needs: [changed-files, conda-cpp-build]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
-    with:
-      build_type: pull-request
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      script: ci/test_cpp.sh
-  conda-cpp-memcheck:
-    needs: conda-cpp-build
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    with:
-      build_type: pull-request
-      script: "ci/test_cpp_memcheck.sh"
-      node_type: "gpu-l4-latest-1"
-  conda-python-build:
-    needs: conda-cpp-build
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
-    with:
-      build_type: pull-request
-      script: ci/build_python.sh
-      # Build a conda package for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-  conda-python-tests:
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    needs: [changed-files, conda-python-build]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    with:
-      build_type: pull-request
-      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
-      run_codecov: false
-      script: ci/test_python.sh
-  docs-build:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
-    with:
-      build_type: pull-request
-      node_type: "cpu8"
-      arch: "amd64"
-      # TODO: switch to {rapids-version}-latest when there are 'ray' packages for Python 3.14
-      #  ref: https://github.com/rapidsai/rapidsmpf/issues/897
-      container_image: "rapidsai/ci-conda:26.08-cuda13.0.2-ubuntu22.04-py3.13"
-      script: "ci/build_docs.sh"
-  devcontainer:
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
-    with:
-      arch: '["amd64", "arm64"]'
-      cuda: '["13.3"]'
-      python_package_manager: '["conda", "pip"]'
-      node_type: "cpu8"
-      env: |
-        SCCACHE_DIST_MAX_RETRIES=inf
-        SCCACHE_SERVER_LOG=sccache=debug
-        SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
-      build_command: |
-        sccache --zero-stats;
-        build-all \
-          -j0 \
-          --verbose \
-          -DBUILD_TESTS=OFF \
-          -DBUILD_BENCHMARKS=ON \
-          -DBUILD_NUMA_SUPPORT=OFF \
-          2>&1 | tee telemetry-artifacts/build.log;
-        sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
+  # conda-cpp-build:
+  #   needs: checks
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     node_type: cpu8
+  #     script: ci/build_cpp.sh
+  # conda-cpp-linters:
+  #   needs: checks
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/cpp_linters.sh"
+  #     node_type: "cpu16"
+  # conda-cpp-tests:
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+  #   needs: [changed-files, conda-cpp-build]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+  #     script: ci/test_cpp.sh
+  # conda-cpp-memcheck:
+  #   needs: conda-cpp-build
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     script: "ci/test_cpp_memcheck.sh"
+  #     node_type: "gpu-l4-latest-1"
+  # conda-python-build:
+  #   needs: conda-cpp-build
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_python.sh
+  #     # Build a conda package for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  # conda-python-tests:
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   needs: [changed-files, conda-python-build]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+  #     run_codecov: false
+  #     script: ci/test_python.sh
+  # docs-build:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "cpu8"
+  #     arch: "amd64"
+  #     # TODO: switch to {rapids-version}-latest when there are 'ray' packages for Python 3.14
+  #     #  ref: https://github.com/rapidsai/rapidsmpf/issues/897
+  #     container_image: "rapidsai/ci-conda:26.08-cuda13.0.2-ubuntu22.04-py3.13"
+  #     script: "ci/build_docs.sh"
+  # devcontainer:
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
+  #   with:
+  #     arch: '["amd64", "arm64"]'
+  #     cuda: '["13.3"]'
+  #     python_package_manager: '["conda", "pip"]'
+  #     node_type: "cpu8"
+  #     env: |
+  #       SCCACHE_DIST_MAX_RETRIES=inf
+  #       SCCACHE_SERVER_LOG=sccache=debug
+  #       SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
+  #     build_command: |
+  #       sccache --zero-stats;
+  #       build-all \
+  #         -j0 \
+  #         --verbose \
+  #         -DBUILD_TESTS=OFF \
+  #         -DBUILD_BENCHMARKS=ON \
+  #         -DBUILD_NUMA_SUPPORT=OFF \
+  #         2>&1 | tee telemetry-artifacts/build.log;
+  #       sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;


### PR DESCRIPTION
xref rapidsai/build-planning#143
xref rapidsai/ci-imgs#400
xref rapidsai/shared-workflows#521

Test run using the smaller `cuda-base` image as the parent image of `citestwheel`

This shouldn't be merged. If all projects can run wheel tests with this image, we'll swap out the image upstream in `shared-workflows`.
