### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/recipes/librapidsmpf/conda_build_config.yaml
+++ b/conda/recipes/librapidsmpf/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=3.26.4,!=3.30.0"
+  - ">=4.0,<4.4"
 
 c_stdlib:
   - sysroot

--- a/conda/recipes/rapidsmpf/conda_build_config.yaml
+++ b/conda/recipes/rapidsmpf/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=3.26.4,!=3.30.0"
+  - ">=4.0,<4.4"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -176,7 +176,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - &cmake_ver cmake>=4.0
+          - &cmake_ver cmake>=4.0,<4.4
           - ninja
   build-cpp:
     common:

--- a/python/librapidsmpf/pyproject.toml
+++ b/python/librapidsmpf/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cuda-toolkit[nvml]==13.*",
     "librmm==26.8.*,>=0.0.0a0",
     "libucxx==0.51.*,>=0.0.0a0",

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cython>=3.2.2",
     "librapidsmpf==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
