### PR TITLE
Name rapidsmpf coroutine and actor threads for profiling

### DIFF
--- a/cpp/src/streaming/core/coro_executor.cpp
+++ b/cpp/src/streaming/core/coro_executor.cpp
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <array>
 #include <cstdio>
 #include <utility>
 
-#if defined(__linux__) || defined(__APPLE__)
 #include <pthread.h>
-#endif
 
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/error.hpp>
@@ -20,25 +19,20 @@ namespace rapidsmpf::streaming {
 CoroThreadPoolExecutor::CoroThreadPoolExecutor(
     std::uint32_t num_streaming_threads, std::shared_ptr<Statistics> statistics
 )
-    : executor_{coro::thread_pool::make_unique(coro::thread_pool::options{
-          .thread_count            = num_streaming_threads,
-          .on_thread_start_functor = [](std::size_t idx) {
-#if defined(__linux__) || defined(__APPLE__)
-              // Linux comm limit is 15 chars + NUL. 'rmpf-coro-<idx>' fits
-              // for idx up to 4 digits, which comfortably exceeds any
-              // realistic thread count.
-              char name[16] = {};
-              std::snprintf(name, sizeof(name), "rmpf-coro-%zu", idx);
-#if defined(__linux__)
-              pthread_setname_np(pthread_self(), name);
-#else  // __APPLE__: names only the calling thread, no pthread_t argument.
-              pthread_setname_np(name);
-#endif
-#else
-              (void)idx;
-#endif
-          },
-      })},
+    : executor_{coro::thread_pool::make_unique(
+          coro::thread_pool::options{
+              .thread_count = num_streaming_threads,
+              .on_thread_start_functor =
+                  [](std::size_t idx) {
+                      // Linux comm limit is 15 chars + NUL. 'rmpf-coro-<idx>' fits
+                      // for idx up to 4 digits, which comfortably exceeds any
+                      // realistic thread count.
+                      std::array<char, 16> name{};
+                      std::snprintf(name.data(), name.size(), "rmpf-coro-%zu", idx);
+                      pthread_setname_np(pthread_self(), name.data());
+                  },
+          }
+      )},
       statistics_{std::move(statistics)},
       creator_thread_id_{std::this_thread::get_id()} {
     RAPIDSMPF_EXPECTS(

--- a/cpp/src/streaming/core/coro_executor.cpp
+++ b/cpp/src/streaming/core/coro_executor.cpp
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cstdio>
 #include <utility>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <pthread.h>
+#endif
 
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/error.hpp>
@@ -15,9 +20,25 @@ namespace rapidsmpf::streaming {
 CoroThreadPoolExecutor::CoroThreadPoolExecutor(
     std::uint32_t num_streaming_threads, std::shared_ptr<Statistics> statistics
 )
-    : executor_{coro::thread_pool::make_unique(
-          coro::thread_pool::options{.thread_count = num_streaming_threads}
-      )},
+    : executor_{coro::thread_pool::make_unique(coro::thread_pool::options{
+          .thread_count            = num_streaming_threads,
+          .on_thread_start_functor = [](std::size_t idx) {
+#if defined(__linux__) || defined(__APPLE__)
+              // Linux comm limit is 15 chars + NUL. 'rmpf-coro-<idx>' fits
+              // for idx up to 4 digits, which comfortably exceeds any
+              // realistic thread count.
+              char name[16] = {};
+              std::snprintf(name, sizeof(name), "rmpf-coro-%zu", idx);
+#if defined(__linux__)
+              pthread_setname_np(pthread_self(), name);
+#else  // __APPLE__: names only the calling thread, no pthread_t argument.
+              pthread_setname_np(name);
+#endif
+#else
+              (void)idx;
+#endif
+          },
+      })},
       statistics_{std::move(statistics)},
       creator_thread_id_{std::this_thread::get_id()} {
     RAPIDSMPF_EXPECTS(

--- a/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/actor.pyx
@@ -358,7 +358,7 @@ def run_actor_network(Context ctx not None, *, actors):
     # Need to run in a separate thread in case the cluster runtime already
     # has an async event loop.
     task_ready = Future()
-    with ThreadPoolExecutor(max_workers=1) as executor:
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="rapidsmpf-actor") as executor:
         worker = executor.submit(sync_wait, run_py_actors(py_actors), task_ready)
         loop, task = task_ready.result()
 


### PR DESCRIPTION
Give rapidsmpf's coroutine workers (`rmpf-coro-<idx>`) and the per-query actor-network `ThreadPoolExecutor` (`rapidsmpf-actor`) real, recognizable thread names by wiring `pthread_setname_np` into libcoro's `on_thread_start_functor` hook and passing `thread_name_prefix=` to the Python executor. This makes them attributable in profilers like nsys, `py-spy`, and `/proc/<pid>/task/<tid>/comm` instead of showing up as `python` or the truncated `ThreadPoolExecu`.
