### PR TITLE
Unpin CMake from < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - clang-tools==20.1.8
 - clang==20.1.8
 - click >=8.1
-- cmake>=4.0,<4.4
+- cmake>=4.0
 - cuda-cudart-dev
 - cuda-cupti-dev
 - cuda-nvcc

--- a/conda/recipes/librapidsmpf/conda_build_config.yaml
+++ b/conda/recipes/librapidsmpf/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0,<4.4"
+  - ">=4.0"
 
 c_stdlib:
   - sysroot

--- a/conda/recipes/rapidsmpf/conda_build_config.yaml
+++ b/conda/recipes/rapidsmpf/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0,<4.4"
+  - ">=4.0"
 
 c_stdlib:
   - sysroot

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator
@@ -176,7 +176,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - &cmake_ver cmake>=4.0,<4.4
+          - &cmake_ver cmake>=4.0
           - ninja
   build-cpp:
     common:

--- a/python/librapidsmpf/pyproject.toml
+++ b/python/librapidsmpf/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0,<4.4",
+    "cmake>=4.0",
     "cuda-toolkit[nvml]==13.*",
     "librmm==26.8.*,>=0.0.0a0",
     "libucxx==0.51.*,>=0.0.0a0",

--- a/python/rapidsmpf/pyproject.toml
+++ b/python/rapidsmpf/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0,<4.4",
+    "cmake>=4.0",
     "cython>=3.2.2",
     "librapidsmpf==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

The issues with CMake 4.4 in rapids-cmake have been fixed, so remove the pin.

Issue: https://github.com/rapidsai/build-planning/issues/302
