### PR TITLE
Add test for `bind()` and CUDA initialization.

### DIFF
--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -14,7 +14,7 @@ function(find_and_configure_cucascade)
     GLOBAL_TARGETS cuCascade::cucascade_topology_discovery
     CPM_ARGS
     GIT_REPOSITORY https://github.com/NVIDIA/cuCascade.git
-    GIT_TAG d515bb0536b8766bae61ec60a530df394467af64
+    GIT_TAG main
     OPTIONS "CUCASCADE_BUILD_TESTS OFF"
             "CUCASCADE_BUILD_BENCHMARKS OFF"
             "CUCASCADE_BUILD_SHARED_LIBS OFF"

--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -13,8 +13,8 @@ function(find_and_configure_cucascade)
     cuCascade 0.1.0
     GLOBAL_TARGETS cuCascade::cucascade_topology_discovery
     CPM_ARGS
-    GIT_REPOSITORY https://github.com/NVIDIA/cuCascade.git
-    GIT_TAG main
+    GIT_REPOSITORY https://github.com/aminaramoon/cucs/
+    GIT_TAG no_rmm_in_discovery
     OPTIONS "CUCASCADE_BUILD_TESTS OFF"
             "CUCASCADE_BUILD_BENCHMARKS OFF"
             "CUCASCADE_BUILD_SHARED_LIBS OFF"

--- a/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
+++ b/python/rapidsmpf/rapidsmpf/tests/test_rrun.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -180,6 +180,42 @@ class TestBindResolution:
             os.environ["CUDA_VISIBLE_DEVICES"] = "GPU-abcdef12-3456"
             with pytest.raises(RuntimeError, match="not a valid GPU ID"):
                 bind(cpu=False, memory=False, network=False)
+
+        _run_in_subprocess(body)
+
+    def test_bind_does_not_initialize_cuda(self) -> None:
+        """bind() must not latch CUDA while it temporarily clears CVD.
+
+        Topology discovery unsets CUDA_VISIBLE_DEVICES so cuCascade can see
+        physical GPU indices. If the CUDA driver initializes in that window,
+        the process permanently sees every GPU on the node even after CVD is
+        restored. On single-GPU CI that cannot be detected via UUID collision,
+        so we instead require that CUDA remain uninitialized after bind():
+        clearing CVD and then querying the device count must yield
+        cudaErrorNoDevice.
+        """
+
+        def body() -> None:
+            import os
+
+            from cuda.bindings import runtime
+
+            from rapidsmpf.rrun.rrun import bind
+
+            # Restrict visibility, but do not touch CUDA before bind().
+            os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+            bind(gpu_id=0, cpu=True, memory=True, network=False, verify=False)
+
+            # If bind() left CUDA uninitialized, an empty CUDA_VISIBLE_DEVICES takes
+            # effect. If bind() latched "all devices" (or even just GPU 0), this change
+            # is ignored and cudaGetDeviceCount succeeds.
+            os.environ["CUDA_VISIBLE_DEVICES"] = ""
+            err, count = runtime.cudaGetDeviceCount()
+            assert err == runtime.cudaError_t.cudaErrorNoDevice, (
+                f"bind() initialized CUDA (cudaGetDeviceCount -> err={err}, "
+                f"count={count}); discovery must not touch the CUDA driver "
+                f"while CUDA_VISIBLE_DEVICES is temporarily cleared"
+            )
 
         _run_in_subprocess(body)
 


### PR DESCRIPTION
https://github.com/NVIDIA/cuCascade/commit/8a3b42f02b69e27dd05402c215d4369ff97e4f1c
changed cucascade's topology discovery in a way that ultimately broke multi-GPU
cudf-polars.

Some part of rapidsmpf's ``bind`` is sensitive to whether or not CUDA is initialized
during topology discovery. This PR adds a test to ensure we catch it sooner
if this happens again.

https://github.com/rapidsai/rapidsmpf/pull/1145 pinned release/26.08 to a known-good commit.
https://github.com/rapidsai/rapidsmpf/pull/1146 forward-merged that to `main`. But we
don't want that pin on `main`: we'd prefer to catch regressions and benefit from improvements
immediately. So the second commit reverts that pin.