### PR TITLE
Make `MemoryReserveOrWait` spill

### DIFF
--- a/cpp/include/rapidsmpf/memory/spill_manager.hpp
+++ b/cpp/include/rapidsmpf/memory/spill_manager.hpp
@@ -144,21 +144,21 @@ class SpillManager {
 
   private:
     /**
-     * @brief Spills memory. The caller must hold `mutex_`.
+     * @brief Spills memory without locking. The caller must hold `mutex_`.
      *
      * @param amount The amount of memory (in bytes) to spill.
      * @return The actual amount of memory spilled (in bytes).
      */
-    std::size_t spill_impl(std::size_t amount);
+    std::size_t spill_unsafe(std::size_t amount);
 
     /**
-     * @brief Spills to reach the requested headroom, reading the available memory
-     * under the caller's lock. The caller must hold `mutex_`.
+     * @brief Spills to reach the requested headroom without locking, reading the
+     * available memory under the caller's lock. The caller must hold `mutex_`.
      *
      * @param headroom The target amount of headroom (in bytes).
      * @return The actual amount of memory spilled (in bytes).
      */
-    std::size_t spill_to_make_headroom_impl(std::int64_t headroom);
+    std::size_t spill_to_make_headroom_unsafe(std::int64_t headroom);
 
     mutable std::mutex mutex_;
     BufferResource* br_;

--- a/cpp/include/rapidsmpf/memory/spill_manager.hpp
+++ b/cpp/include/rapidsmpf/memory/spill_manager.hpp
@@ -124,7 +124,42 @@ class SpillManager {
      */
     std::size_t spill_to_make_headroom(std::int64_t headroom = 0);
 
+    /**
+     * @brief Non-blocking version of `spill_to_make_headroom()`.
+     *
+     * Returns immediately instead of waiting when the spill lock is unavailable.
+     * Intended for pollers that retry, such as the streaming layer's memory
+     * reservation loop.
+     *
+     * @param headroom The target amount of headroom (in bytes). A negative headroom
+     * triggers spilling only once the memory available for reservation drops below
+     * `headroom`.
+     * @return The actual amount of memory spilled (in bytes), or `std::nullopt` if no
+     * spill was attempted. A `std::nullopt` result does not imply that spilling is
+     * impossible or that another spill is in progress. Callers should retry.
+     *
+     * @see spill_to_make_headroom()
+     */
+    std::optional<std::size_t> try_spill_to_make_headroom(std::int64_t headroom = 0);
+
   private:
+    /**
+     * @brief Spills memory. The caller must hold `mutex_`.
+     *
+     * @param amount The amount of memory (in bytes) to spill.
+     * @return The actual amount of memory spilled (in bytes).
+     */
+    std::size_t spill_impl(std::size_t amount);
+
+    /**
+     * @brief Spills to reach the requested headroom, reading the available memory
+     * under the caller's lock. The caller must hold `mutex_`.
+     *
+     * @param headroom The target amount of headroom (in bytes).
+     * @return The actual amount of memory spilled (in bytes).
+     */
+    std::size_t spill_to_make_headroom_impl(std::int64_t headroom);
+
     mutable std::mutex mutex_;
     BufferResource* br_;
     std::size_t spill_function_id_counter_{0};

--- a/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
@@ -10,6 +10,7 @@
 
 #include <coro/task.hpp>
 
+#include <rapidsmpf/communicator/logger.hpp>
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
 #include <rapidsmpf/streaming/core/actor.hpp>
@@ -55,12 +56,14 @@ class MemoryReserveOrWait {
      * still cannot be satisfied.
      *
      * @param options Configuration options.
+     * @param logger Shared pointer to a logger.
      * @param mem_type The memory type for which reservations are requested.
      * @param executor Shared pointer to a coroutine executor.
      * @param br Buffer resource for memory allocation.*
      */
     MemoryReserveOrWait(
         config::Options options,
+        std::shared_ptr<Logger> logger,
         MemoryType mem_type,
         std::shared_ptr<CoroThreadPoolExecutor> executor,
         std::shared_ptr<BufferResource> br
@@ -281,12 +284,14 @@ class MemoryReserveOrWait {
     mutable std::mutex mutex_;
     std::uint64_t sequence_counter{0};
     MemoryType const mem_type_;
+    std::shared_ptr<Logger> logger_;
     std::shared_ptr<CoroThreadPoolExecutor> executor_;
     std::shared_ptr<BufferResource> br_;
     Duration const timeout_;
     std::set<Request> reservation_requests_;
     std::atomic<std::uint64_t> periodic_memory_check_counter_{0};
     std::optional<coro::task<void>> periodic_memory_check_task_;
+    bool periodic_task_running_{false};
 };
 
 /**

--- a/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
@@ -98,13 +98,15 @@ class MemoryReserveOrWait {
      * highest-priority one needs, and again just before progress is forced. Both are
      * limited to `MemoryType::DEVICE`.
      *
-     * The timeout does not apply specifically to this request. Instead, it is used
-     * as a global progress guarantee: if no pending reservation request can be
-     * satisfied within the timeout, `MemoryReserveOrWait` forces progress by
-     * selecting the smallest pending request and attempting to reserve memory for
-     * it. The forced reservation attempt may result in an empty `MemoryReservation`
-     * if the selected request still cannot be satisfied, for example when nothing
-     * is spillable.
+     * The timeout does not apply specifically to this request. Instead, it bounds
+     * when a final recovery attempt begins, not when it completes: if no pending
+     * reservation request can be satisfied within the timeout, `MemoryReserveOrWait`
+     * forces progress by selecting the smallest pending request, spilling to make
+     * room for it, and attempting to reserve memory. That spill waits for any
+     * in-flight spill to finish, so the call can return later than the timeout. The
+     * forced reservation attempt may result in an empty `MemoryReservation` if the
+     * selected request still cannot be satisfied, for example when nothing is
+     * spillable.
      *
      * When multiple reservation requests are eligible, `MemoryReserveOrWait` uses
      * @p net_memory_delta as a heuristic to prefer requests that are expected to

--- a/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
@@ -30,6 +30,11 @@ class Context;
  * memory with backpressure. Callers submit reservation requests via
  * `reserve_or_wait()`, which suspends until enough memory is available or
  * progress must be forced.
+ *
+ * While requests are pending and none of them fit into the available memory,
+ * spilling is triggered on the caller's behalf. This applies to `MemoryType::DEVICE`
+ * only, since `SpillManager` measures headroom against device memory. Requests of
+ * other memory types wait without spilling.
  */
 class MemoryReserveOrWait {
   public:
@@ -54,6 +59,8 @@ class MemoryReserveOrWait {
      * progress by selecting the smallest pending request and attempting to reserve
      * memory for it. This attempt may result in an empty reservation if the request
      * still cannot be satisfied.
+     *
+     * Spilling is attempted before that timeout is reached, see the class docs.
      *
      * @param options Configuration options.
      * @param logger Shared pointer to a logger.
@@ -87,12 +94,17 @@ class MemoryReserveOrWait {
      * (including other pending requests) makes progress within the configured
      * timeout.
      *
+     * While no pending request fits, spilling is attempted to free the memory the
+     * highest-priority one needs, and again just before progress is forced. Both are
+     * limited to `MemoryType::DEVICE`.
+     *
      * The timeout does not apply specifically to this request. Instead, it is used
      * as a global progress guarantee: if no pending reservation request can be
      * satisfied within the timeout, `MemoryReserveOrWait` forces progress by
      * selecting the smallest pending request and attempting to reserve memory for
      * it. The forced reservation attempt may result in an empty `MemoryReservation`
-     * if the selected request still cannot be satisfied.
+     * if the selected request still cannot be satisfied, for example when nothing
+     * is spillable.
      *
      * When multiple reservation requests are eligible, `MemoryReserveOrWait` uses
      * @p net_memory_delta as a heuristic to prefer requests that are expected to

--- a/cpp/src/memory/spill_manager.cpp
+++ b/cpp/src/memory/spill_manager.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <mutex>
+#include <optional>
 #include <utility>
 
 #include <rapidsmpf/memory/buffer_resource.hpp>
@@ -65,10 +67,8 @@ void SpillManager::remove_spill_function(SpillFunctionID fid) {
     }
 }
 
-std::size_t SpillManager::spill(std::size_t amount) {
-    RAPIDSMPF_NVTX_FUNC_RANGE();
+std::size_t SpillManager::spill_impl(std::size_t amount) {
     std::size_t spilled{0};
-    std::unique_lock<std::mutex> lock(mutex_);
     for (auto const [_, fid] : spill_function_priorities_) {
         if (spilled >= amount) {
             break;
@@ -78,13 +78,37 @@ std::size_t SpillManager::spill(std::size_t amount) {
     return spilled;
 }
 
-std::size_t SpillManager::spill_to_make_headroom(std::int64_t headroom) {
+std::size_t SpillManager::spill_to_make_headroom_impl(std::int64_t headroom) {
     // TODO: check other memory types.
-    std::int64_t available = br_->memory_available_for_reservation(MemoryType::DEVICE);
+    std::int64_t const available =
+        br_->memory_available_for_reservation(MemoryType::DEVICE);
     if (headroom <= available) {
         return 0;
     }
-    return spill(safe_cast<std::size_t>(headroom - available));
+    return spill_impl(safe_cast<std::size_t>(headroom - available));
+}
+
+std::size_t SpillManager::spill(std::size_t amount) {
+    RAPIDSMPF_NVTX_FUNC_RANGE();
+    std::lock_guard<std::mutex> lock(mutex_);
+    return spill_impl(amount);
+}
+
+std::size_t SpillManager::spill_to_make_headroom(std::int64_t headroom) {
+    RAPIDSMPF_NVTX_FUNC_RANGE();
+    std::lock_guard<std::mutex> lock(mutex_);
+    return spill_to_make_headroom_impl(headroom);
+}
+
+std::optional<std::size_t> SpillManager::try_spill_to_make_headroom(
+    std::int64_t headroom
+) {
+    RAPIDSMPF_NVTX_FUNC_RANGE();
+    std::unique_lock<std::mutex> lock(mutex_, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return std::nullopt;
+    }
+    return spill_to_make_headroom_impl(headroom);
 }
 
 }  // namespace rapidsmpf

--- a/cpp/src/memory/spill_manager.cpp
+++ b/cpp/src/memory/spill_manager.cpp
@@ -67,7 +67,7 @@ void SpillManager::remove_spill_function(SpillFunctionID fid) {
     }
 }
 
-std::size_t SpillManager::spill_impl(std::size_t amount) {
+std::size_t SpillManager::spill_unsafe(std::size_t amount) {
     std::size_t spilled{0};
     for (auto const [_, fid] : spill_function_priorities_) {
         if (spilled >= amount) {
@@ -78,26 +78,26 @@ std::size_t SpillManager::spill_impl(std::size_t amount) {
     return spilled;
 }
 
-std::size_t SpillManager::spill_to_make_headroom_impl(std::int64_t headroom) {
+std::size_t SpillManager::spill_to_make_headroom_unsafe(std::int64_t headroom) {
     // TODO: check other memory types.
     std::int64_t const available =
         br_->memory_available_for_reservation(MemoryType::DEVICE);
     if (headroom <= available) {
         return 0;
     }
-    return spill_impl(safe_cast<std::size_t>(headroom - available));
+    return spill_unsafe(safe_cast<std::size_t>(headroom - available));
 }
 
 std::size_t SpillManager::spill(std::size_t amount) {
     RAPIDSMPF_NVTX_FUNC_RANGE();
     std::lock_guard<std::mutex> lock(mutex_);
-    return spill_impl(amount);
+    return spill_unsafe(amount);
 }
 
 std::size_t SpillManager::spill_to_make_headroom(std::int64_t headroom) {
     RAPIDSMPF_NVTX_FUNC_RANGE();
     std::lock_guard<std::mutex> lock(mutex_);
-    return spill_to_make_headroom_impl(headroom);
+    return spill_to_make_headroom_unsafe(headroom);
 }
 
 std::optional<std::size_t> SpillManager::try_spill_to_make_headroom(
@@ -108,7 +108,7 @@ std::optional<std::size_t> SpillManager::try_spill_to_make_headroom(
     if (!lock.owns_lock()) {
         return std::nullopt;
     }
-    return spill_to_make_headroom_impl(headroom);
+    return spill_to_make_headroom_unsafe(headroom);
 }
 
 }  // namespace rapidsmpf

--- a/cpp/src/streaming/core/context.cpp
+++ b/cpp/src/streaming/core/context.cpp
@@ -87,7 +87,9 @@ Context::Context(
 
     for (auto mem_type : MEMORY_TYPES) {
         memory_[static_cast<std::size_t>(mem_type)] =
-            std::make_shared<MemoryReserveOrWait>(options_, mem_type, executor_, br_);
+            std::make_shared<MemoryReserveOrWait>(
+                options_, logger_, mem_type, executor_, br_
+            );
     }
 }
 

--- a/cpp/src/streaming/core/memory_reserve_or_wait.cpp
+++ b/cpp/src/streaming/core/memory_reserve_or_wait.cpp
@@ -224,8 +224,7 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
                 try {
                     logger_->warn(
                         "a spill function threw while making headroom for ",
-                        format_nbytes(headroom),
-                        ", falling back to the reservation timeout"
+                        format_nbytes(headroom)
                     );
                 } catch (...) {  // NOLINT(bugprone-empty-catch)
                 }

--- a/cpp/src/streaming/core/memory_reserve_or_wait.cpp
+++ b/cpp/src/streaming/core/memory_reserve_or_wait.cpp
@@ -251,7 +251,9 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
         void dismiss() noexcept {
             self = nullptr;
         }
-    } running_flag_guard{.self = this};
+    };
+
+    RunningFlagGuard running_flag_guard{.self = this};
 
     while (true) {
         auto last_reservation_success = Clock::now();

--- a/cpp/src/streaming/core/memory_reserve_or_wait.cpp
+++ b/cpp/src/streaming/core/memory_reserve_or_wait.cpp
@@ -23,14 +23,17 @@ namespace rapidsmpf::streaming {
 
 MemoryReserveOrWait::MemoryReserveOrWait(
     config::Options options,
+    std::shared_ptr<Logger> logger,
     MemoryType mem_type,
     std::shared_ptr<CoroThreadPoolExecutor> executor,
     std::shared_ptr<BufferResource> br
 )
     : mem_type_{mem_type},
+      logger_{std::move(logger)},
       executor_{std::move(executor)},
       br_{std::move(br)},
       timeout_{options.get<Duration>("memory_reserve_timeout", parse_duration)} {
+    RAPIDSMPF_EXPECTS(logger_ != nullptr, "logger cannot be NULL");
     RAPIDSMPF_EXPECTS(executor_ != nullptr, "executor cannot be NULL");
     RAPIDSMPF_EXPECTS(br_ != nullptr, "br cannot be NULL");
 }
@@ -78,7 +81,6 @@ coro::task<MemoryReservation> MemoryReserveOrWait::reserve_or_wait(
 
     // Enqueue a reservation request under the mutex.
     std::unique_lock lock(mutex_);
-    bool const spawn_periodic_memory_check = reservation_requests_.empty();
     reservation_requests_.insert(
         Request{
             .size = size,
@@ -88,9 +90,9 @@ coro::task<MemoryReservation> MemoryReserveOrWait::reserve_or_wait(
         }
     );
 
-    // If this is the first pending request, start the periodic memory check task.
+    // If no periodic memory check task is running, start one.
     std::optional<coro::task<void>> previous_periodic_task;
-    if (spawn_periodic_memory_check) {
+    if (!periodic_task_running_) {
         // A previous periodic task may exist but is guaranteed to be either already
         // finished or about to finish. This can happen when the last request was
         // extracted and the task is in the process of exiting.
@@ -99,6 +101,8 @@ coro::task<MemoryReservation> MemoryReserveOrWait::reserve_or_wait(
         // ensuring that at most one periodic task is active at any time.
         previous_periodic_task = std::move(periodic_memory_check_task_);
         periodic_memory_check_task_ = executor_->spawn_joinable(periodic_memory_check());
+        // Claim the slot until the task releases it.
+        periodic_task_running_ = true;
     }
     lock.unlock();
 
@@ -164,9 +168,10 @@ Duration MemoryReserveOrWait::timeout() const noexcept {
 }
 
 coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
-    // Helper that returns available memory, clamped so negative values become zero.
+    // Helper that returns the memory available for new reservations, clamped so
+    // negative values become zero.
     auto memory_available = [this]() -> std::size_t {
-        std::int64_t const ret = br_->memory_available(mem_type_);
+        std::int64_t const ret = br_->memory_available_for_reservation(mem_type_);
         return safe_cast<std::size_t>(std::max(ret, std::int64_t{0}));
     };
 
@@ -198,13 +203,68 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
         RAPIDSMPF_EXPECTS(err, "cannot spawn push-into-queue task");
     };
 
+    // Helper that spills until `headroom` bytes are reservable, swallowing a spill
+    // function that throws and logging it once per task. Returns false only when a
+    // non-blocking spill found the spill lock held.
+    bool spill_failure_logged = false;
+    auto make_headroom = [&](std::size_t headroom, bool blocking) -> bool {
+        // Only device memory is supported, see `spill_to_make_headroom()`.
+        if (mem_type_ != MemoryType::DEVICE) {
+            return true;
+        }
+        try {
+            auto const target = safe_cast<std::int64_t>(headroom);
+            if (blocking) {
+                br_->spill_manager().spill_to_make_headroom(target);
+                return true;
+            }
+            return br_->spill_manager().try_spill_to_make_headroom(target).has_value();
+        } catch (...) {
+            if (!std::exchange(spill_failure_logged, true)) {
+                try {
+                    logger_->warn(
+                        "a spill function threw while making headroom for ",
+                        format_nbytes(headroom),
+                        ", falling back to the reservation timeout"
+                    );
+                } catch (...) {  // NOLINT(bugprone-empty-catch)
+                }
+            }
+            return true;
+        }
+    };
+
+    // RAII helper that releases `periodic_task_running_` when this task exits without
+    // reaching one of the `co_return` paths below, such as on an exception. Those paths
+    // release the flag under the same lock acquisition that observes the empty request
+    // set, and dismiss the guard.
+    struct RunningFlagGuard {
+        MemoryReserveOrWait* self;
+
+        ~RunningFlagGuard() {
+            if (self != nullptr) {
+                std::lock_guard lock(self->mutex_);
+                self->periodic_task_running_ = false;
+            }
+        }
+
+        void dismiss() noexcept {
+            self = nullptr;
+        }
+    } running_flag_guard{.self = this};
+
     while (true) {
         auto last_reservation_success = Clock::now();
+        // Spilling is attempted once per timeout window, re-armed by each served
+        // request.
+        bool spill_attempted = false;
         while (true) {
             // Exit if no more pending requests remain.
             {
                 std::unique_lock lock(mutex_);
                 if (reservation_requests_.empty()) {
+                    periodic_task_running_ = false;
+                    running_flag_guard.dismiss();
                     co_return;
                 }
             }
@@ -222,6 +282,18 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
             std::unique_lock lock(mutex_);
             auto eligibles = eligible_requests(max_size);
             if (eligibles.empty()) {
+                // Nothing fits. Spill enough to admit the request with the smallest
+                // net_memory_delta, then re-poll.
+                if (!spill_attempted && !reservation_requests_.empty()) {
+                    auto const target = std::ranges::min_element(
+                        reservation_requests_, std::less<>{}, &Request::net_memory_delta
+                    );
+                    auto const headroom = target->size;
+                    // Spill without holding the mutex, the spill functions take the
+                    // buffer resource's lock.
+                    lock.unlock();
+                    spill_attempted = make_headroom(headroom, /* blocking = */ false);
+                }
                 continue;  // No eligible requests.
             }
 
@@ -240,6 +312,7 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
             lock.unlock();
             push_into_queue(request.queue, std::move(res));
             last_reservation_success = Clock::now();
+            spill_attempted = false;
         }
 
         // Reaching this point means we hit the timeout. We force progress by selecting
@@ -247,6 +320,8 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
         // net_memory_delta.
         std::unique_lock lock(mutex_);
         if (reservation_requests_.empty()) {
+            periodic_task_running_ = false;
+            running_flag_guard.dismiss();
             co_return;
         }
 
@@ -270,6 +345,9 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
 
         Request request = reservation_requests_.extract(it).value();
         lock.unlock();
+
+        // Last chance before handing back a zero-size reservation.
+        make_headroom(request.size, /* blocking = */ true);
 
         // Reserve memory and accept a zero-size result if it does not fit into the
         // currently available memory.

--- a/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
+++ b/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
@@ -42,50 +42,6 @@ class StreamingMemoryReserveOrWait
         return br->memory_available(rapidsmpf::MemoryType::DEVICE);
     }
 
-    // Pins the memory available for reservation to `available` bytes and registers a
-    // spill function that frees exactly what it is asked for, recording each request.
-    // Pinning keeps the buffer resource's periodic spill thread out of the way, it only
-    // acts once the available memory goes negative.
-    class SpillRecorder {
-      public:
-        SpillRecorder(rapidsmpf::BufferResource* br, std::int64_t available)
-            : br_{br},
-              limit_{
-                  rapidsmpf::safe_cast<std::int64_t>(
-                      br->device_mr_adaptor().current_allocated()
-                  )
-                  + available
-              } {
-            br_->set_memory_limit(rapidsmpf::MemoryType::DEVICE, limit_);
-            fid_ = br_->spill_manager().add_spill_function(
-                [this](std::size_t amount) -> std::size_t {
-                    std::lock_guard lock(mutex_);
-                    amounts_.push_back(amount);
-                    limit_ += rapidsmpf::safe_cast<std::int64_t>(amount);
-                    br_->set_memory_limit(rapidsmpf::MemoryType::DEVICE, limit_);
-                    return amount;
-                },
-                /* priority = */ 1
-            );
-        }
-
-        ~SpillRecorder() {
-            br_->spill_manager().remove_spill_function(fid_);
-        }
-
-        [[nodiscard]] std::vector<std::size_t> amounts() const {
-            std::lock_guard lock(mutex_);
-            return amounts_;
-        }
-
-      private:
-        rapidsmpf::BufferResource* br_;
-        std::int64_t limit_;
-        std::size_t fid_{};
-        mutable std::mutex mutex_;
-        std::vector<std::size_t> amounts_;
-    };
-
     // Actor that reserves `size` bytes and expects a reservation of `expected` bytes.
     static Actor waiter(
         MemoryReserveOrWait& mrow,
@@ -330,6 +286,54 @@ TEST_P(StreamingMemoryReserveOrWait, NoDeadlockWhenSpawningWithStaleHandle) {
     }
 }
 
+// Pins the memory available for reservation to `available` bytes and registers a spill
+// function backed by a finite pool of `spillable` bytes, recording each request. Frees
+// what it is asked for until the pool is exhausted, then returns 0.
+//
+// Pinning keeps the buffer resource's periodic spill thread out of the way, it only
+// acts once the available memory goes negative.
+class SpillRecorder {
+  public:
+    SpillRecorder(BufferResource* br, std::int64_t available, std::size_t spillable)
+        : br_{br},
+          limit_{
+              safe_cast<std::int64_t>(br->device_mr_adaptor().current_allocated())
+              + available
+          },
+          spillable_{spillable} {
+        br_->set_memory_limit(MemoryType::DEVICE, limit_);
+        fid_ = br_->spill_manager().add_spill_function(
+            [this](std::size_t amount) -> std::size_t {
+                std::lock_guard lock(mutex_);
+                amounts_.push_back(amount);
+                auto const spilled = std::min(amount, spillable_);
+                spillable_ -= spilled;
+                limit_ += safe_cast<std::int64_t>(spilled);
+                br_->set_memory_limit(MemoryType::DEVICE, limit_);
+                return spilled;
+            },
+            /* priority = */ 1
+        );
+    }
+
+    ~SpillRecorder() {
+        br_->spill_manager().remove_spill_function(fid_);
+    }
+
+    [[nodiscard]] std::vector<std::size_t> amounts() const {
+        std::lock_guard lock(mutex_);
+        return amounts_;
+    }
+
+  private:
+    BufferResource* br_;
+    std::int64_t limit_;
+    std::size_t spillable_;
+    std::size_t fid_{};
+    mutable std::mutex mutex_;
+    std::vector<std::size_t> amounts_;
+};
+
 TEST_P(StreamingMemoryReserveOrWait, SpillingUnblocksWaiter) {
     if (is_running_under_valgrind()) {
         GTEST_SKIP() << "Test runs very slow in valgrind";
@@ -346,7 +350,7 @@ TEST_P(StreamingMemoryReserveOrWait, SpillingUnblocksWaiter) {
 
     // The available memory covers the request on its own, but an outstanding
     // reservation consumes all of it, so only spilling can unblock the waiter.
-    SpillRecorder spills{br.get(), /* available = */ 10};
+    SpillRecorder spills{br.get(), /* available = */ 10, /* spillable = */ 10};
     auto [outstanding, _] = br->reserve(MemoryType::DEVICE, 10, AllowOverbooking::NO);
     ASSERT_EQ(outstanding.size(), 10);
 
@@ -402,7 +406,7 @@ TEST_P(StreamingMemoryReserveOrWait, NoSpillWhenMemoryIsAvailable) {
         ctx->br()
     };
 
-    SpillRecorder spills{br.get(), /* available = */ 1024};
+    SpillRecorder spills{br.get(), /* available = */ 1024, /* spillable = */ 0};
 
     std::vector<Actor> actors;
     actors.push_back(waiter(mrow, 10, 0, 10));

--- a/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
+++ b/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
@@ -5,6 +5,7 @@
 
 #include <thread>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <rapidsmpf/streaming/core/context.hpp>
@@ -40,6 +41,61 @@ class StreamingMemoryReserveOrWait
     std::int64_t get_mem_avail() {
         return br->memory_available(rapidsmpf::MemoryType::DEVICE);
     }
+
+    // Pins the memory available for reservation to `available` bytes and registers a
+    // spill function that frees exactly what it is asked for, recording each request.
+    // Pinning keeps the buffer resource's periodic spill thread out of the way, it only
+    // acts once the available memory goes negative.
+    class SpillRecorder {
+      public:
+        SpillRecorder(rapidsmpf::BufferResource* br, std::int64_t available)
+            : br_{br},
+              limit_{
+                  rapidsmpf::safe_cast<std::int64_t>(
+                      br->device_mr_adaptor().current_allocated()
+                  )
+                  + available
+              } {
+            br_->set_memory_limit(rapidsmpf::MemoryType::DEVICE, limit_);
+            fid_ = br_->spill_manager().add_spill_function(
+                [this](std::size_t amount) -> std::size_t {
+                    std::lock_guard lock(mutex_);
+                    amounts_.push_back(amount);
+                    limit_ += rapidsmpf::safe_cast<std::int64_t>(amount);
+                    br_->set_memory_limit(rapidsmpf::MemoryType::DEVICE, limit_);
+                    return amount;
+                },
+                /* priority = */ 1
+            );
+        }
+
+        ~SpillRecorder() {
+            br_->spill_manager().remove_spill_function(fid_);
+        }
+
+        [[nodiscard]] std::vector<std::size_t> amounts() const {
+            std::lock_guard lock(mutex_);
+            return amounts_;
+        }
+
+      private:
+        rapidsmpf::BufferResource* br_;
+        std::int64_t limit_;
+        std::size_t fid_{};
+        mutable std::mutex mutex_;
+        std::vector<std::size_t> amounts_;
+    };
+
+    // Actor that reserves `size` bytes and expects a reservation of `expected` bytes.
+    static Actor waiter(
+        MemoryReserveOrWait& mrow,
+        std::size_t size,
+        std::int64_t net_memory_delta,
+        std::size_t expected
+    ) {
+        auto res = co_await mrow.reserve_or_wait(size, net_memory_delta);
+        EXPECT_EQ(res.size(), expected);
+    }
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -61,7 +117,9 @@ TEST_P(StreamingMemoryReserveOrWait, AccessorsReturnExpectedValues) {
         {{"memory_reserve_timeout", config::OptionValue("12345 ms")}}
     };
 
-    MemoryReserveOrWait mrow{options, MemoryType::DEVICE, ctx->executor(), ctx->br()};
+    MemoryReserveOrWait mrow{
+        options, ctx->logger(), MemoryType::DEVICE, ctx->executor(), ctx->br()
+    };
 
     // Executor and buffer resource should match the context.
     EXPECT_EQ(mrow.executor(), ctx->executor());
@@ -78,6 +136,7 @@ TEST_P(StreamingMemoryReserveOrWait, ShutdownEarly) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
+        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -128,6 +187,7 @@ TEST_P(StreamingMemoryReserveOrWait, CheckPriority) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
+        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -193,6 +253,7 @@ TEST_P(StreamingMemoryReserveOrWait, RestartPeriodicTask) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
+        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -244,6 +305,7 @@ TEST_P(StreamingMemoryReserveOrWait, NoDeadlockWhenSpawningWithStaleHandle) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
+        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -268,6 +330,88 @@ TEST_P(StreamingMemoryReserveOrWait, NoDeadlockWhenSpawningWithStaleHandle) {
     }
 }
 
+TEST_P(StreamingMemoryReserveOrWait, SpillingUnblocksWaiter) {
+    if (is_running_under_valgrind()) {
+        GTEST_SKIP() << "Test runs very slow in valgrind";
+    }
+
+    MemoryReserveOrWait mrow{
+        // Use a very high timeout, so only spilling can satisfy the request.
+        config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
+        ctx->logger(),
+        MemoryType::DEVICE,
+        ctx->executor(),
+        ctx->br()
+    };
+
+    // The available memory covers the request on its own, but an outstanding
+    // reservation consumes all of it, so only spilling can unblock the waiter.
+    SpillRecorder spills{br.get(), /* available = */ 10};
+    auto [outstanding, _] = br->reserve(MemoryType::DEVICE, 10, AllowOverbooking::NO);
+    ASSERT_EQ(outstanding.size(), 10);
+
+    std::vector<Actor> actors;
+    actors.push_back(waiter(mrow, 10, 0, 10));
+    run_actor_network(std::move(actors));
+
+    EXPECT_THAT(spills.amounts(), ::testing::Contains(10u));
+}
+
+TEST_P(StreamingMemoryReserveOrWait, ThrowingSpillFunctionDoesNotStrandWaiter) {
+    if (is_running_under_valgrind()) {
+        GTEST_SKIP() << "Test runs very slow in valgrind";
+    }
+
+    MemoryReserveOrWait mrow{
+        // Short timeout, the waiter can only make progress via the timeout path.
+        config::Options({{"memory_reserve_timeout", config::OptionValue("100ms")}}),
+        ctx->logger(),
+        MemoryType::DEVICE,
+        ctx->executor(),
+        ctx->br()
+    };
+
+    br->set_memory_limit(
+        MemoryType::DEVICE,
+        safe_cast<std::int64_t>(br->device_mr_adaptor().current_allocated())
+    );
+    ASSERT_EQ(get_mem_avail(), 0);
+
+    std::atomic<bool> spill_called{false};
+    SpillManager::SpillFunction func = [&](std::size_t) -> std::size_t {
+        spill_called = true;
+        throw std::runtime_error("spill function failed");
+    };
+    auto fid = br->spill_manager().add_spill_function(func, /* priority = */ 1);
+
+    // The waiter completes via the timeout instead of hanging on its queue.
+    std::vector<Actor> actors;
+    actors.push_back(waiter(mrow, 10, 0, 0));
+    run_actor_network(std::move(actors));
+
+    br->spill_manager().remove_spill_function(fid);
+    EXPECT_TRUE(spill_called.load());
+}
+
+TEST_P(StreamingMemoryReserveOrWait, NoSpillWhenMemoryIsAvailable) {
+    MemoryReserveOrWait mrow{
+        config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
+        ctx->logger(),
+        MemoryType::DEVICE,
+        ctx->executor(),
+        ctx->br()
+    };
+
+    SpillRecorder spills{br.get(), /* available = */ 1024};
+
+    std::vector<Actor> actors;
+    actors.push_back(waiter(mrow, 10, 0, 10));
+    run_actor_network(std::move(actors));
+
+    // The request fits immediately, so the fast path never reaches the periodic task.
+    EXPECT_TRUE(spills.amounts().empty());
+}
+
 TEST_P(StreamingMemoryReserveOrWait, OverbookOnTimeoutReportsOverbookingBytes) {
     // Start with no available memory so the request cannot be satisfied normally.
     set_mem_avail(0);
@@ -276,6 +420,7 @@ TEST_P(StreamingMemoryReserveOrWait, OverbookOnTimeoutReportsOverbookingBytes) {
         MemoryReserveOrWait mrow{
             // Use a very small timeout to trigger timeout immediately.
             config::Options({{"memory_reserve_timeout", config::OptionValue("1ns")}}),
+            ctx->logger(),
             MemoryType::DEVICE,
             ctx->executor(),
             ctx->br()
@@ -294,6 +439,7 @@ TEST_P(StreamingMemoryReserveOrWait, FailOnTimeoutThrowsOverflowError) {
         MemoryReserveOrWait mrow{
             // Use a very small timeout to trigger timeout immediately.
             config::Options({{"memory_reserve_timeout", config::OptionValue("1ns")}}),
+            ctx->logger(),
             MemoryType::DEVICE,
             ctx->executor(),
             ctx->br()

--- a/cpp/tests/test_spill_manager.cpp
+++ b/cpp/tests/test_spill_manager.cpp
@@ -4,6 +4,11 @@
  */
 
 
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <thread>
+
 #include <gtest/gtest.h>
 
 #include <rmm/mr/limiting_resource_adaptor.hpp>
@@ -103,4 +108,75 @@ TEST(SpillManager, HeadroomAccountsForReservations) {
     EXPECT_EQ(br->memory_available_for_reservation(MemoryType::DEVICE), 60_KiB);
     EXPECT_EQ(br->spill_manager().spill_to_make_headroom(100_KiB), 40_KiB);
     EXPECT_EQ(br->memory_available_for_reservation(MemoryType::DEVICE), 100_KiB);
+}
+
+TEST(SpillManager, TrySpillToMakeHeadroomWhenIdle) {
+    std::int64_t mem_available = 0;
+    auto br = BufferResource::create(
+        rmm::mr::get_current_device_resource_ref(),
+        PinnedMemoryDisabled,
+        {{MemoryType::DEVICE, mem_available}},
+        std::nullopt  // No periodic spill thread
+    );
+
+    // Spill function that increases the available memory perfectly.
+    SpillManager::SpillFunction func =
+        [&br, &mem_available](std::size_t amount) -> std::size_t {
+        mem_available += safe_cast<std::int64_t>(amount);
+        br->set_memory_limit(MemoryType::DEVICE, mem_available);
+        return amount;
+    };
+    br->spill_manager().add_spill_function(func, /* priority = */ 1);
+
+    // Nothing else holds the spill lock, so this spills like the blocking version.
+    auto const spilled = br->spill_manager().try_spill_to_make_headroom(10_KiB);
+    ASSERT_TRUE(spilled.has_value());
+    EXPECT_EQ(*spilled, 10_KiB);
+    EXPECT_EQ(br->memory_available(MemoryType::DEVICE), 10_KiB);
+}
+
+TEST(SpillManager, TrySpillToMakeHeadroomSkipsWhileSpilling) {
+    std::int64_t mem_available = 0;
+    auto br = BufferResource::create(
+        rmm::mr::get_current_device_resource_ref(),
+        PinnedMemoryDisabled,
+        {{MemoryType::DEVICE, mem_available}},
+        std::nullopt  // No periodic spill thread
+    );
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool entered_spill{false};
+    bool release_spill{false};
+
+    // Spill function that blocks until the test releases it, keeping the spill
+    // manager's lock held in the meantime.
+    SpillManager::SpillFunction func = [&](std::size_t amount) -> std::size_t {
+        {
+            std::unique_lock lock(mutex);
+            entered_spill = true;
+            cv.notify_all();
+            cv.wait(lock, [&] { return release_spill; });
+        }
+        mem_available += safe_cast<std::int64_t>(amount);
+        br->set_memory_limit(MemoryType::DEVICE, mem_available);
+        return amount;
+    };
+    br->spill_manager().add_spill_function(func, /* priority = */ 1);
+
+    std::thread thd([&] { br->spill_manager().spill_to_make_headroom(10_KiB); });
+    {
+        std::unique_lock lock(mutex);
+        cv.wait(lock, [&] { return entered_spill; });
+    }
+
+    // A spill is in progress, so this returns immediately instead of blocking.
+    EXPECT_EQ(br->spill_manager().try_spill_to_make_headroom(10_KiB), std::nullopt);
+
+    {
+        std::lock_guard lock(mutex);
+        release_spill = true;
+    }
+    cv.notify_all();
+    thd.join();
 }

--- a/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
@@ -348,12 +348,18 @@ cdef class MemoryReserveOrWait:
         memory becomes available or no reservation request, including other pending
         requests, makes progress within the configured timeout.
 
+        While no pending request fits, spilling is attempted to free the memory the
+        highest-priority one needs, and again just before progress is forced. Both are
+        limited to :attr:`MemoryType.DEVICE`, since ``SpillManager`` measures headroom
+        against device memory. Requests of other memory types wait without spilling.
+
         The timeout does not apply specifically to this request. Instead, it serves as
         a global progress guarantee. If no pending reservation request can be satisfied
         within the timeout, ``MemoryReserveOrWait`` forces progress by selecting the
         smallest pending request and attempting to reserve memory for it. The forced
         reservation attempt may result in an empty :class:`MemoryReservation` if the
-        selected request still cannot be satisfied.
+        selected request still cannot be satisfied, for example when nothing is
+        spillable.
 
         When multiple reservation requests are eligible, ``MemoryReserveOrWait`` uses
         ``net_memory_delta`` as a heuristic to prefer requests that are expected to

--- a/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
@@ -353,13 +353,15 @@ cdef class MemoryReserveOrWait:
         limited to :attr:`MemoryType.DEVICE`, since ``SpillManager`` measures headroom
         against device memory. Requests of other memory types wait without spilling.
 
-        The timeout does not apply specifically to this request. Instead, it serves as
-        a global progress guarantee. If no pending reservation request can be satisfied
-        within the timeout, ``MemoryReserveOrWait`` forces progress by selecting the
-        smallest pending request and attempting to reserve memory for it. The forced
-        reservation attempt may result in an empty :class:`MemoryReservation` if the
-        selected request still cannot be satisfied, for example when nothing is
-        spillable.
+        The timeout does not apply specifically to this request. Instead, it bounds
+        when a final recovery attempt begins, not when it completes. If no pending
+        reservation request can be satisfied within the timeout,
+        ``MemoryReserveOrWait`` forces progress by selecting the smallest pending
+        request, spilling to make room for it, and attempting to reserve memory. That
+        spill waits for any in-flight spill to finish, so the call can return later
+        than the timeout. The forced reservation attempt may result in an empty
+        :class:`MemoryReservation` if the selected request still cannot be satisfied,
+        for example when nothing is spillable.
 
         When multiple reservation requests are eligible, ``MemoryReserveOrWait`` uses
         ``net_memory_delta`` as a heuristic to prefer requests that are expected to

--- a/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
@@ -42,7 +42,7 @@ cdef extern from * nogil:
         rapidsmpf::streaming::Context &ctx
     ) {
         return std::make_shared<rapidsmpf::streaming::MemoryReserveOrWait>(
-            std::move(options), mem_type, ctx.executor(), ctx.br()
+            std::move(options), ctx.logger(), mem_type, ctx.executor(), ctx.br()
         );
     }
     }  // namespace


### PR DESCRIPTION
`MemoryReserveOrWait` now spills. When no pending request fits the available memory, the wait loop frees enough for the highest-priority one and re-polls, so a waiter is unblocked by spilling instead of sitting until its timeout expires. Spilling from the poll path is non-blocking, so it never queues behind an in-flight spill or parks the streaming executor.

Before this it never spilled. It waited for the available memory to rise while nothing in the mechanism caused it to rise. The background spiller could not cover for it either. It runs with a headroom of zero, and a request parked in `reserve_or_wait` holds no reservation, only the intent to take one, so it is invisible to that check. #1162 made the spiller account for outstanding reservations, which does not help here for the same reason: a pending request is not yet a reservation.

The result was circular. Under pressure `reserve_or_wait` timed out, the `reserve_or_wait_or_overbook` fallback allocated past the limit, and only then did available memory go negative and the periodic thread begin spilling. Overbooking was what armed the spiller, so memory was spilled after the limit was exceeded rather than to avoid exceeding it.

### Breaking changes

`MemoryReserveOrWait`'s constructor takes a mandatory `std::shared_ptr<Logger>` as its second argument, so it can warn when a spill function throws. This is source-breaking for anyone constructing one directly. All in-repo call sites are updated, libcudf_streaming never constructs one, and the Python signature is unchanged because the binding already had the `Context` to take the logger from.

`spill_to_make_headroom()` keeps its signature but changes behavior. Under concurrency it can now return 0 where it previously returned a nonzero amount, because a caller that waited for an in-progress spill sees the memory that spill freed instead of spilling again for a shortfall that no longer exists.

