### PR TITLE
ci: Make GB300 tests optional for successful completion

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,26 @@ jobs:
       branch: ${{ inputs.branch }}
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       date: ${{ inputs.date }}
+      matrix_filter: map(select(.GPU != "gb300"))
+      script: ci/test_cpp.sh
+      sha: ${{ inputs.sha }}
+  conda-cpp-tests-gb300:
+    if: inputs.build_type != 'pull-request'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      continue-on-error: true
+      date: ${{ inputs.date }}
+      matrix_filter: map(select(.GPU == "gb300"))
       script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
   conda-cpp-memcheck:
@@ -72,6 +92,27 @@ jobs:
       branch: ${{ inputs.branch }}
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       date: ${{ inputs.date }}
+      matrix_filter: map(select(.GPU != "gb300"))
+      run_codecov: false
+      script: ci/test_python.sh
+      sha: ${{ inputs.sha }}
+  conda-python-tests-gb300:
+    if: inputs.build_type != 'pull-request'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      branch: ${{ inputs.branch }}
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
+      continue-on-error: true
+      date: ${{ inputs.date }}
+      matrix_filter: map(select(.GPU == "gb300"))
       run_codecov: false
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,10 @@ jobs:
       script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
   conda-cpp-tests-gb300:
+    # Until nvbug 6565551 is fixed, multi-process virtualised runs on GB300
+    # can put the GPU in an unrecoverable state in the VM if two processes
+    # initialise a cuda context simultaneously. Hence we make the tests on
+    # GB300 optional.
     if: inputs.build_type != 'pull-request'
     permissions:
       actions: read
@@ -97,6 +101,10 @@ jobs:
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
   conda-python-tests-gb300:
+    # Until nvbug 6565551 is fixed, multi-process virtualised runs on GB300
+    # can put the GPU in an unrecoverable state in the VM if two processes
+    # initialise a cuda context simultaneously. Hence we make the tests on
+    # GB300 optional.
     if: inputs.build_type != 'pull-request'
     permissions:
       actions: read


### PR DESCRIPTION
Due to nvbug 6565551, multi-process tests on GB300 can fail when the virtualisation breaks. Since this is nothing we can recover from in user space, there's not much we can do.

To avoid this blocking CI, let's make the GB300 test runs optional.