### PR TITLE
Fix cuCascade exclusion from librapidsmpf package

### DIFF
--- a/cmake/thirdparty/get_cucascade.cmake
+++ b/cmake/thirdparty/get_cucascade.cmake
@@ -21,7 +21,7 @@ function(find_and_configure_cucascade)
             "CUCASCADE_BUILD_STATIC_LIBS ON"
             "CUCASCADE_WARNINGS_AS_ERRORS OFF"
             "CUCASCADE_TOPOLOGY_ONLY ON"
-    EXCLUDE_FROM_ALL
+    EXCLUDE_FROM_ALL ON
   )
 endfunction()
 

--- a/conda/recipes/librapidsmpf/recipe.yaml
+++ b/conda/recipes/librapidsmpf/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 schema_version: 1
 
@@ -132,6 +132,11 @@ outputs:
           - cuda-cupti
           - librmm
           - openmpi
+    tests:
+      - script:
+          - test ! -d "${PREFIX}/include/cucascade"
+          - test ! -f "${PREFIX}/lib/libcucascade_topology_discovery.a"
+          - test ! -d "${PREFIX}/lib/cmake/cuCascade"
     about:
       homepage: https://github.com/rapidsai/rapidsmpf
       license: Apache-2.0


### PR DESCRIPTION
The `librapidsmpf` 26.08 conda packages unexpectedly contain cuCascade headers, the static topology-discovery archive, and cuCascade CMake package files. [Downstream cuDF builds](https://github.com/NVIDIA/cudf/actions/runs/32892064637/job/98207910853) then discover that bundled CMake package instead of fetching the pinned source. Its exported static target references `CUDA::nvml_static`, which is not guaranteed in the consumer environment, causing all four cuDF C++ package builds to fail during CMake generation.

`EXCLUDE_FROM_ALL` was intended to keep this private CPM dependency out of the install, but CPM.cmake parses it as a single-value argument. Supplying the keyword without `ON` leaves the exclusion disabled. Corresponding CPM issue is at https://github.com/cpm-cmake/CPM.cmake/issues/693

This was discovered when building a 26.08.01 release for cudf, but it will affect other consumers of librapidsmpf. I'm issuing this PR against the release/26.08 branch because I think this needs a hotfix release.
