### PR TITLE
ci: avoid triggered-by-schedule and triggered-by-merge builds cancelling each other

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ on:
         default: nightly
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build_type || 'branch' }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/278

Today, merging a PR while the nightly build is in progress can lead to it being cancelled.
This updates CI configurations to prevent that.
