### PR TITLE
Squash more HtoD copy stream sync issues

### DIFF
--- a/cpp/include/rapidsmpf/memory/buffer.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer.hpp
@@ -376,6 +376,9 @@ class Buffer {
 /**
  * @brief Asynchronously copy data between buffers.
  *
+ * @note The copy is stream-ordered on @p dst's stream, correct cross-stream ordering
+ * between @p src's stream and @p dst's stream is provided automatically.
+ *
  * Copies @p size bytes from @p src, starting at @p src_offset, into @p dst at
  * @p dst_offset.
  *

--- a/cpp/tests/streaming/test_fanout.cpp
+++ b/cpp/tests/streaming/test_fanout.cpp
@@ -12,6 +12,7 @@
 #include <coro/coro.hpp>
 
 #include <rapidsmpf/memory/buffer.hpp>
+#include <rapidsmpf/memory/memory_type.hpp>
 #include <rapidsmpf/memory/pinned_memory_resource.hpp>
 #include <rapidsmpf/streaming/core/actor.hpp>
 #include <rapidsmpf/streaming/core/coro_utils.hpp>
@@ -81,6 +82,9 @@ std::vector<Message> make_buffer_inputs(int n, rapidsmpf::BufferResource& br) {
             ),
             stream
         );
+        // If the copy to the device buffer is actually stream ordered, the host values
+        // might go out of scope before the copy completes.
+        stream.synchronize();
         ContentDescription cd{
             std::ranges::single_view{std::pair{MemoryType::DEVICE, 1024 * sizeof(int)}},
             ContentDescription::Spillable::YES

--- a/cpp/tests/test_buffer.cpp
+++ b/cpp/tests/test_buffer.cpp
@@ -97,6 +97,7 @@ TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
     auto rmm_buffer = std::make_unique<rmm::device_buffer>(
         random_data.data(), buffer_size, stream1, br->device_mr()
     );
+    stream1.synchronize();
 
     auto [reserve1, overbooking1] =
         br->reserve(mem_type, buffer_size, AllowOverbooking::YES);

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -435,12 +435,12 @@ class BaseBufferResourceCopyTest : public ::testing::Test {
             br->reserve(mem_type, size, AllowOverbooking::NO);
         auto buf = br->make_buffer(size, stream, alloc_reserve);
         EXPECT_EQ(buf->mem_type(), mem_type);
-        // copy the host pattern to the Buffer
         buf->write_access([&](std::byte* buf_data, rmm::cuda_stream_view stream) {
             RAPIDSMPF_CUDA_TRY(
                 cuda_memcpy_async(buf_data, host_pattern.data(), size, stream)
             );
         });
+        buf->latest_write_event().host_wait();
         return buf;
     }
 

--- a/cpp/tests/test_metadata_payload_exchange.cpp
+++ b/cpp/tests/test_metadata_payload_exchange.cpp
@@ -55,12 +55,12 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
                 stream, br->reserve_or_fail(data_size, MemoryType::DEVICE)
             );
             // Fill with test data
+            std::vector<std::uint8_t> test_data(data_size);
+            std::iota(test_data.begin(), test_data.end(), 0);
             data_buffer->write_access(
-                [data_size](std::byte* ptr, rmm::cuda_stream_view stream) {
-                    std::vector<std::uint8_t> test_data(data_size);
-                    std::iota(test_data.begin(), test_data.end(), 0);
+                [&test_data](std::byte* ptr, rmm::cuda_stream_view stream) {
                     RAPIDSMPF_CUDA_TRY(
-                        cuda_memcpy_async(ptr, test_data.data(), data_size, stream)
+                        cuda_memcpy_async(ptr, test_data.data(), test_data.size(), stream)
                     );
                 }
             );

--- a/cpp/tests/utils.hpp
+++ b/cpp/tests/utils.hpp
@@ -126,6 +126,7 @@ template <typename T>
     );
     auto data_ptr =
         std::make_unique<rmm::device_buffer>(data.data(), data.size(), stream);
+    stream.synchronize();
     return rapidsmpf::PackedData{
         std::move(metadata_ptr), br->move(std::move(data_ptr), stream)
     };
@@ -166,6 +167,7 @@ template <typename T = int>
                        ) {
         RAPIDSMPF_CUDA_TRY(rapidsmpf::cuda_memcpy_async(ptr, d_ptr, m_size, op_stream));
     });
+    data->latest_write_event().host_wait();
 
     return {std::move(metadata), std::move(data)};
 }

--- a/python/rapidsmpf/rapidsmpf/testing.py
+++ b/python/rapidsmpf/rapidsmpf/testing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Submodule for testing."""
 
@@ -76,6 +76,7 @@ def generate_packed_data(
     data = np.arange(offset, offset + n_elements, dtype=_DTYPE).tobytes()
     gpu_data = rmm.DeviceBuffer(size=len(data), stream=stream, mr=br.device_mr)
     gpu_data.copy_from_host(data, stream=stream)
+    stream.synchronize()
     return PackedData.from_device_buffer(gpu_data, data, stream, br)
 
 


### PR DESCRIPTION
We previously went round and did an audit of the HtoD copies and inserted stream syncs, but missed a few. These are all the rest I found.

Mostly mechanical, with one notable change. Since `buffer_copy` knows the memory type of both the source and destination I chose to explicitly insert the stream synchronisation in the copy when we know the source is in pageable host memory. This is morally the same as the `stream_wait` call we already have.