### PR TITLE
ensure nightly builds always produce new packages, expand 'changed-files' lists

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,8 @@ concurrency:
 permissions: {}
 
 jobs:
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-cpp-build:
     permissions:
       actions: read

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,7 @@ jobs:
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-cpp-build:
+    needs: [build-details]
     permissions:
       actions: read
       contents: read
@@ -48,13 +49,14 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       node_type: cpu8
       script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
   conda-python-build:
-    needs: [conda-cpp-build]
+    needs: [build-details, conda-cpp-build]
     permissions:
       actions: read
       contents: read
@@ -65,6 +67,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
@@ -107,6 +110,7 @@ jobs:
       script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
   wheel-build-librapidsmpf:
+    needs: [build-details]
     permissions:
       actions: read
       contents: read
@@ -117,6 +121,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       node_type: cpu8
@@ -145,7 +150,7 @@ jobs:
       package-type: cpp
       publish-wheel-search-key: rapidsmpf_wheel_cpp_librapidsmpf
   wheel-build-rapidsmpf:
-    needs: wheel-build-librapidsmpf
+    needs: [build-details, wheel-build-librapidsmpf]
     permissions:
       actions: read
       contents: read
@@ -156,6 +161,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       node_type: cpu8
@@ -184,7 +190,7 @@ jobs:
       package-type: python
       publish-wheel-search-key: rapidsmpf_wheel_python_rapidsmpf
   wheel-build-rapidsmpf-singlecomm:
-    needs: wheel-build-rapidsmpf
+    needs: [build-details, wheel-build-rapidsmpf]
     permissions:
       actions: read
       contents: read
@@ -195,6 +201,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       node_type: cpu8

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -148,6 +148,8 @@ jobs:
           - '!cpp/.clang-format'
           - '!cpp/doxygen/**'
           - '!docs/**''
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   checks:
     permissions:
       actions: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,6 +20,7 @@ jobs:
       packages: read
       pull-requests: read
     needs:
+      - build-details
       - changed-files
       - checks
       - conda-cpp-build
@@ -59,6 +60,9 @@ jobs:
           - '!.github/labeler.yml'
           - '!.github/ops-bot.yaml'
           - '!.github/release.yml'
+          - '!.github/zizmor.yml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/test.yaml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!.yamllint.yaml'
@@ -80,6 +84,9 @@ jobs:
           - '!.github/labeler.yml'
           - '!.github/ops-bot.yaml'
           - '!.github/release.yml'
+          - '!.github/zizmor.yml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/test.yaml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!.yamllint.yaml'
@@ -104,6 +111,9 @@ jobs:
           - '!.github/labeler.yml'
           - '!.github/ops-bot.yaml'
           - '!.github/release.yml'
+          - '!.github/zizmor.yml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/test.yaml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!.yamllint.yaml'
@@ -129,6 +139,9 @@ jobs:
           - '!.github/labeler.yml'
           - '!.github/ops-bot.yaml'
           - '!.github/release.yml'
+          - '!.github/zizmor.yml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/test.yaml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!.yamllint.yaml'
@@ -160,7 +173,7 @@ jobs:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
   wheel-build-librapidsmpf:
-    needs: checks
+    needs: [build-details, checks]
     permissions:
       actions: read
       contents: read
@@ -171,6 +184,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       node_type: cpu8
       script: ci/build_wheel_librapidsmpf.sh
       package-name: librapidsmpf
@@ -178,7 +192,7 @@ jobs:
       # build for every combination of arch and CUDA version, but only for the latest Python version
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
   wheel-build-rapidsmpf:
-    needs: [checks, wheel-build-librapidsmpf]
+    needs: [build-details, checks, wheel-build-librapidsmpf]
     permissions:
       actions: read
       contents: read
@@ -189,6 +203,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       node_type: cpu8
       script: ci/build_wheel_rapidsmpf.sh
       package-name: rapidsmpf
@@ -196,7 +211,7 @@ jobs:
       # Build a wheel for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
   wheel-build-rapidsmpf-singlecomm:
-    needs: [checks, wheel-build-librapidsmpf]
+    needs: [build-details, checks, wheel-build-librapidsmpf]
     permissions:
       actions: read
       contents: read
@@ -207,6 +222,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       node_type: cpu8
       script: ci/build_wheel_singlecomm.sh
       package-name: rapidsmpf-singlecomm
@@ -229,7 +245,7 @@ jobs:
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       script: ci/test_wheel.sh
   conda-cpp-build:
-    needs: checks
+    needs: [build-details, checks]
     permissions:
       actions: read
       contents: read
@@ -240,6 +256,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       node_type: cpu8
       script: ci/build_cpp.sh
   conda-cpp-linters:
@@ -286,7 +303,7 @@ jobs:
       script: "ci/test_cpp_memcheck.sh"
       node_type: "gpu-l4-latest-1"
   conda-python-build:
-    needs: conda-cpp-build
+    needs: [build-details, conda-cpp-build]
     permissions:
       actions: read
       contents: read
@@ -297,6 +314,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
       # Build a conda package for each CUDA x ARCH x minimum supported Python version
       matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
 source rapids-configure-sccache
-source rapids-date-string
+source rapids-datetime-string
 
 export CMAKE_GENERATOR=Ninja
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
 source rapids-configure-sccache
-source rapids-date-string
+source rapids-datetime-string
 
 export CMAKE_GENERATOR=Ninja
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -24,13 +24,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 source rapids-configure-sccache
-source rapids-date-string
+source rapids-datetime-string
 source rapids-init-pip
 
 export SCCACHE_S3_PREPROCESSOR_CACHE_KEY_PREFIX="${package_name}/${RAPIDS_CONDA_ARCH}/cuda${RAPIDS_CUDA_VERSION%%.*}/wheel/preprocessor-cache"
 export SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
 
-rapids-generate-version > ./VERSION
+RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+  rapids-generate-version > ./VERSION
 
 cd "${package_dir}"
 

--- a/conda/recipes/librapidsmpf/recipe.yaml
+++ b/conda/recipes/librapidsmpf/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 schema_version: 1
 
@@ -7,7 +7,7 @@ context:
   minor_version: ${{ (version | split("."))[:2] | join(".") }}
   cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}
   cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
-  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
+  datetime_string: '${{ env.get("RAPIDS_DATETIME_STRING") }}'
   head_rev: ${{ git.head_rev(".")[:8] }}
   ucxx_version: ${{ env.get("UCXX_PACKAGE_DEPENDENCY") }}
 
@@ -100,7 +100,7 @@ outputs:
         ignore:
           # See https://github.com/rapidsai/build-planning/issues/160
           - lib/librapidsmpf.so
-      string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
+      string: cuda${{ cuda_major }}_${{ datetime_string }}_${{ head_rev }}
     requirements:
       build:
         - cmake ${{ cmake_version }}
@@ -145,7 +145,7 @@ outputs:
         content: |
           cmake --install cpp/build --component=testing
           cmake --install cpp/build --component=benchmarking
-      string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
+      string: cuda${{ cuda_major }}_${{ datetime_string }}_${{ head_rev }}
     requirements:
       build:
         - cmake ${{ cmake_version }}

--- a/conda/recipes/rapidsmpf/recipe.yaml
+++ b/conda/recipes/rapidsmpf/recipe.yaml
@@ -7,7 +7,7 @@ context:
   minor_version: ${{ (version | split("."))[:2] | join(".") }}
   cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}
   cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
-  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
+  datetime_string: '${{ env.get("RAPIDS_DATETIME_STRING") }}'
   py_abi_min: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_abi_min | version_to_buildstring }}
   py_runtime_latest: "3.14"
@@ -24,7 +24,7 @@ source:
 build:
   python:
     version_independent: true
-  string: cuda${{ cuda_major }}_cp${{ py_buildstring }}_abi3_${{ date_string }}_${{ head_rev }}
+  string: cuda${{ cuda_major }}_cp${{ py_buildstring }}_abi3_${{ datetime_string }}_${{ head_rev }}
   files:
     exclude:
       # libarrow feedstock incorrectly ships this file so we exclude it manually


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/218

* uses the new patterns for versioning nightly packages (see https://github.com/rapidsai/shared-workflows/pull/603), to ensure they're always uploaded on new builds. 

For wheels:

```text
# before
26.10.0a55 

# after
26.10.0a55.post260803200854
```

And for conda:

```text
# before
26.10.0a55[build=cuda12_260803_9da146ef]

# after
26.10.0a55[build=cuda12_260803200854_9da146ef]
```

Other changes:

* updates `changed-files` lists to avoid triggering test jobs in PR CI when only `.github/workflows/{build,test}.yaml` are changed

## Notes for Reviewers

### How I tested this

See https://github.com/rapidsai/cugraph-gnn/pull/508
