### PR TITLE
wheels: enforce 'abi3audit' checks

### DIFF
--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -13,10 +13,20 @@ rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
-    "$(echo "${wheel_dir_relative_path}"/*.whl)"
+    "${wheel_dir_relative_path}"/*.whl
 
 rapids-logger "validate packages with 'twine'"
 
 twine check \
     --strict \
-    "$(echo "${wheel_dir_relative_path}"/*.whl)"
+    "${wheel_dir_relative_path}"/*.whl
+
+rapids-logger "validate packages with 'abi3audit'"
+
+# 'abi3audit' fails on wheels with DSOs that lack an ABI tag (e.g. 'lib*' wheels).
+# Filtering by '*abi*' avoids those.
+find \
+    "${wheel_dir_relative_path}" \
+    -type f \
+    -name '*abi*' \
+    -exec abi3audit --strict --summary --verbose '{}' \+


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/315

Adds `abi3audit` to `ci/validate_wheel.sh`, to catch any mismatch between a wheel's ABI tag and its actual limited-ABI usage.
