### PR TITLE
Select batched memcpy flags by copy size

### DIFF
--- a/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
+++ b/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
@@ -4,7 +4,9 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
+#include <ranges>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -19,7 +21,9 @@ namespace rapidsmpf {
  * On CUDA 13.0+ with a non-default stream, uses `cudaMemcpyBatchAsync` with
  * `cudaMemcpySrcAccessOrderStream`, which defers reading the source buffers until
  * the stream reaches each copy. This enables true asynchronous copies from pageable
- * host memory on modern systems with HMM/ATS support.
+ * host memory on modern systems with HMM/ATS support. A batch uses
+ * `cudaMemcpyFlagPreferOverlapWithCompute` when every copy is 128 KiB or less. If any
+ * copy is larger, the batch uses `cudaMemcpyFlagDefault`.
  *
  * Falls back to per-copy `cudaMemcpyAsync` on older CUDA versions or when the default
  * stream is used.
@@ -78,13 +82,19 @@ namespace rapidsmpf {
             count = valid_dsts.size();
         }
 
+        constexpr std::size_t prefer_overlap_threshold = 128 * 1024;
+        auto const flags = std::ranges::any_of(
+                               std::ranges::views::iota(std::size_t{0}, count),
+                               [&](auto i) { return sizes[i] > prefer_overlap_threshold; }
+                           )
+                               ? cudaMemcpyFlagDefault
+                               : cudaMemcpyFlagPreferOverlapWithCompute;
         cudaMemcpyAttributes attrs = {
-            .srcAccessOrder = cudaMemcpySrcAccessOrderStream,
-            .flags = cudaMemcpyFlagPreferOverlapWithCompute
+            .srcAccessOrder = cudaMemcpySrcAccessOrderStream, .flags = flags
         };
-        std::size_t attrs_idxs = 0;
+        std::size_t attrs_idx = 0;
         return cudaMemcpyBatchAsync(
-            dsts, srcs, sizes, count, &attrs, &attrs_idxs, 1, stream.value()
+            dsts, srcs, sizes, count, &attrs, &attrs_idx, 1, stream.value()
         );
     }
 #endif  // CUDART_VERSION >= 13000

--- a/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
+++ b/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <ranges>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -84,9 +83,10 @@ namespace rapidsmpf {
 
         constexpr std::size_t prefer_overlap_threshold = 128 * 1024;
         unsigned int const flags =
-            std::ranges::any_of(
-                std::ranges::views::iota(std::size_t{0}, count),
-                [&](auto i) { return sizes[i] > prefer_overlap_threshold; }
+            std::any_of(
+                sizes,
+                sizes + count,
+                [&](auto size) { return size > prefer_overlap_threshold; }
             )
                 ? cudaMemcpyFlagDefault
                 : cudaMemcpyFlagPreferOverlapWithCompute;

--- a/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
+++ b/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
@@ -83,12 +83,13 @@ namespace rapidsmpf {
         }
 
         constexpr std::size_t prefer_overlap_threshold = 128 * 1024;
-        auto const flags = std::ranges::any_of(
-                               std::ranges::views::iota(std::size_t{0}, count),
-                               [&](auto i) { return sizes[i] > prefer_overlap_threshold; }
-                           )
-                               ? cudaMemcpyFlagDefault
-                               : cudaMemcpyFlagPreferOverlapWithCompute;
+        unsigned int const flags =
+            std::ranges::any_of(
+                std::ranges::views::iota(std::size_t{0}, count),
+                [&](auto i) { return sizes[i] > prefer_overlap_threshold; }
+            )
+                ? cudaMemcpyFlagDefault
+                : cudaMemcpyFlagPreferOverlapWithCompute;
         cudaMemcpyAttributes attrs = {
             .srcAccessOrder = cudaMemcpySrcAccessOrderStream, .flags = flags
         };


### PR DESCRIPTION
## Description

This addresses a performance issue documented in NVIDIA/cudf#23674.

Use `cudaMemcpyFlagPreferOverlapWithCompute` for a `cudaMemcpyBatchAsync` batch only when every copy is 128 KiB or less. If any copy is larger, use `cudaMemcpyFlagDefault` for the entire batch. The choice of 128 KiB was determined by benchmarking on several devices (GB300, GB10, RTX PRO A6000) and minimizing the time cost modeled with latency and bandwidth.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapidsmpf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.