### PR TITLE
Fix docs build on 26.10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,9 +99,7 @@ jobs:
       arch: "amd64"
       branch: ${{ inputs.branch }}
       build_type: ${{ inputs.build_type || 'branch' }}
-      # TODO: switch to {rapids-version}-latest when there are 'ray' packages for Python 3.14
-      #  ref: https://github.com/rapidsai/rapidsmpf/issues/897
-      container_image: "rapidsai/ci-conda:26.10-cuda13.0.2-ubuntu22.04-py3.13"
+      container_image: "rapidsai/ci-conda:26.10-latest"
       date: ${{ inputs.date }}
       node_type: "cpu8"
       script: "ci/build_docs.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -325,9 +325,7 @@ jobs:
       build_type: pull-request
       node_type: "cpu8"
       arch: "amd64"
-      # TODO: switch to {rapids-version}-latest when there are 'ray' packages for Python 3.14
-      #  ref: https://github.com/rapidsai/rapidsmpf/issues/897
-      container_image: "rapidsai/ci-conda:26.10-cuda13.0.2-ubuntu22.04-py3.13"
+      container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/build_docs.sh"
   devcontainer:
     permissions:


### PR DESCRIPTION
Ray packages now exist for python 3.14 so we can remove the TODO note and do what it tells us.