### PR TITLE
fix(pre-commit): normalize SPDX handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
             ^CHANGELOG.md$
           )
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: be37aaed37d910d88ff39aff4c0de2d4c1e1568c  # frozen: v1.4.3
+    rev: 49d5f7ac8225db3ebd7d0ab3701d6336d3c208ec  # frozen: v1.6.0
     hooks:
       - id: verify-copyright
         args: [--fix, --spdx]

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -36,7 +36,7 @@ BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Custom
 BreakStringLiterals: true
 ColumnLimit: 90
-CommentPragmas: 'SPDX-(FileCopyrightText|License-Identifier): '
+CommentPragmas: '(IWYU pragma:|SPDX-)'
 DerivePointerAlignment: false
 IndentCaseBlocks: true
 IndentCaseLabels: false

--- a/cpp/include/rrun/rrun.hpp
+++ b/cpp/include/rrun/rrun.hpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once

--- a/cpp/src/rrun/rrun.cpp
+++ b/cpp/src/rrun/rrun.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <algorithm>

--- a/cpp/tests/streaming/test_partition.cpp
+++ b/cpp/tests/streaming/test_partition.cpp
@@ -1,6 +1,6 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/303.

Standardizes clang-format's SPDX protection and ensures the repository uses `rapidsai/pre-commit-hooks` `v1.6.0`. It also restores malformed SPDX headers where present.

Validated with `pre-commit run --all-files`.
