### PR TITLE
Switch back to cuCascade main during development cycle

### DIFF
--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -14,7 +14,7 @@ function(find_and_configure_cucascade)
     GLOBAL_TARGETS cuCascade::cucascade_topology_discovery
     CPM_ARGS
     GIT_REPOSITORY https://github.com/NVIDIA/cuCascade.git
-    GIT_TAG d515bb0536b8766bae61ec60a530df394467af64
+    GIT_TAG main
     OPTIONS "CUCASCADE_BUILD_TESTS OFF"
             "CUCASCADE_BUILD_BENCHMARKS OFF"
             "CUCASCADE_BUILD_SHARED_LIBS OFF"


### PR DESCRIPTION
https://github.com/rapidsai/rapidsmpf/pull/1145 pinned to https://github.com/NVIDIA/cuCascade/commit/d515bb0536b8766bae61ec60a530df394467af64 for two reasons:
1. Pinning is always required before a RAPIDS release;
2. https://github.com/NVIDIA/cuCascade/commit/8a3b42f02b69e27dd05402c215d4369ff97e4f1c broke RapidsMPF.

This unpins cuCascade now that the issue has been fixed.