### PR TITLE
Migrate cuda stream views to cuda::stream_ref

### DIFF
--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -8,8 +8,9 @@
 
 #include <mpi.h>
 
+#include <cuda/stream>
+
 #include <rmm/cuda_stream_pool.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -209,7 +210,7 @@ class ArgumentParser {
 Duration run(
     std::shared_ptr<Communicator> comm,
     ArgumentParser const& args,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     BufferResource* br,
     std::shared_ptr<rapidsmpf::Statistics> statistics
 ) {
@@ -221,11 +222,9 @@ Duration run(
             auto [res, _] =
                 br->reserve(MemoryType::DEVICE, args.msg_size * 2, AllowOverbooking::YES);
             auto buf = br->make_buffer(args.msg_size, stream, res);
-            buf->write_access(
-                [size = args.msg_size](std::byte* ptr, rmm::cuda_stream_view s) {
-                    RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(ptr, 0x42, size, s.value()));
-                }
-            );
+            buf->write_access([size = args.msg_size](std::byte* ptr, cuda::stream_ref s) {
+                RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(ptr, 0x42, size, s.get()));
+            });
             send_bufs.push_back(std::move(buf));
             recv_bufs.push_back(br->make_buffer(args.msg_size, stream, res));
         }
@@ -319,7 +318,7 @@ int main(int argc, char** argv) {
     }
 
     auto& log = comm->logger();
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     args.pprint(*comm);
     set_current_rmm_resource(args.rmm_mr);
 

--- a/cpp/benchmarks/bench_memory_resources.cpp
+++ b/cpp/benchmarks/bench_memory_resources.cpp
@@ -9,8 +9,9 @@
 
 #include <benchmark/benchmark.h>
 
+#include <cuda/stream>
+
 #include <rmm/cuda_stream_pool.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -73,7 +74,7 @@ class NewDelete {
     }
 
     void* allocate(
-        rmm::cuda_stream_view,
+        cuda::stream_ref,
         std::size_t size,
         std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT
     ) {
@@ -81,7 +82,7 @@ class NewDelete {
     }
 
     void deallocate(
-        rmm::cuda_stream_view,
+        cuda::stream_ref,
         void* ptr,
         std::size_t,
         std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT
@@ -142,7 +143,7 @@ cuda::mr::any_resource<cuda::mr::host_accessible> create_host_memory_resource(
 }
 
 void BM_Allocate(benchmark::State& state) {
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const allocation_size = static_cast<std::size_t>(state.range(0));
     auto const resource_type = static_cast<ResourceType>(state.range(1));
 
@@ -157,11 +158,11 @@ void BM_Allocate(benchmark::State& state) {
     for (auto _ : state) {
         void* ptr = mr.allocate(stream, allocation_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
         benchmark::DoNotOptimize(ptr);
-        stream.synchronize();
+        stream.sync();
 
         state.PauseTiming();
         mr.deallocate(stream, ptr, allocation_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-        stream.synchronize();
+        stream.sync();
         state.ResumeTiming();
     }
 
@@ -175,7 +176,7 @@ void BM_Allocate(benchmark::State& state) {
 }
 
 void BM_Deallocate(benchmark::State& state) {
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const allocation_size = safe_cast<std::size_t>(state.range(0));
     auto const resource_type = static_cast<ResourceType>(state.range(1));
 
@@ -190,11 +191,11 @@ void BM_Deallocate(benchmark::State& state) {
     for (auto _ : state) {
         state.PauseTiming();
         void* ptr = mr.allocate(stream, allocation_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-        stream.synchronize();
+        stream.sync();
         state.ResumeTiming();
 
         mr.deallocate(stream, ptr, allocation_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-        stream.synchronize();
+        stream.sync();
     }
 
     state.SetBytesProcessed(
@@ -207,7 +208,7 @@ void BM_Deallocate(benchmark::State& state) {
 }
 
 void BM_DeviceToHostCopyInclAlloc(benchmark::State& state) {
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const transfer_size = static_cast<std::size_t>(state.range(0));
     auto const resource_type = static_cast<ResourceType>(state.range(1));
 
@@ -224,8 +225,8 @@ void BM_DeviceToHostCopyInclAlloc(benchmark::State& state) {
     // Allocate device memory
     auto src = rmm::device_buffer(transfer_size, stream, *device_mr);
     // Initialize src to avoid optimization removal
-    RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(src.data(), 0xAB, transfer_size, stream));
-    stream.synchronize();
+    RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(src.data(), 0xAB, transfer_size, stream.get()));
+    stream.sync();
 
     for (auto _ : state) {
         void* dst =
@@ -233,7 +234,7 @@ void BM_DeviceToHostCopyInclAlloc(benchmark::State& state) {
         RAPIDSMPF_CUDA_TRY(
             rapidsmpf::cuda_memcpy_async(dst, src.data(), transfer_size, stream)
         );
-        stream.synchronize();
+        stream.sync();
 
         state.PauseTiming();
         host_mr.deallocate(stream, dst, transfer_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -256,16 +257,16 @@ void bench_copy(
     T& mr,
     void const* src,
     std::size_t size,
-    rmm::cuda_stream_view stream
+    cuda::stream_ref stream
 ) {
     for (auto _ : state) {
         state.PauseTiming();
         void* dst = mr.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-        stream.synchronize();
+        stream.sync();
         state.ResumeTiming();
 
         RAPIDSMPF_CUDA_TRY(rapidsmpf::cuda_memcpy_async(dst, src, size, stream));
-        stream.synchronize();
+        stream.sync();
 
         state.PauseTiming();
         mr.deallocate(stream, dst, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -274,7 +275,7 @@ void bench_copy(
 }
 
 void BM_DeviceToHostCopy(benchmark::State& state) {
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const transfer_size = static_cast<std::size_t>(state.range(0));
     auto const resource_type = static_cast<ResourceType>(state.range(1));
 
@@ -290,7 +291,7 @@ void BM_DeviceToHostCopy(benchmark::State& state) {
 
     auto src = rmm::device_buffer(transfer_size, stream, *device_mr);
     // Initialize src to avoid optimization removal
-    RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(src.data(), 0xAB, transfer_size, stream));
+    RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(src.data(), 0xAB, transfer_size, stream.get()));
 
     bench_copy(state, host_mr, src.data(), transfer_size, stream);
 
@@ -305,7 +306,7 @@ void BM_DeviceToHostCopy(benchmark::State& state) {
 }
 
 void BM_HostToDeviceCopy(benchmark::State& state) {
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const transfer_size = static_cast<std::size_t>(state.range(0));
     auto const resource_type = static_cast<ResourceType>(state.range(1));
 
@@ -340,7 +341,7 @@ void BM_HostToDeviceCopy(benchmark::State& state) {
 }
 
 void BM_HostToHostCopy(benchmark::State& state) {
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const transfer_size = static_cast<std::size_t>(state.range(0));
     auto const resource_type = static_cast<ResourceType>(state.range(1));
 
@@ -370,7 +371,7 @@ void BM_HostToHostCopy(benchmark::State& state) {
 }
 
 void BM_DeviceToDeviceCopy(benchmark::State& state) {
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const transfer_size = static_cast<std::size_t>(state.range(0));
 
     // Device MR, independent of host resource type
@@ -379,7 +380,7 @@ void BM_DeviceToDeviceCopy(benchmark::State& state) {
     rmm::device_buffer src(transfer_size, stream, *device_mr);
 
     // Initialize src to avoid optimization removal
-    RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(src.data(), 0xAB, transfer_size, stream));
+    RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(src.data(), 0xAB, transfer_size, stream.get()));
 
     bench_copy(state, *device_mr, src.data(), transfer_size, stream);
 
@@ -452,7 +453,7 @@ void BM_PinnedFirstAlloc_InitialPoolSize(benchmark::State& state) {
     // Ensure CUDA device context is initialized (required for pinned memory pools).
     RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
 
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default;
+    cuda::stream_ref stream{cudaStreamLegacy};
     auto const allocation_size = static_cast<std::size_t>(state.range(0)) << 20;
     auto const primed = static_cast<bool>(state.range(1));
 
@@ -467,10 +468,10 @@ void BM_PinnedFirstAlloc_InitialPoolSize(benchmark::State& state) {
         auto mr = br->try_pinned_mr();
         state.ResumeTiming();
         void* ptr = mr->allocate(stream, allocation_size);
-        stream.synchronize();
+        stream.sync();
         state.PauseTiming();
         mr->deallocate(stream, ptr, allocation_size);
-        stream.synchronize();
+        stream.sync();
     }
 
     state.SetBytesProcessed(int64_t(state.iterations()) * int64_t(allocation_size));

--- a/cpp/examples/example_cupti_monitor.cpp
+++ b/cpp/examples/example_cupti_monitor.cpp
@@ -59,7 +59,7 @@ int main() {
             try {
                 // Allocate device memory using rmm::device_buffer
                 rmm::device_buffer buf(
-                    allocation_size, cuda::stream_ref{cudaStream_t{nullptr}}
+                    allocation_size, cuda::stream_ref{cudaStreamLegacy}
                 );
                 device_buffers.push_back(std::move(buf));
             } catch (rmm::bad_alloc const& e) {

--- a/cpp/examples/example_cupti_monitor.cpp
+++ b/cpp/examples/example_cupti_monitor.cpp
@@ -10,6 +10,8 @@
 
 #include <cuda_runtime.h>
 
+#include <cuda/stream>
+
 #include <rmm/device_buffer.hpp>
 
 #ifdef RAPIDSMPF_HAVE_CUPTI
@@ -56,7 +58,9 @@ int main() {
                       << " MB on GPU using rmm::device_buffer...\n";
             try {
                 // Allocate device memory using rmm::device_buffer
-                rmm::device_buffer buf(allocation_size, rmm::cuda_stream_default);
+                rmm::device_buffer buf(
+                    allocation_size, cuda::stream_ref{cudaStream_t{nullptr}}
+                );
                 device_buffers.push_back(std::move(buf));
             } catch (rmm::bad_alloc const& e) {
                 std::cerr << "rmm::device_buffer allocation failed: " << e.what()

--- a/cpp/include/rapidsmpf/coll/allgather.hpp
+++ b/cpp/include/rapidsmpf/coll/allgather.hpp
@@ -14,8 +14,6 @@
 #include <optional>
 #include <vector>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <rapidsmpf/coll/utils.hpp>
 #include <rapidsmpf/communicator/communicator.hpp>
 #include <rapidsmpf/memory/buffer.hpp>

--- a/cpp/include/rapidsmpf/coll/allreduce.hpp
+++ b/cpp/include/rapidsmpf/coll/allreduce.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,6 +13,8 @@
 #include <memory>
 #include <mutex>
 #include <utility>
+
+#include <cuda/stream>
 
 #ifdef __CUDACC__
 #include <thrust/execution_policy.h>
@@ -297,14 +299,14 @@ struct DeviceOp {
             "DeviceOp expects device memory"
         );
         // Both buffers are guaranteed to be on the same stream by the AllReduce ctor.
-        right->write_access([&](std::byte* right_bytes, rmm::cuda_stream_view stream) {
+        right->write_access([&](std::byte* right_bytes, cuda::stream_ref stream) {
             auto const* left_bytes = reinterpret_cast<std::byte const*>(left->data());
 
             T* right_ptr = reinterpret_cast<T*>(right_bytes);
             T const* left_ptr = reinterpret_cast<T const*>(left_bytes);
 
             thrust::transform(
-                thrust::cuda::par_nosync.on(stream.value()),
+                thrust::cuda::par_nosync.on(stream.get()),
                 left_ptr,
                 left_ptr + count,
                 right_ptr,

--- a/cpp/include/rapidsmpf/cuda_event.hpp
+++ b/cpp/include/rapidsmpf/cuda_event.hpp
@@ -8,7 +8,7 @@
 
 #include <cuda_runtime.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <rapidsmpf/error.hpp>
 
@@ -57,7 +57,7 @@ class CudaEvent {
      * @throws rapidsmpf::cuda_error if event creation or recording fails.
      */
     static std::shared_ptr<CudaEvent> make_shared_record(
-        rmm::cuda_stream_view stream, unsigned flags = cudaEventDisableTiming
+        cuda::stream_ref stream, unsigned flags = cudaEventDisableTiming
     );
 
     /**
@@ -100,7 +100,7 @@ class CudaEvent {
      *
      * @throws rapidsmpf::cuda_error if cudaEventRecord fails.
      */
-    void record(rmm::cuda_stream_view stream);
+    void record(cuda::stream_ref stream);
 
     /**
      * @brief Check if the CUDA event has been completed.
@@ -128,7 +128,7 @@ class CudaEvent {
      *
      * @throws rapidsmpf::cuda_error if cudaStreamWaitEvent fails.
      */
-    void stream_wait(rmm::cuda_stream_view stream) const;
+    void stream_wait(cuda::stream_ref stream) const;
 
     /**
      * @brief Access the underlying CUDA event handle.

--- a/cpp/include/rapidsmpf/cuda_stream.hpp
+++ b/cpp/include/rapidsmpf/cuda_stream.hpp
@@ -1,11 +1,13 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 
 #include <memory>
 #include <ranges>
+
+#include <cuda/stream>
 
 #include <rapidsmpf/cuda_event.hpp>
 
@@ -18,8 +20,8 @@ namespace rapidsmpf {
  * This call is asynchronous with respect to the host thread; no host-side
  * blocking occurs.
  *
- * @tparam Range1 Iterable whose elements are rmm::cuda_stream_view.
- * @tparam Range2 Iterable whose elements are rmm::cuda_stream_view.
+ * @tparam Range1 Iterable whose elements are cuda::stream_ref.
+ * @tparam Range2 Iterable whose elements are cuda::stream_ref.
  *
  * @param downstreams Streams that must not run ahead.
  * @param upstreams Streams whose already-enqueued work must complete first.
@@ -36,9 +38,9 @@ void cuda_stream_join(
 ) {
     // Quick exit if all streams are identical.
     if ([&] {
-            for (rmm::cuda_stream_view const& upstream : upstreams) {
-                for (rmm::cuda_stream_view const& downstream : downstreams) {
-                    if (upstream.value() != downstream.value()) {
+            for (cuda::stream_ref const& upstream : upstreams) {
+                for (cuda::stream_ref const& downstream : downstreams) {
+                    if (upstream.get() != downstream.get()) {
                         return false;
                     }
                 }
@@ -59,10 +61,10 @@ void cuda_stream_join(
     }
 
     // Let all downstreams wait on all upstreams.
-    for (rmm::cuda_stream_view const& upstream : upstreams) {
+    for (cuda::stream_ref const& upstream : upstreams) {
         event->record(upstream);
-        for (rmm::cuda_stream_view const& downstream : downstreams) {
-            if (upstream.value() != downstream.value()) {
+        for (cuda::stream_ref const& downstream : downstreams) {
+            if (upstream.get() != downstream.get()) {
                 event->stream_wait(downstream);
             }
         }
@@ -89,9 +91,7 @@ void cuda_stream_join(
  * @see cuda_stream_join(Range1 const&, Range2 const&, CudaEvent*)
  */
 inline void cuda_stream_join(
-    rmm::cuda_stream_view downstream,
-    rmm::cuda_stream_view upstream,
-    CudaEvent* event = nullptr
+    cuda::stream_ref downstream, cuda::stream_ref upstream, CudaEvent* event = nullptr
 ) {
     return cuda_stream_join(
         std::views::single(downstream), std::views::single(upstream), event

--- a/cpp/include/rapidsmpf/detail/rmm_resource_adaptor_impl.hpp
+++ b/cpp/include/rapidsmpf/detail/rmm_resource_adaptor_impl.hpp
@@ -16,6 +16,7 @@
 #include <cuda_runtime_api.h>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>

--- a/cpp/include/rapidsmpf/memory/buffer.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer.hpp
@@ -368,7 +368,7 @@ class Buffer {
   private:
     MemoryType const mem_type_;
     std::variant<DeviceBufferT, HostBufferT> storage_;
-    cuda::stream_ref stream_{cudaStream_t{nullptr}};
+    cuda::stream_ref stream_{cudaStreamLegacy};
     CudaEvent latest_write_event_;
     std::atomic<bool> lock_;
 };

--- a/cpp/include/rapidsmpf/memory/buffer.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer.hpp
@@ -12,7 +12,8 @@
 
 #include <cuda_runtime.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/device_buffer.hpp>
 
 #include <rapidsmpf/cuda_event.hpp>
@@ -91,7 +92,7 @@ class Buffer {
      * (i.e., `this->stream()`).
      *
      * The callable must be invocable as:
-     *   - `R(std::byte*, rmm::cuda_stream_view)`.
+     *   - `R(std::byte*, cuda::stream_ref)`.
      *
      * All work performed by @p f must be stream-ordered on the buffer's stream.
      * Enqueuing work on any other stream without synchronizing with the buffer's
@@ -107,15 +108,15 @@ class Buffer {
      * outside of @p f is undefined behavior.
      *
      * @tparam F Callable type.
-     * @param f Callable that accepts `(std::byte*, rmm::cuda_stream_view)`.
+     * @param f Callable that accepts `(std::byte*, cuda::stream_ref)`.
      * @return Whatever @p f returns (`void` if none).
      *
      * @throws std::logic_error If the buffer is locked.
      *
      * @code{.cpp}
      * // Snippet: copy data from `src_ptr` into `buffer` on the buffer's stream.
-     * buffer.write_access([&](std::byte* buffer_ptr, rmm::cuda_stream_view stream) {
-     *   assert(buffer.stream().value() == stream.value());
+     * buffer.write_access([&](std::byte* buffer_ptr, cuda::stream_ref stream) {
+     *   assert(buffer.stream().get() == stream.get());
      *   RAPIDSMPF_CUDA_TRY(rapidsmpf::cuda_memcpy_async(
      *       buffer_ptr,
      *       src_ptr,
@@ -126,14 +127,13 @@ class Buffer {
      * @endcode
      */
     template <typename F>
-    auto write_access(F&& f)
-        -> std::invoke_result_t<F, std::byte*, rmm::cuda_stream_view> {
+    auto write_access(F&& f) -> std::invoke_result_t<F, std::byte*, cuda::stream_ref> {
         using Fn = std::remove_reference_t<F>;
         static_assert(
-            std::is_invocable_v<Fn, std::byte*, rmm::cuda_stream_view>,
-            "write_access() expects callable R(std::byte*, rmm::cuda_stream_view)"
+            std::is_invocable_v<Fn, std::byte*, cuda::stream_ref>,
+            "write_access() expects callable R(std::byte*, cuda::stream_ref)"
         );
-        using R = std::invoke_result_t<Fn, std::byte*, rmm::cuda_stream_view>;
+        using R = std::invoke_result_t<Fn, std::byte*, cuda::stream_ref>;
 
         auto* ptr = const_cast<std::byte*>(data());
         if constexpr (std::is_void_v<R>) {
@@ -201,7 +201,7 @@ class Buffer {
      *
      * @return The associated CUDA stream.
      */
-    [[nodiscard]] constexpr rmm::cuda_stream_view stream() const noexcept {
+    [[nodiscard]] constexpr cuda::stream_ref stream() const noexcept {
         return stream_;
     }
 
@@ -238,7 +238,7 @@ class Buffer {
      * buffer_copy(buffer_a, buffer_b, size);
      * @endcode
      */
-    void rebind_stream(rmm::cuda_stream_view new_stream);
+    void rebind_stream(cuda::stream_ref new_stream);
 
     /**
      * @brief Check whether the buffer's most recent write has completed.
@@ -269,7 +269,7 @@ class Buffer {
      *   MPI_Isend(buffer.data(), buffer.size(), MPI_BYTE, dst, tag, comm, &req);
      * } else {
      *   // Ensure completion before handing to MPI.
-     *   buffer.stream().synchronize();
+     *   buffer.stream().sync();
      *   MPI_Isend(buffer.data(), buffer.size(), MPI_BYTE, dst, tag, comm, &req);
      * }
      * @endcode
@@ -307,7 +307,7 @@ class Buffer {
      */
     Buffer(
         std::unique_ptr<HostBuffer> host_buffer,
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         MemoryType mem_type
     );
 
@@ -368,7 +368,7 @@ class Buffer {
   private:
     MemoryType const mem_type_;
     std::variant<DeviceBufferT, HostBufferT> storage_;
-    rmm::cuda_stream_view stream_;
+    cuda::stream_ref stream_{cudaStream_t{nullptr}};
     CudaEvent latest_write_event_;
     std::atomic<bool> lock_;
 };

--- a/cpp/include/rapidsmpf/memory/buffer_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer_resource.hpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <rmm/cuda_stream_pool.hpp>
 
@@ -413,7 +414,7 @@ class BufferResource : public std::enable_shared_from_this<BufferResource> {
      * @throws rapidsmpf::reservation_error if `size` exceeds the size of the reservation.
      */
     std::unique_ptr<Buffer> make_buffer(
-        std::size_t size, rmm::cuda_stream_view stream, MemoryReservation& reservation
+        std::size_t size, cuda::stream_ref stream, MemoryReservation& reservation
     );
 
     /**
@@ -427,7 +428,7 @@ class BufferResource : public std::enable_shared_from_this<BufferResource> {
      * @return A unique pointer to the allocated Buffer.
      */
     std::unique_ptr<Buffer> make_buffer(
-        rmm::cuda_stream_view stream, MemoryReservation&& reservation
+        cuda::stream_ref stream, MemoryReservation&& reservation
     );
 
     /**
@@ -450,7 +451,7 @@ class BufferResource : public std::enable_shared_from_this<BufferResource> {
      * @return Unique pointer to the resulting Buffer.
      */
     std::unique_ptr<Buffer> move(
-        std::unique_ptr<rmm::device_buffer> data, rmm::cuda_stream_view stream
+        std::unique_ptr<rmm::device_buffer> data, cuda::stream_ref stream
     );
 
     /**

--- a/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
+++ b/cpp/include/rapidsmpf/memory/cuda_memcpy_async.hpp
@@ -10,7 +10,7 @@
 
 #include <cuda_runtime.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace rapidsmpf {
 
@@ -39,10 +39,10 @@ namespace rapidsmpf {
     void const* const* srcs,
     std::size_t const* sizes,
     std::size_t count,
-    rmm::cuda_stream_view stream
+    cuda::stream_ref stream
 ) {
 #if CUDART_VERSION >= 13000
-    if (!stream.is_default()) {
+    if (stream.get() != cudaStream_t{nullptr} && stream.get() != cudaStreamLegacy) {
         // Filter out invalid copies; cudaMemcpyBatchAsync does not support
         // nullptr dst/src or size==0.
         auto is_invalid = [&](std::size_t i) {
@@ -95,7 +95,7 @@ namespace rapidsmpf {
         };
         std::size_t attrs_idx = 0;
         return cudaMemcpyBatchAsync(
-            dsts, srcs, sizes, count, &attrs, &attrs_idx, 1, stream.value()
+            dsts, srcs, sizes, count, &attrs, &attrs_idx, 1, stream.get()
         );
     }
 #endif  // CUDART_VERSION >= 13000
@@ -103,9 +103,8 @@ namespace rapidsmpf {
         if (dsts[i] == nullptr || srcs[i] == nullptr || sizes[i] == 0) {
             continue;
         }
-        cudaError_t status = cudaMemcpyAsync(
-            dsts[i], srcs[i], sizes[i], cudaMemcpyDefault, stream.value()
-        );
+        cudaError_t status =
+            cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], cudaMemcpyDefault, stream.get());
         if (status != cudaSuccess) {
             return status;
         }
@@ -144,7 +143,7 @@ namespace rapidsmpf {
  * @return cudaError_t CUDA error code.
  */
 [[nodiscard]] inline cudaError_t cuda_memcpy_async(
-    void* dst, void const* src, std::size_t count, rmm::cuda_stream_view stream
+    void* dst, void const* src, std::size_t count, cuda::stream_ref stream
 ) {
     if (count == 0) {
         return cudaSuccess;

--- a/cpp/include/rapidsmpf/memory/host_buffer.hpp
+++ b/cpp/include/rapidsmpf/memory/host_buffer.hpp
@@ -221,7 +221,7 @@ class HostBuffer {
         std::function<void(cuda::stream_ref)> deallocate_fn
     );
 
-    cuda::stream_ref stream_;
+    cuda::stream_ref stream_{cudaStreamLegacy};
     std::span<std::byte> span_{};
     /// @brief Callable that releases the underlying memory when invoked with the current
     /// stream. Null when the buffer is empty.

--- a/cpp/include/rapidsmpf/memory/host_buffer.hpp
+++ b/cpp/include/rapidsmpf/memory/host_buffer.hpp
@@ -14,8 +14,8 @@
 #include <vector>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -45,7 +45,7 @@ class HostBuffer {
      */
     HostBuffer(
         std::size_t size,
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         cuda::mr::any_resource<cuda::mr::host_accessible> mr
     );
 
@@ -91,7 +91,7 @@ class HostBuffer {
      *
      * @return CUDA stream view.
      */
-    [[nodiscard]] rmm::cuda_stream_view stream() const noexcept;
+    [[nodiscard]] cuda::stream_ref stream() const noexcept;
 
     /**
      * @brief Get the size of the buffer in bytes.
@@ -142,7 +142,7 @@ class HostBuffer {
      *
      * @param stream The new CUDA stream.
      */
-    void set_stream(rmm::cuda_stream_view stream);
+    void set_stream(cuda::stream_ref stream);
 
     /**
      * @brief Construct a `HostBuffer` by copying data from a `std::vector<std::uint8_t>`.
@@ -158,7 +158,7 @@ class HostBuffer {
      */
     static HostBuffer from_uint8_vector(
         std::vector<std::uint8_t> const& data,
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         rmm::host_async_resource_ref mr
     );
 
@@ -175,7 +175,7 @@ class HostBuffer {
      * @return A new `HostBuffer` owning the vector's memory.
      */
     static HostBuffer from_owned_vector(
-        std::vector<std::uint8_t>&& data, rmm::cuda_stream_view stream
+        std::vector<std::uint8_t>&& data, cuda::stream_ref stream
     );
 
     /**
@@ -202,8 +202,7 @@ class HostBuffer {
      * host memory type. If non-pinned host buffer leads to an irrecoverable condition.
      */
     static HostBuffer from_rmm_device_buffer(
-        std::unique_ptr<rmm::device_buffer> pinned_host_buffer,
-        rmm::cuda_stream_view stream
+        std::unique_ptr<rmm::device_buffer> pinned_host_buffer, cuda::stream_ref stream
     );
 
   private:
@@ -218,15 +217,15 @@ class HostBuffer {
      */
     HostBuffer(
         std::span<std::byte> span,
-        rmm::cuda_stream_view stream,
-        std::function<void(rmm::cuda_stream_view)> deallocate_fn
+        cuda::stream_ref stream,
+        std::function<void(cuda::stream_ref)> deallocate_fn
     );
 
-    rmm::cuda_stream_view stream_;
+    cuda::stream_ref stream_;
     std::span<std::byte> span_{};
     /// @brief Callable that releases the underlying memory when invoked with the current
     /// stream. Null when the buffer is empty.
-    std::function<void(rmm::cuda_stream_view)> deallocate_fn_{};
+    std::function<void(cuda::stream_ref)> deallocate_fn_{};
 };
 
 }  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/memory/host_memory_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/host_memory_resource.hpp
@@ -8,8 +8,9 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <cuda/stream>
+
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <rapidsmpf/error.hpp>
@@ -87,7 +88,7 @@ class HostMemoryResource : public BackRefMixin<BufferResource> {
      * @throw std::invalid_argument If @p alignment is not a valid alignment.
      */
     void* allocate(
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         std::size_t size,
         std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT
     );
@@ -104,7 +105,7 @@ class HostMemoryResource : public BackRefMixin<BufferResource> {
      * @param alignment Alignment originally used for the allocation.
      */
     void deallocate(
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         void* ptr,
         std::size_t size,
         std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT

--- a/cpp/include/rapidsmpf/memory/packed_data.hpp
+++ b/cpp/include/rapidsmpf/memory/packed_data.hpp
@@ -8,7 +8,8 @@
 #include <memory>
 #include <vector>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/device_buffer.hpp>
 
 #include <rapidsmpf/error.hpp>
@@ -75,7 +76,7 @@ struct PackedData {
      *
      * @return The CUDA stream.
      */
-    [[nodiscard]] rmm::cuda_stream_view stream() const {
+    [[nodiscard]] cuda::stream_ref stream() const {
         return data->stream();
     }
 

--- a/cpp/include/rapidsmpf/memory/pinned_memory_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/pinned_memory_resource.hpp
@@ -12,10 +12,10 @@
 #include <cuda_runtime_api.h>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <rapidsmpf/config.hpp>

--- a/cpp/include/rapidsmpf/stream_ordered_timing.hpp
+++ b/cpp/include/rapidsmpf/stream_ordered_timing.hpp
@@ -91,7 +91,7 @@ class StreamOrderedTiming {
 
   private:
     std::uintptr_t uid_{0};
-    cuda::stream_ref stream_;
+    cuda::stream_ref stream_{cudaStreamLegacy};
     std::shared_ptr<Statistics> statistics_;
 };
 

--- a/cpp/include/rapidsmpf/stream_ordered_timing.hpp
+++ b/cpp/include/rapidsmpf/stream_ordered_timing.hpp
@@ -8,7 +8,7 @@
 #include <optional>
 #include <string>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <rapidsmpf/statistics.hpp>
 
@@ -44,9 +44,7 @@ class StreamOrderedTiming {
      * @param stream The CUDA stream to time.
      * @param statistics The Statistics object that will receive the duration entry.
      */
-    StreamOrderedTiming(
-        rmm::cuda_stream_view stream, std::shared_ptr<Statistics> statistics
-    );
+    StreamOrderedTiming(cuda::stream_ref stream, std::shared_ptr<Statistics> statistics);
 
     /**
      * @brief Marks the stop position in the stream and schedules recording of the
@@ -93,7 +91,7 @@ class StreamOrderedTiming {
 
   private:
     std::uintptr_t uid_{0};
-    rmm::cuda_stream_view stream_;
+    cuda::stream_ref stream_;
     std::shared_ptr<Statistics> statistics_;
 };
 

--- a/cpp/src/coll/utils.cpp
+++ b/cpp/src/coll/utils.cpp
@@ -10,6 +10,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/coll/utils.hpp>
 #include <rapidsmpf/error.hpp>
 
@@ -146,7 +148,8 @@ std::unique_ptr<Chunk> Chunk::deserialize(
         Chunk::INVALID_RANK,
         std::move(metadata),
         br->make_buffer(
-            br->stream_pool()->get_stream(), br->reserve_or_fail(data_size, MEMORY_TYPES)
+            cuda::stream_ref{br->stream_pool()->get_stream().value()},
+            br->reserve_or_fail(data_size, MEMORY_TYPES)
         )
     ));
 }

--- a/cpp/src/coll/utils.cpp
+++ b/cpp/src/coll/utils.cpp
@@ -148,8 +148,7 @@ std::unique_ptr<Chunk> Chunk::deserialize(
         Chunk::INVALID_RANK,
         std::move(metadata),
         br->make_buffer(
-            br->stream_pool()->get_stream(),
-            br->reserve_or_fail(data_size, MEMORY_TYPES)
+            br->stream_pool()->get_stream(), br->reserve_or_fail(data_size, MEMORY_TYPES)
         )
     ));
 }

--- a/cpp/src/coll/utils.cpp
+++ b/cpp/src/coll/utils.cpp
@@ -148,7 +148,7 @@ std::unique_ptr<Chunk> Chunk::deserialize(
         Chunk::INVALID_RANK,
         std::move(metadata),
         br->make_buffer(
-            cuda::stream_ref{br->stream_pool()->get_stream().value()},
+            br->stream_pool()->get_stream(),
             br->reserve_or_fail(data_size, MEMORY_TYPES)
         )
     ));

--- a/cpp/src/communicator/mpi.cpp
+++ b/cpp/src/communicator/mpi.cpp
@@ -11,8 +11,6 @@
 
 #include <mpi.h>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <rapidsmpf/communicator/mpi.hpp>
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/progress_thread.hpp>

--- a/cpp/src/cuda_event.cpp
+++ b/cpp/src/cuda_event.cpp
@@ -5,6 +5,8 @@
 
 #include <utility>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/cuda_event.hpp>
 
 namespace rapidsmpf {
@@ -14,7 +16,7 @@ CudaEvent::CudaEvent(unsigned flags) {
 }
 
 std::shared_ptr<CudaEvent> CudaEvent::make_shared_record(
-    rmm::cuda_stream_view stream, unsigned flags
+    cuda::stream_ref stream, unsigned flags
 ) {
     auto ret = std::make_shared<CudaEvent>(flags);
     ret->record(stream);
@@ -43,8 +45,8 @@ CudaEvent& CudaEvent::operator=(CudaEvent&& other) {
     return *this;
 }
 
-void CudaEvent::record(rmm::cuda_stream_view stream) {
-    RAPIDSMPF_CUDA_TRY(cudaEventRecord(event_, stream));
+void CudaEvent::record(cuda::stream_ref stream) {
+    RAPIDSMPF_CUDA_TRY(cudaEventRecord(event_, stream.get()));
 }
 
 [[nodiscard]] bool CudaEvent::is_ready() const {
@@ -59,8 +61,8 @@ void CudaEvent::host_wait() const {
     RAPIDSMPF_CUDA_TRY(cudaEventSynchronize(event_));
 }
 
-void CudaEvent::stream_wait(rmm::cuda_stream_view stream) const {
-    RAPIDSMPF_CUDA_TRY(cudaStreamWaitEvent(stream, event_));
+void CudaEvent::stream_wait(cuda::stream_ref stream) const {
+    RAPIDSMPF_CUDA_TRY(cudaStreamWaitEvent(stream.get(), event_));
 }
 
 cudaEvent_t const& CudaEvent::value() const noexcept {

--- a/cpp/src/memory/buffer.cpp
+++ b/cpp/src/memory/buffer.cpp
@@ -8,8 +8,7 @@
 #include <cuda_runtime.h>
 
 #include <cuda/std/cstdint>
-
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 #include <rapidsmpf/cuda_stream.hpp>
 #include <rapidsmpf/memory/buffer.hpp>
@@ -22,9 +21,7 @@ namespace rapidsmpf {
 
 
 Buffer::Buffer(
-    std::unique_ptr<HostBuffer> host_buffer,
-    rmm::cuda_stream_view stream,
-    MemoryType mem_type
+    std::unique_ptr<HostBuffer> host_buffer, cuda::stream_ref stream, MemoryType mem_type
 )
     : size{host_buffer ? host_buffer->size() : 0},
       mem_type_{mem_type},
@@ -117,9 +114,9 @@ Buffer::HostBufferT Buffer::release_host_buffer() {
     RAPIDSMPF_FAIL("Buffer doesn't hold a HostBuffer");
 }
 
-void Buffer::rebind_stream(rmm::cuda_stream_view new_stream) {
+void Buffer::rebind_stream(cuda::stream_ref new_stream) {
     throw_if_locked();
-    if (new_stream.value() == stream_.value()) {
+    if (new_stream.get() == stream_.get()) {
         return;
     }
 
@@ -163,7 +160,7 @@ void buffer_copy(
     // might deallocate `src` before the memcpy enqueued on `dst.stream()` has completed.
     src.latest_write_event().stream_wait(dst.stream());
     StreamOrderedTiming timing{dst.stream(), statistics};
-    dst.write_access([&](std::byte* dst_data, rmm::cuda_stream_view stream) {
+    dst.write_access([&](std::byte* dst_data, cuda::stream_ref stream) {
         RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(
             dst_data + dst_offset, src.data() + src_offset, size, stream
         ));

--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -281,7 +281,7 @@ std::unique_ptr<Buffer> BufferResource::make_buffer(
 std::unique_ptr<Buffer> BufferResource::move(
     std::unique_ptr<rmm::device_buffer> data, cuda::stream_ref stream
 ) {
-    auto upstream = cuda::stream_ref{data->stream().value()};
+    cuda::stream_ref upstream = data->stream();
     if (upstream.get() != stream.get()) {
         cuda_stream_join(stream, upstream);
         data->set_stream(stream);

--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/cuda_stream.hpp>
@@ -237,7 +238,7 @@ std::size_t BufferResource::release(MemoryReservation& reservation, std::size_t 
 }
 
 std::unique_ptr<Buffer> BufferResource::make_buffer(
-    std::size_t size, rmm::cuda_stream_view stream, MemoryReservation& reservation
+    std::size_t size, cuda::stream_ref stream, MemoryReservation& reservation
 ) {
     auto const mem_type = reservation.mem_type_;
     StreamOrderedTiming timing{stream, statistics_};
@@ -272,16 +273,16 @@ std::unique_ptr<Buffer> BufferResource::make_buffer(
 }
 
 std::unique_ptr<Buffer> BufferResource::make_buffer(
-    rmm::cuda_stream_view stream, MemoryReservation&& reservation
+    cuda::stream_ref stream, MemoryReservation&& reservation
 ) {
     return make_buffer(reservation.size(), stream, reservation);
 }
 
 std::unique_ptr<Buffer> BufferResource::move(
-    std::unique_ptr<rmm::device_buffer> data, rmm::cuda_stream_view stream
+    std::unique_ptr<rmm::device_buffer> data, cuda::stream_ref stream
 ) {
-    auto upstream = data->stream();
-    if (upstream.value() != stream.value()) {
+    auto upstream = cuda::stream_ref{data->stream().value()};
+    if (upstream.get() != stream.get()) {
         cuda_stream_join(stream, upstream);
         data->set_stream(stream);
     }
@@ -320,7 +321,7 @@ std::unique_ptr<rmm::device_buffer> BufferResource::move_to_device_buffer(
     auto stream = buffer->stream();
     auto ret = move(std::move(buffer), reservation)->release_device_buffer();
     RAPIDSMPF_EXPECTS(
-        ret->stream().value() == stream.value(),
+        ret->stream().value() == stream.get(),
         "something went wrong, the Buffer's stream and the device_buffer's stream "
         "don't match"
     );

--- a/cpp/src/memory/host_buffer.cpp
+++ b/cpp/src/memory/host_buffer.cpp
@@ -5,6 +5,8 @@
 
 #include <utility>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/memory/cuda_memcpy_async.hpp>
 #include <rapidsmpf/memory/host_buffer.hpp>
 #include <rapidsmpf/memory/memory_type.hpp>
@@ -14,7 +16,7 @@ namespace rapidsmpf {
 
 HostBuffer::HostBuffer(
     std::size_t size,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::host_accessible> mr
 )
     : stream_{stream} {
@@ -23,17 +25,16 @@ HostBuffer::HostBuffer(
             mr.allocate(stream_, size, alignof(::cuda::std::max_align_t))
         );
         span_ = std::span<std::byte>{ptr, size};
-        deallocate_fn_ =
-            [mr = std::move(mr), ptr, size](rmm::cuda_stream_view s) mutable {
-                mr.deallocate(s, ptr, size, alignof(::cuda::std::max_align_t));
-            };
+        deallocate_fn_ = [mr = std::move(mr), ptr, size](cuda::stream_ref s) mutable {
+            mr.deallocate(s, ptr, size, alignof(::cuda::std::max_align_t));
+        };
     }
 }
 
 HostBuffer::HostBuffer(
     std::span<std::byte> span,
-    rmm::cuda_stream_view stream,
-    std::function<void(rmm::cuda_stream_view)> deallocate_fn
+    cuda::stream_ref stream,
+    std::function<void(cuda::stream_ref)> deallocate_fn
 )
     : stream_{stream}, span_{span}, deallocate_fn_{std::move(deallocate_fn)} {}
 
@@ -68,7 +69,7 @@ HostBuffer::~HostBuffer() noexcept {
     deallocate_async();
 }
 
-rmm::cuda_stream_view HostBuffer::stream() const noexcept {
+cuda::stream_ref HostBuffer::stream() const noexcept {
     return stream_;
 }
 
@@ -88,23 +89,23 @@ std::byte const* HostBuffer::data() const noexcept {
     return span_.data();
 }
 
-void HostBuffer::set_stream(rmm::cuda_stream_view new_stream) {
+void HostBuffer::set_stream(cuda::stream_ref new_stream) {
     stream_ = new_stream;
 }
 
 std::vector<std::uint8_t> HostBuffer::copy_to_uint8_vector() const {
     std::vector<std::uint8_t> ret(size());
     if (!empty()) {
-        stream_.synchronize();
+        stream_.sync();
         RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(ret.data(), data(), size(), stream_));
-        stream_.synchronize();
+        stream_.sync();
     }
     return ret;
 };
 
 HostBuffer HostBuffer::from_uint8_vector(
     std::vector<std::uint8_t> const& data,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rmm::host_async_resource_ref mr
 ) {
     HostBuffer ret(data.size(), stream, mr);
@@ -112,13 +113,13 @@ HostBuffer HostBuffer::from_uint8_vector(
         RAPIDSMPF_CUDA_TRY(
             cuda_memcpy_async(ret.data(), data.data(), data.size(), stream)
         );
-        stream.synchronize();  // need to ensure that data outlives the async copy
+        stream.sync();  // need to ensure that data outlives the async copy
     }
     return ret;
 }
 
 HostBuffer HostBuffer::from_owned_vector(
-    std::vector<std::uint8_t>&& data, rmm::cuda_stream_view stream
+    std::vector<std::uint8_t>&& data, cuda::stream_ref stream
 ) {
     // Wrap in shared_ptr so the lambda is copyable (required by std::function).
     auto shared_vec = std::make_shared<std::vector<std::uint8_t>>(std::move(data));
@@ -126,16 +127,14 @@ HostBuffer HostBuffer::from_owned_vector(
     std::span<std::byte> span{ptr, shared_vec->size()};
 
     return HostBuffer{
-        span,
-        stream,
-        [shared_vec_ = std::move(shared_vec)](rmm::cuda_stream_view) mutable {
+        span, stream, [shared_vec_ = std::move(shared_vec)](cuda::stream_ref) mutable {
             shared_vec_.reset();
         }
     };
 }
 
 HostBuffer HostBuffer::from_rmm_device_buffer(
-    std::unique_ptr<rmm::device_buffer> pinned_host_buffer, rmm::cuda_stream_view stream
+    std::unique_ptr<rmm::device_buffer> pinned_host_buffer, cuda::stream_ref stream
 ) {
     RAPIDSMPF_EXPECTS(
         pinned_host_buffer != nullptr,
@@ -158,7 +157,7 @@ HostBuffer HostBuffer::from_rmm_device_buffer(
     return HostBuffer{
         std::move(span),
         stream,
-        [shared_db_ = std::move(shared_db)](rmm::cuda_stream_view) mutable {
+        [shared_db_ = std::move(shared_db)](cuda::stream_ref) mutable {
             shared_db_.reset();
         }
     };

--- a/cpp/src/memory/host_memory_resource.cpp
+++ b/cpp/src/memory/host_memory_resource.cpp
@@ -9,6 +9,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/memory/host_memory_resource.hpp>
 
 namespace rapidsmpf {
@@ -41,7 +43,7 @@ void enable_hugepage_for_region(void* ptr, std::size_t size) {
 }  // namespace
 
 void* HostMemoryResource::allocate(
-    rmm::cuda_stream_view, std::size_t size, std::size_t alignment
+    cuda::stream_ref, std::size_t size, std::size_t alignment
 ) {
     void* ret = ::operator new(size, std::align_val_t{alignment});
     enable_hugepage_for_region(ret, size);
@@ -49,9 +51,9 @@ void* HostMemoryResource::allocate(
 }
 
 void HostMemoryResource::deallocate(
-    rmm::cuda_stream_view stream, void* ptr, std::size_t, std::size_t alignment
+    cuda::stream_ref stream, void* ptr, std::size_t, std::size_t alignment
 ) noexcept {
-    stream.synchronize();
+    stream.sync();
     ::operator delete(ptr, std::align_val_t{alignment});
 }
 }  // namespace rapidsmpf

--- a/cpp/src/shuffler/chunk.cpp
+++ b/cpp/src/shuffler/chunk.cpp
@@ -98,8 +98,7 @@ Chunk Chunk::deserialize(
             br != nullptr, "Deserializing non-control Chunk requires a BufferResource"
         );
         data = br->make_buffer(
-            cuda::stream_ref{br->stream_pool()->get_stream().value()},
-            br->reserve_or_fail(data_size, MEMORY_TYPES)
+            br->stream_pool()->get_stream(), br->reserve_or_fail(data_size, MEMORY_TYPES)
         );
         if (rapidsmpf::contains(SPILL_TARGET_MEMORY_TYPES, data->mem_type())) {
             br->statistics()->add_bytes_stat("recv-into-host-memory", data_size);

--- a/cpp/src/shuffler/chunk.cpp
+++ b/cpp/src/shuffler/chunk.cpp
@@ -6,6 +6,8 @@
 #include <cstring>
 #include <sstream>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/memory/buffer.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
@@ -96,7 +98,8 @@ Chunk Chunk::deserialize(
             br != nullptr, "Deserializing non-control Chunk requires a BufferResource"
         );
         data = br->make_buffer(
-            br->stream_pool()->get_stream(), br->reserve_or_fail(data_size, MEMORY_TYPES)
+            cuda::stream_ref{br->stream_pool()->get_stream().value()},
+            br->reserve_or_fail(data_size, MEMORY_TYPES)
         );
         if (rapidsmpf::contains(SPILL_TARGET_MEMORY_TYPES, data->mem_type())) {
             br->statistics()->add_bytes_stat("recv-into-host-memory", data_size);

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/communicator/communicator.hpp>
 #include <rapidsmpf/communicator/metadata_payload_exchange/core.hpp>
 #include <rapidsmpf/communicator/metadata_payload_exchange/tag.hpp>
@@ -232,7 +234,7 @@ Shuffler::Shuffler(
                     op_id,
                     [this](std::size_t size) -> std::unique_ptr<Buffer> {
                         return br_->make_buffer(
-                            br_->stream_pool()->get_stream(),
+                            cuda::stream_ref{br_->stream_pool()->get_stream().value()},
                             br_->reserve_or_fail(size, MEMORY_TYPES)
                         );
                     },

--- a/cpp/src/shuffler/shuffler.cpp
+++ b/cpp/src/shuffler/shuffler.cpp
@@ -234,7 +234,7 @@ Shuffler::Shuffler(
                     op_id,
                     [this](std::size_t size) -> std::unique_ptr<Buffer> {
                         return br_->make_buffer(
-                            cuda::stream_ref{br_->stream_pool()->get_stream().value()},
+                            br_->stream_pool()->get_stream(),
                             br_->reserve_or_fail(size, MEMORY_TYPES)
                         );
                     },

--- a/cpp/src/stream_ordered_timing.cpp
+++ b/cpp/src/stream_ordered_timing.cpp
@@ -9,6 +9,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/stream_ordered_timing.hpp>
 #include <rapidsmpf/utils/misc.hpp>
@@ -98,7 +100,7 @@ void timing_stop_cb(void* data) {
 }  // namespace
 
 StreamOrderedTiming::StreamOrderedTiming(
-    rmm::cuda_stream_view stream, std::shared_ptr<Statistics> statistics
+    cuda::stream_ref stream, std::shared_ptr<Statistics> statistics
 )
     : stream_{stream}, statistics_{std::move(statistics)} {
     RAPIDSMPF_EXPECTS(statistics_ != nullptr, "the statistics pointer cannot be NULL");
@@ -115,7 +117,7 @@ StreamOrderedTiming::StreamOrderedTiming(
     lock.unlock();
 
     RAPIDSMPF_CUDA_TRY(
-        cudaLaunchHostFunc(stream_, timing_start_cb, reinterpret_cast<void*>(uid_))
+        cudaLaunchHostFunc(stream_.get(), timing_start_cb, reinterpret_cast<void*>(uid_))
     );
 }
 
@@ -133,7 +135,7 @@ void StreamOrderedTiming::stop_and_record(
     }
 
     RAPIDSMPF_CUDA_TRY(
-        cudaLaunchHostFunc(stream_, timing_stop_cb, reinterpret_cast<void*>(uid_))
+        cudaLaunchHostFunc(stream_.get(), timing_stop_cb, reinterpret_cast<void*>(uid_))
     );
 }
 

--- a/cpp/src/streaming/coll/shuffler.cpp
+++ b/cpp/src/streaming/coll/shuffler.cpp
@@ -5,8 +5,6 @@
 
 #include <memory>
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <rapidsmpf/cuda_event.hpp>
 #include <rapidsmpf/cuda_stream.hpp>
 #include <rapidsmpf/error.hpp>

--- a/cpp/tests/streaming/base_streaming_fixture.hpp
+++ b/cpp/tests/streaming/base_streaming_fixture.hpp
@@ -43,7 +43,7 @@ class BaseStreamingFixture : public ::testing::Test {
         env_vars["num_streaming_threads"] = std::to_string(num_streaming_threads);
         rapidsmpf::config::Options options(std::move(env_vars));
 
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
         br = rapidsmpf::BufferResource::create(
             mr_cuda, rapidsmpf::PinnedMemoryDisabled, std::move(memory_limits)
         );
@@ -52,7 +52,7 @@ class BaseStreamingFixture : public ::testing::Test {
         );
     }
 
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     rmm::mr::cuda_memory_resource mr_cuda;
     std::shared_ptr<rapidsmpf::BufferResource> br;
     std::shared_ptr<rapidsmpf::streaming::Context> ctx;

--- a/cpp/tests/streaming/base_streaming_fixture.hpp
+++ b/cpp/tests/streaming/base_streaming_fixture.hpp
@@ -7,7 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/communicator/single.hpp>
@@ -42,7 +43,7 @@ class BaseStreamingFixture : public ::testing::Test {
         env_vars["num_streaming_threads"] = std::to_string(num_streaming_threads);
         rapidsmpf::config::Options options(std::move(env_vars));
 
-        stream = rmm::cuda_stream_view{};
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
         br = rapidsmpf::BufferResource::create(
             mr_cuda, rapidsmpf::PinnedMemoryDisabled, std::move(memory_limits)
         );
@@ -51,7 +52,7 @@ class BaseStreamingFixture : public ::testing::Test {
         );
     }
 
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     rmm::mr::cuda_memory_resource mr_cuda;
     std::shared_ptr<rapidsmpf::BufferResource> br;
     std::shared_ptr<rapidsmpf::streaming::Context> ctx;

--- a/cpp/tests/streaming/test_allgather.cpp
+++ b/cpp/tests/streaming/test_allgather.cpp
@@ -10,6 +10,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <coro/latch.hpp>
 
 #include <rapidsmpf/communicator/single.hpp>
@@ -73,10 +75,10 @@ TEST_P(StreamingAllGather, basic) {
 
         auto br = ctx->br();
         auto buf = br->make_buffer(
-            br->stream_pool()->get_stream(),
+            cuda::stream_ref{br->stream_pool()->get_stream().value()},
             br->reserve_or_fail(data.size() * sizeof(int), mem_type)
         );
-        buf->write_access([&](std::byte* buf_data, rmm::cuda_stream_view stream) {
+        buf->write_access([&](std::byte* buf_data, cuda::stream_ref stream) {
             RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(
                 buf_data, data.data(), data.size() * sizeof(int), stream
             ));
@@ -110,7 +112,7 @@ TEST_P(StreamingAllGather, basic) {
                 result.data() + offset, pd.data->data(), pd.data->size, pd.data->stream()
             ));
             offset += msize;
-            pd.data->stream().synchronize();
+            pd.data->stream().sync();
         }
     };
 
@@ -146,10 +148,10 @@ TEST_P(StreamingAllGather, streaming_actor) {
 
         auto br = ctx->br();
         auto buf = br->make_buffer(
-            br->stream_pool()->get_stream(),
+            cuda::stream_ref{br->stream_pool()->get_stream().value()},
             br->reserve_or_fail(data.size() * sizeof(int), mem_type)
         );
-        buf->write_access([&](std::byte* buf_data, rmm::cuda_stream_view stream) {
+        buf->write_access([&](std::byte* buf_data, cuda::stream_ref stream) {
             RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(
                 buf_data, data.data(), data.size() * sizeof(int), stream
             ));
@@ -192,7 +194,7 @@ TEST_P(StreamingAllGather, streaming_actor) {
             actual.data() + offset, pd.data->data(), pd.data->size, pd.stream()
         ));
         offset += msize;
-        pd.stream().synchronize();
+        pd.stream().sync();
     }
     auto expected = iota_vector<int>(size * size * n_inserts);
     EXPECT_EQ(expected, actual);

--- a/cpp/tests/streaming/test_allgather.cpp
+++ b/cpp/tests/streaming/test_allgather.cpp
@@ -75,7 +75,7 @@ TEST_P(StreamingAllGather, basic) {
 
         auto br = ctx->br();
         auto buf = br->make_buffer(
-            cuda::stream_ref{br->stream_pool()->get_stream().value()},
+            br->stream_pool()->get_stream(),
             br->reserve_or_fail(data.size() * sizeof(int), mem_type)
         );
         buf->write_access([&](std::byte* buf_data, cuda::stream_ref stream) {
@@ -148,7 +148,7 @@ TEST_P(StreamingAllGather, streaming_actor) {
 
         auto br = ctx->br();
         auto buf = br->make_buffer(
-            cuda::stream_ref{br->stream_pool()->get_stream().value()},
+            br->stream_pool()->get_stream(),
             br->reserve_or_fail(data.size() * sizeof(int), mem_type)
         );
         buf->write_access([&](std::byte* buf_data, cuda::stream_ref stream) {

--- a/cpp/tests/streaming/test_allreduce.cpp
+++ b/cpp/tests/streaming/test_allreduce.cpp
@@ -10,6 +10,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <rapidsmpf/coll/allreduce.hpp>
 #include <rapidsmpf/memory/buffer.hpp>
 #include <rapidsmpf/memory/cuda_memcpy_async.hpp>
@@ -31,10 +33,10 @@ std::unique_ptr<Buffer> make_buffer(
     MemoryType mem_type
 ) {
     auto const nbytes = count * sizeof(T);
-    auto stream = br->stream_pool()->get_stream();
+    auto stream = cuda::stream_ref{br->stream_pool()->get_stream().value()};
     auto reservation = br->reserve_or_fail(nbytes, mem_type);
     auto buffer = br->make_buffer(stream, std::move(reservation));
-    buffer->write_access([&](std::byte* buf_data, rmm::cuda_stream_view s) {
+    buffer->write_access([&](std::byte* buf_data, cuda::stream_ref s) {
         RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(buf_data, data, nbytes, s));
     });
     buffer->latest_write_event().host_wait();
@@ -51,7 +53,7 @@ std::vector<T> unpack_to_host(Buffer& buffer) {
     std::vector<T> out(count);
     auto* raw_ptr = buffer.exclusive_data_access();
     RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(out.data(), raw_ptr, nbytes, buffer.stream()));
-    buffer.stream().synchronize();
+    buffer.stream().sync();
     buffer.unlock();
     return out;
 }

--- a/cpp/tests/streaming/test_allreduce.cpp
+++ b/cpp/tests/streaming/test_allreduce.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<Buffer> make_buffer(
     MemoryType mem_type
 ) {
     auto const nbytes = count * sizeof(T);
-    auto stream = cuda::stream_ref{br->stream_pool()->get_stream().value()};
+    auto stream = br->stream_pool()->get_stream();
     auto reservation = br->reserve_or_fail(nbytes, mem_type);
     auto buffer = br->make_buffer(stream, std::move(reservation));
     buffer->write_access([&](std::byte* buf_data, cuda::stream_ref s) {

--- a/cpp/tests/streaming/test_fanout.cpp
+++ b/cpp/tests/streaming/test_fanout.cpp
@@ -9,6 +9,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <coro/coro.hpp>
 
 #include <rapidsmpf/memory/buffer.hpp>
@@ -57,7 +59,8 @@ std::vector<Message> make_buffer_inputs(int n, rapidsmpf::BufferResource& br) {
     inputs.reserve(n);
 
     Message::CopyCallback copy_cb = [&](Message const& msg, MemoryReservation& res) {
-        rmm::cuda_stream_view stream = br.stream_pool()->get_stream();
+        cuda::stream_ref stream =
+            cuda::stream_ref{br.stream_pool()->get_stream().value()};
         auto const cd = msg.content_description();
         auto buf_cpy = br.make_buffer(cd.content_size(), stream, res);
         // cd needs to be updated to reflect the new buffer
@@ -74,7 +77,8 @@ std::vector<Message> make_buffer_inputs(int n, rapidsmpf::BufferResource& br) {
     for (int i = 0; i < n; ++i) {
         std::vector<int> values(1024, 0);
         std::iota(values.begin(), values.end(), i);
-        rmm::cuda_stream_view stream = br.stream_pool()->get_stream();
+        cuda::stream_ref stream =
+            cuda::stream_ref{br.stream_pool()->get_stream().value()};
         // allocate outside of buffer resource
         auto buffer = br.move(
             std::make_unique<rmm::device_buffer>(
@@ -84,7 +88,7 @@ std::vector<Message> make_buffer_inputs(int n, rapidsmpf::BufferResource& br) {
         );
         // If the copy to the device buffer is actually stream ordered, the host values
         // might go out of scope before the copy completes.
-        stream.synchronize();
+        stream.sync();
         ContentDescription cd{
             std::ranges::single_view{std::pair{MemoryType::DEVICE, 1024 * sizeof(int)}},
             ContentDescription::Spillable::YES
@@ -227,7 +231,7 @@ TEST_P(StreamingFanout, SinkPerChannel_Buffer) {
             EXPECT_EQ(1024 * sizeof(int), buf.size);
 
             std::vector<int> recv(1024);
-            buf.stream().synchronize();
+            buf.stream().sync();
             RAPIDSMPF_CUDA_TRY(
                 cudaMemcpy(recv.data(), buf.data(), 1024 * sizeof(int), cudaMemcpyDefault)
             );

--- a/cpp/tests/streaming/test_fanout.cpp
+++ b/cpp/tests/streaming/test_fanout.cpp
@@ -59,8 +59,7 @@ std::vector<Message> make_buffer_inputs(int n, rapidsmpf::BufferResource& br) {
     inputs.reserve(n);
 
     Message::CopyCallback copy_cb = [&](Message const& msg, MemoryReservation& res) {
-        cuda::stream_ref stream =
-            cuda::stream_ref{br.stream_pool()->get_stream().value()};
+        auto stream = br.stream_pool()->get_stream();
         auto const cd = msg.content_description();
         auto buf_cpy = br.make_buffer(cd.content_size(), stream, res);
         // cd needs to be updated to reflect the new buffer
@@ -77,8 +76,7 @@ std::vector<Message> make_buffer_inputs(int n, rapidsmpf::BufferResource& br) {
     for (int i = 0; i < n; ++i) {
         std::vector<int> values(1024, 0);
         std::iota(values.begin(), values.end(), i);
-        cuda::stream_ref stream =
-            cuda::stream_ref{br.stream_pool()->get_stream().value()};
+        cuda::stream_ref stream = br.stream_pool()->get_stream();
         // allocate outside of buffer resource
         auto buffer = br.move(
             std::make_unique<rmm::device_buffer>(

--- a/cpp/tests/streaming/test_message.cpp
+++ b/cpp/tests/streaming/test_message.cpp
@@ -6,6 +6,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -19,11 +21,11 @@ class StreamingMessage : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = rmm::cuda_stream_view{};
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
     }
 
     std::shared_ptr<BufferResource> br;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
 };
 
 TEST_F(StreamingMessage, ConstructAndGetInt) {

--- a/cpp/tests/streaming/test_message.cpp
+++ b/cpp/tests/streaming/test_message.cpp
@@ -21,11 +21,11 @@ class StreamingMessage : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
     }
 
     std::shared_ptr<BufferResource> br;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
 };
 
 TEST_F(StreamingMessage, ConstructAndGetInt) {

--- a/cpp/tests/streaming/test_sparse_alltoall.cpp
+++ b/cpp/tests/streaming/test_sparse_alltoall.cpp
@@ -12,6 +12,8 @@
 #include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <coro/latch.hpp>
 
 #include <rapidsmpf/memory/buffer.hpp>
@@ -46,12 +48,12 @@ PackedData make_payload(
     MemoryType mem_type,
     std::shared_ptr<BufferResource> const& br
 ) {
-    auto stream = br->stream_pool()->get_stream();
+    auto stream = cuda::stream_ref{br->stream_pool()->get_stream().value()};
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
     std::memcpy(metadata->data(), &metadata_value, sizeof(int));
 
     auto data = br->make_buffer(stream, br->reserve_or_fail(sizeof(int), mem_type));
-    data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
+    data->write_access([&](std::byte* ptr, cuda::stream_ref op_stream) {
         RAPIDSMPF_CUDA_TRY(
             rapidsmpf::cuda_memcpy_async(
                 ptr, &payload_value, sizeof(payload_value), op_stream
@@ -74,13 +76,10 @@ int decode_payload(PackedData const& packed_data) {
     int result = -1;
     RAPIDSMPF_CUDA_TRY(
         rapidsmpf::cuda_memcpy_async(
-            &result,
-            packed_data.data->data(),
-            sizeof(result),
-            packed_data.stream().value()
+            &result, packed_data.data->data(), sizeof(result), packed_data.stream().get()
         )
     );
-    packed_data.stream().synchronize();
+    packed_data.stream().sync();
     return result;
 }
 

--- a/cpp/tests/streaming/test_sparse_alltoall.cpp
+++ b/cpp/tests/streaming/test_sparse_alltoall.cpp
@@ -48,7 +48,7 @@ PackedData make_payload(
     MemoryType mem_type,
     std::shared_ptr<BufferResource> const& br
 ) {
-    auto stream = cuda::stream_ref{br->stream_pool()->get_stream().value()};
+    auto stream = br->stream_pool()->get_stream();
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
     std::memcpy(metadata->data(), &metadata_value, sizeof(int));
 

--- a/cpp/tests/test_allgather.cpp
+++ b/cpp/tests/test_allgather.cpp
@@ -10,7 +10,8 @@
 
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/coll/allgather.hpp>
@@ -32,7 +33,7 @@ extern Environment* GlobalEnvironment;
 class BaseAllGatherTest : public ::testing::Test {
   protected:
     void SetUp() override {
-        stream = rmm::cuda_stream_view{};
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
         br = rapidsmpf::BufferResource::create(rmm::mr::cuda_memory_resource{});
     }
 
@@ -40,7 +41,7 @@ class BaseAllGatherTest : public ::testing::Test {
         br = nullptr;
     }
 
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 
@@ -396,7 +397,7 @@ TEST_F(BaseAllGatherTest, opid_reuse) {
 // (the largest chunk, since none covers 100 alone). The second must search for a chunk
 // >= 10 and pick the 20-byte chunk, totalling 110.
 TEST(PostBox, spill_uses_remaining_amount) {
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
     auto mr = std::make_unique<rmm::mr::cuda_memory_resource>();
     auto br = rapidsmpf::BufferResource::create(*mr);
 

--- a/cpp/tests/test_allgather.cpp
+++ b/cpp/tests/test_allgather.cpp
@@ -33,7 +33,7 @@ extern Environment* GlobalEnvironment;
 class BaseAllGatherTest : public ::testing::Test {
   protected:
     void SetUp() override {
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
         br = rapidsmpf::BufferResource::create(rmm::mr::cuda_memory_resource{});
     }
 
@@ -41,7 +41,7 @@ class BaseAllGatherTest : public ::testing::Test {
         br = nullptr;
     }
 
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 
@@ -397,7 +397,7 @@ TEST_F(BaseAllGatherTest, opid_reuse) {
 // (the largest chunk, since none covers 100 alone). The second must search for a chunk
 // >= 10 and pick the 20-byte chunk, totalling 110.
 TEST(PostBox, spill_uses_remaining_amount) {
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
     auto mr = std::make_unique<rmm::mr::cuda_memory_resource>();
     auto br = rapidsmpf::BufferResource::create(*mr);
 

--- a/cpp/tests/test_allreduce.cu
+++ b/cpp/tests/test_allreduce.cu
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,8 +18,8 @@
 #include <thrust/functional.h>
 
 #include <cuda/std/functional>
+#include <cuda/stream>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/coll/allreduce.hpp>
@@ -152,7 +152,7 @@ std::unique_ptr<rapidsmpf::Buffer> make_buffer(
     rapidsmpf::BufferResource* br, T const* data, std::size_t count, MemoryType mem_type
 ) {
     auto const nbytes = count * sizeof(T);
-    auto stream = br->stream_pool()->get_stream();
+    auto stream = cuda::stream_ref{br->stream_pool()->get_stream().value()};
     auto reservation = br->reserve_or_fail(nbytes, mem_type);
     auto buffer = br->make_buffer(stream, std::move(reservation));
 
@@ -163,7 +163,7 @@ std::unique_ptr<rapidsmpf::Buffer> make_buffer(
 
     auto* raw_ptr = buffer->exclusive_data_access();
     RAPIDSMPF_CUDA_TRY(rapidsmpf::cuda_memcpy_async(raw_ptr, data, nbytes, stream));
-    stream.synchronize();
+    stream.sync();
     buffer->unlock();
 
     return buffer;
@@ -185,12 +185,12 @@ std::vector<T> unpack_to_host(rapidsmpf::Buffer& buffer) {
     std::vector<T> out(count);
     // Buffer is only guaranteed to be stream ordered on stream, not fully ready, so sync
     // first.
-    buffer.stream().synchronize();
+    buffer.stream().sync();
     auto* raw_ptr = buf->exclusive_data_access();
     RAPIDSMPF_CUDA_TRY(
         rapidsmpf::cuda_memcpy_async(out.data(), raw_ptr, nbytes, buf->stream())
     );
-    buf->stream().synchronize();
+    buf->stream().sync();
     buf->unlock();
 
     return out;

--- a/cpp/tests/test_allreduce.cu
+++ b/cpp/tests/test_allreduce.cu
@@ -152,7 +152,7 @@ std::unique_ptr<rapidsmpf::Buffer> make_buffer(
     rapidsmpf::BufferResource* br, T const* data, std::size_t count, MemoryType mem_type
 ) {
     auto const nbytes = count * sizeof(T);
-    auto stream = cuda::stream_ref{br->stream_pool()->get_stream().value()};
+    cuda::stream_ref stream = br->stream_pool()->get_stream();
     auto reservation = br->reserve_or_fail(nbytes, mem_type);
     auto buffer = br->make_buffer(stream, std::move(reservation));
 

--- a/cpp/tests/test_buffer.cpp
+++ b/cpp/tests/test_buffer.cpp
@@ -91,8 +91,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
     MemoryType mem_type = GetParam();
-    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
-    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    cuda::stream_ref stream1 = stream_pool->get_stream();
+    cuda::stream_ref stream2 = stream_pool->get_stream();
     ASSERT_NE(stream1.get(), stream2.get());
 
     auto rmm_buffer = std::make_unique<rmm::device_buffer>(
@@ -141,8 +141,8 @@ TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
 
 TEST_P(BufferRebindStreamTest, RebindStreamSynchronizesCorrectly) {
     MemoryType mem_type = GetParam();
-    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
-    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    cuda::stream_ref stream1 = stream_pool->get_stream();
+    cuda::stream_ref stream2 = stream_pool->get_stream();
     ASSERT_NE(stream1.get(), stream2.get());
 
     constexpr std::size_t test_size = 4_MiB;
@@ -179,8 +179,8 @@ TEST_P(BufferRebindStreamTest, RebindStreamSynchronizesCorrectly) {
 
 TEST_P(BufferRebindStreamTest, MultipleRebinds) {
     MemoryType mem_type = GetParam();
-    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
-    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    cuda::stream_ref stream1 = stream_pool->get_stream();
+    cuda::stream_ref stream2 = stream_pool->get_stream();
     ASSERT_NE(stream1.get(), stream2.get());
 
     constexpr std::size_t test_size = 2_MiB;
@@ -220,8 +220,8 @@ TEST_P(BufferRebindStreamTest, MultipleRebinds) {
 
 TEST_P(BufferRebindStreamTest, ThrowsWhenLocked) {
     MemoryType mem_type = GetParam();
-    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
-    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    cuda::stream_ref stream1 = stream_pool->get_stream();
+    cuda::stream_ref stream2 = stream_pool->get_stream();
     ASSERT_NE(stream1.get(), stream2.get());
 
     constexpr std::size_t test_size = 1_MiB;

--- a/cpp/tests/test_buffer.cpp
+++ b/cpp/tests/test_buffer.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <cuda/memory>
+#include <cuda/stream>
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_pool.hpp>
@@ -32,10 +33,10 @@ namespace {
 // unlike MemcpyAsync, MemsetAsync does not transparently handle host ptrs on all
 // architectures.
 void checked_memset(
-    void* ptr, std::size_t size, std::uint8_t value, rmm::cuda_stream_view stream
+    void* ptr, std::size_t size, std::uint8_t value, cuda::stream_ref stream
 ) {
     if (cuda::is_device_accessible(ptr, rmm::get_current_cuda_device().value())) {
-        RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(ptr, value, size, stream));
+        RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(ptr, value, size, stream.get()));
     } else {
         std::memset(ptr, value, size);
     }
@@ -90,25 +91,25 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
     MemoryType mem_type = GetParam();
-    auto stream1 = stream_pool->get_stream();
-    auto stream2 = stream_pool->get_stream();
-    ASSERT_NE(stream1.value(), stream2.value());
+    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
+    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    ASSERT_NE(stream1.get(), stream2.get());
 
     auto rmm_buffer = std::make_unique<rmm::device_buffer>(
         random_data.data(), buffer_size, stream1, br->device_mr()
     );
-    stream1.synchronize();
+    stream1.sync();
 
     auto [reserve1, overbooking1] =
         br->reserve(mem_type, buffer_size, AllowOverbooking::YES);
     auto buffer1 = br->make_buffer(buffer_size, stream1, reserve1);
     EXPECT_EQ(buffer1->mem_type(), mem_type);
-    EXPECT_EQ(buffer1->stream().value(), stream1.value());
+    EXPECT_EQ(buffer1->stream().get(), stream1.get());
 
     std::size_t num_chunks = buffer_size / chunk_size;
     for (std::size_t i = 0; i < num_chunks; ++i) {
         std::size_t offset = i * chunk_size;
-        buffer1->write_access([&](std::byte* dst, rmm::cuda_stream_view stream) {
+        buffer1->write_access([&](std::byte* dst, cuda::stream_ref stream) {
             RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(
                 dst + offset,
                 static_cast<std::byte*>(rmm_buffer->data()) + offset,
@@ -122,10 +123,10 @@ TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
         br->reserve(mem_type, buffer_size, AllowOverbooking::YES);
     auto buffer2 = br->make_buffer(buffer_size, stream2, reserve2);
     EXPECT_EQ(buffer2->mem_type(), mem_type);
-    EXPECT_EQ(buffer2->stream().value(), stream2.value());
+    EXPECT_EQ(buffer2->stream().get(), stream2.get());
 
     buffer1->rebind_stream(stream2);
-    EXPECT_EQ(buffer1->stream().value(), stream2.value());
+    EXPECT_EQ(buffer1->stream().get(), stream2.get());
 
     buffer_copy(br->statistics(), *buffer2, *buffer1, buffer_size);
 
@@ -133,16 +134,16 @@ TEST_P(BufferRebindStreamTest, RebindStreamAndCopy) {
     RAPIDSMPF_CUDA_TRY(
         cuda_memcpy_async(result.data(), buffer2->data(), buffer_size, stream2)
     );
-    stream2.synchronize();
+    stream2.sync();
 
     EXPECT_EQ(result, random_data);
 }
 
 TEST_P(BufferRebindStreamTest, RebindStreamSynchronizesCorrectly) {
     MemoryType mem_type = GetParam();
-    auto stream1 = stream_pool->get_stream();
-    auto stream2 = stream_pool->get_stream();
-    ASSERT_NE(stream1.value(), stream2.value());
+    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
+    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    ASSERT_NE(stream1.get(), stream2.get());
 
     constexpr std::size_t test_size = 4_MiB;
 
@@ -151,14 +152,14 @@ TEST_P(BufferRebindStreamTest, RebindStreamSynchronizesCorrectly) {
     auto buffer1 = br->make_buffer(test_size, stream1, reserve1);
     EXPECT_EQ(buffer1->mem_type(), mem_type);
 
-    buffer1->write_access([&](std::byte* ptr, rmm::cuda_stream_view stream) {
+    buffer1->write_access([&](std::byte* ptr, cuda::stream_ref stream) {
         checked_memset(ptr, test_size, 0xAB, stream);
     });
 
     buffer1->rebind_stream(stream2);
-    EXPECT_EQ(buffer1->stream().value(), stream2.value());
+    EXPECT_EQ(buffer1->stream().get(), stream2.get());
 
-    buffer1->write_access([&](std::byte* ptr, rmm::cuda_stream_view stream) {
+    buffer1->write_access([&](std::byte* ptr, cuda::stream_ref stream) {
         checked_memset(ptr, test_size / 2, 0xCD, stream);
     });
 
@@ -166,7 +167,7 @@ TEST_P(BufferRebindStreamTest, RebindStreamSynchronizesCorrectly) {
     RAPIDSMPF_CUDA_TRY(
         cuda_memcpy_async(result.data(), buffer1->data(), test_size, stream2)
     );
-    stream2.synchronize();
+    stream2.sync();
 
     for (std::size_t i = 0; i < test_size / 2; ++i) {
         EXPECT_EQ(result[i], 0xCD) << "Mismatch at index " << i;
@@ -178,28 +179,28 @@ TEST_P(BufferRebindStreamTest, RebindStreamSynchronizesCorrectly) {
 
 TEST_P(BufferRebindStreamTest, MultipleRebinds) {
     MemoryType mem_type = GetParam();
-    auto stream1 = stream_pool->get_stream();
-    auto stream2 = stream_pool->get_stream();
-    ASSERT_NE(stream1.value(), stream2.value());
+    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
+    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    ASSERT_NE(stream1.get(), stream2.get());
 
     constexpr std::size_t test_size = 2_MiB;
     auto [reserve, overbooking] = br->reserve(mem_type, test_size, AllowOverbooking::YES);
     auto buffer = br->make_buffer(test_size, stream1, reserve);
     EXPECT_EQ(buffer->mem_type(), mem_type);
 
-    buffer->write_access([&](std::byte* ptr, rmm::cuda_stream_view stream) {
+    buffer->write_access([&](std::byte* ptr, cuda::stream_ref stream) {
         checked_memset(ptr, test_size, 0x11, stream);
     });
 
     buffer->rebind_stream(stream2);
-    EXPECT_EQ(buffer->stream().value(), stream2.value());
-    buffer->write_access([&](std::byte* ptr, rmm::cuda_stream_view stream) {
+    EXPECT_EQ(buffer->stream().get(), stream2.get());
+    buffer->write_access([&](std::byte* ptr, cuda::stream_ref stream) {
         checked_memset(ptr, test_size / 2, 0x22, stream);
     });
 
     buffer->rebind_stream(stream1);
-    EXPECT_EQ(buffer->stream().value(), stream1.value());
-    buffer->write_access([&](std::byte* ptr, rmm::cuda_stream_view stream) {
+    EXPECT_EQ(buffer->stream().get(), stream1.get());
+    buffer->write_access([&](std::byte* ptr, cuda::stream_ref stream) {
         checked_memset(ptr + test_size / 2, test_size / 2, 0x33, stream);
     });
 
@@ -207,7 +208,7 @@ TEST_P(BufferRebindStreamTest, MultipleRebinds) {
     RAPIDSMPF_CUDA_TRY(
         cuda_memcpy_async(result.data(), buffer->data(), test_size, stream1)
     );
-    stream1.synchronize();
+    stream1.sync();
 
     for (std::size_t i = 0; i < test_size / 2; ++i) {
         EXPECT_EQ(result[i], 0x22) << "Mismatch at index " << i;
@@ -219,9 +220,9 @@ TEST_P(BufferRebindStreamTest, MultipleRebinds) {
 
 TEST_P(BufferRebindStreamTest, ThrowsWhenLocked) {
     MemoryType mem_type = GetParam();
-    auto stream1 = stream_pool->get_stream();
-    auto stream2 = stream_pool->get_stream();
-    ASSERT_NE(stream1.value(), stream2.value());
+    auto stream1 = cuda::stream_ref{stream_pool->get_stream().value()};
+    auto stream2 = cuda::stream_ref{stream_pool->get_stream().value()};
+    ASSERT_NE(stream1.get(), stream2.get());
 
     constexpr std::size_t test_size = 1_MiB;
     auto [reserve, overbooking] = br->reserve(mem_type, test_size, AllowOverbooking::YES);
@@ -233,8 +234,8 @@ TEST_P(BufferRebindStreamTest, ThrowsWhenLocked) {
     EXPECT_THROW(buffer->rebind_stream(stream2), std::logic_error);
     buffer->unlock();
     EXPECT_NO_THROW(buffer->rebind_stream(stream2));
-    EXPECT_EQ(buffer->stream().value(), stream2.value());
+    EXPECT_EQ(buffer->stream().get(), stream2.get());
 
     EXPECT_NO_THROW(buffer->rebind_stream(stream2));
-    EXPECT_EQ(buffer->stream().value(), stream2.value());
+    EXPECT_EQ(buffer->stream().get(), stream2.get());
 }

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -9,7 +9,8 @@
 
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/limiting_resource_adaptor.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -39,13 +40,13 @@ using namespace rapidsmpf;
 std::unique_ptr<Buffer> zeros(
     BufferResource& br,
     std::size_t size,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     MemoryReservation& reservation
 ) {
     auto ret = br.make_buffer(size, stream, reservation);
     if (size > 0) {
-        ret->write_access([&](std::byte* ptr, rmm::cuda_stream_view s) {
-            RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(ptr, 0, size, s));
+        ret->write_access([&](std::byte* ptr, cuda::stream_ref s) {
+            RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(ptr, 0, size, s.get()));
         });
     }
     return ret;
@@ -181,7 +182,7 @@ TEST(BufferResource, ReservationReleasing) {
 
 TEST(BufferResource, MemoryLimit) {
     rmm::mr::cuda_memory_resource mr_cuda;
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // Create a buffer resource that limits available device memory to 10 KiB.
     auto br = BufferResource::create(
@@ -309,7 +310,7 @@ TEST(BufferResource, AllocStatistics) {
         std::make_shared<rmm::cuda_stream_pool>(1, rmm::cuda_stream::flags::non_blocking),
         stats
     );
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     constexpr std::size_t device_size = 4_KiB;
     constexpr std::size_t pinned_size = 8_KiB;
@@ -336,7 +337,7 @@ TEST(BufferResource, AllocStatistics) {
         br->make_buffer(host_size, stream, r);
     }
 
-    stream.synchronize();
+    stream.sync();
 
     // device: 2 allocations of device_size each.
     auto const dev_bytes = stats->get_stat("alloc-device-bytes");
@@ -430,7 +431,7 @@ class BaseBufferResourceCopyTest : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = rmm::cuda_stream_view{};
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
         // initialize the host pattern
         host_pattern.resize(buffer_size);
@@ -446,7 +447,7 @@ class BaseBufferResourceCopyTest : public ::testing::Test {
             br->reserve(mem_type, size, AllowOverbooking::NO);
         auto buf = br->make_buffer(size, stream, alloc_reserve);
         EXPECT_EQ(buf->mem_type(), mem_type);
-        buf->write_access([&](std::byte* buf_data, rmm::cuda_stream_view stream) {
+        buf->write_access([&](std::byte* buf_data, cuda::stream_ref stream) {
             RAPIDSMPF_CUDA_TRY(
                 cuda_memcpy_async(buf_data, host_pattern.data(), size, stream)
             );
@@ -458,7 +459,7 @@ class BaseBufferResourceCopyTest : public ::testing::Test {
     static constexpr std::size_t buffer_size = 1024;  // 1 KiB
 
     std::shared_ptr<BufferResource> br;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
 
     std::vector<std::uint8_t> host_pattern;  // a predefined pattern for testing
 };
@@ -491,14 +492,14 @@ class BufferResourceCopySliceTest
             std::ptrdiff_t(offset)  // src_offset
         );
         EXPECT_EQ(slice->mem_type(), dest_type);
-        slice->stream().synchronize();
+        slice->stream().sync();
         EXPECT_TRUE(slice->is_latest_write_done());
 
         std::vector<std::uint8_t> verify_data(length);
         RAPIDSMPF_CUDA_TRY(
             cuda_memcpy_async(verify_data.data(), slice->data(), length, stream)
         );
-        stream.synchronize();
+        stream.sync();
         verify_slice(verify_data, offset, length);
         return slice;
     }
@@ -571,14 +572,14 @@ class BufferResourceCopyToTest : public BaseBufferResourceCopyTest,
             std::ptrdiff_t(dest_offset),  // dst_offset
             0  // src_offset
         );
-        dest->stream().synchronize();
+        dest->stream().sync();
         EXPECT_TRUE(dest->is_latest_write_done());
 
         std::vector<std::uint8_t> verify_data_buf(length);
         RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(
             verify_data_buf.data(), dest->data() + dest_offset, length, stream
         ));
-        stream.synchronize();
+        stream.sync();
         verify_slice(verify_data_buf, 0, length);
     }
 
@@ -641,7 +642,7 @@ class BufferResourceDifferentResourcesTest : public ::testing::Test {
   protected:
     void SetUp() override {
         buffer_size = 1_KiB;
-        stream = rmm::cuda_stream_view{};
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
         // Host pattern for initialization and verification
         host_pattern.resize(buffer_size);
@@ -669,12 +670,12 @@ class BufferResourceDifferentResourcesTest : public ::testing::Test {
         EXPECT_EQ(buf1->size, buffer_size);
         EXPECT_EQ(buf1->mem_type(), MemoryType::DEVICE);
 
-        buf1->write_access([&](std::byte* buf1_data, rmm::cuda_stream_view stream) {
+        buf1->write_access([&](std::byte* buf1_data, cuda::stream_ref stream) {
             RAPIDSMPF_CUDA_TRY(
                 cuda_memcpy_async(buf1_data, host_pattern.data(), buffer_size, stream)
             );
         });
-        buf1->stream().synchronize();
+        buf1->stream().sync();
         EXPECT_EQ(device_total(*br1), static_cast<std::int64_t>(buffer_size));
         return buf1;
     }
@@ -687,7 +688,7 @@ class BufferResourceDifferentResourcesTest : public ::testing::Test {
     }
 
     std::size_t buffer_size;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     std::vector<std::uint8_t> host_pattern;
 
     std::shared_ptr<BufferResource> br1;
@@ -716,7 +717,7 @@ TEST_F(BufferResourceDifferentResourcesTest, CopySlice) {
     );
     EXPECT_EQ(buf2->size, slice_length);
     EXPECT_EQ(res2.size(), 0);  // reservation should be consumed
-    buf2->stream().synchronize();
+    buf2->stream().sync();
 
     // Verify memory allocation
     verify_memory_allocation(buffer_size, slice_length);
@@ -729,7 +730,7 @@ TEST_F(BufferResourceDifferentResourcesTest, Copy) {
     auto buf2 = br2->make_buffer(stream, br2->reserve_or_fail(buffer_size, MEMORY_TYPES));
     buffer_copy(br2->statistics(), *buf2, *buf1, buffer_size);
     EXPECT_EQ(buf2->size, buffer_size);
-    buf2->stream().synchronize();
+    buf2->stream().sync();
 
     // Verify memory allocation
     verify_memory_allocation(buffer_size, buffer_size);
@@ -777,11 +778,11 @@ TEST_F(BufferCopyEdgeCases, ZeroSizeIsNoOp) {
 
     // Pre-fill dst with a sentinel pattern
     std::vector<std::uint8_t> sent(N, 0xCD);
-    dst->write_access([&](std::byte* dst_data, rmm::cuda_stream_view stream) {
+    dst->write_access([&](std::byte* dst_data, cuda::stream_ref stream) {
         RAPIDSMPF_CUDA_TRY(cuda_memcpy_async(dst_data, sent.data(), N, stream));
     });
     EXPECT_NO_THROW(buffer_copy(br->statistics(), *dst, *src, 0, 0, 0));
-    dst->stream().synchronize();
+    dst->stream().sync();
 
     // dst unchanged
     for (std::size_t i = 0; i < N; ++i) {
@@ -805,7 +806,7 @@ TEST(BufferResource, DeviceMrKeepsBufferResourceAlive) {
 
     auto br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
     std::weak_ptr<BufferResource> weak_br = br;
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // Construct a device_buffer using the BR memory resource. Internally,
     // `rmm::device_buffer` stores the resource as an owning `cuda::mr::any_resource`,
@@ -832,7 +833,7 @@ TEST(BufferResource, HostMrKeepsBufferResourceAlive) {
 
     auto br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
     std::weak_ptr<BufferResource> weak_br = br;
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // Allocate a HOST buffer. The underlying `HostBuffer` stores the host memory
     // resource as an owning `any_resource`, which copies the `HostMemoryResource`.
@@ -860,7 +861,7 @@ TEST(BufferResource, PinnedMrKeepsBufferResourceAlive) {
         rmm::mr::get_current_device_resource_ref(), PinnedPoolProperties{}
     );
     std::weak_ptr<BufferResource> weak_br = br;
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // Allocate a PINNED_HOST buffer. The underlying `HostBuffer` stores the pinned
     // memory resource as an owning `any_resource`, which copies the
@@ -909,7 +910,9 @@ TEST(BufferResource, DeviceMrIsAddressableByMemoryRecorder) {
 
     {
         auto rec = stats->create_memory_recorder(br->device_mr(), "br-scope");
-        rmm::device_buffer buf{kAllocBytes, rmm::cuda_stream_view{}, br->device_mr()};
+        rmm::device_buffer buf{
+            kAllocBytes, cuda::stream_ref{cudaStream_t{nullptr}}, br->device_mr()
+        };
     }
 
     auto const& records = stats->get_memory_records();

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -182,7 +182,7 @@ TEST(BufferResource, ReservationReleasing) {
 
 TEST(BufferResource, MemoryLimit) {
     rmm::mr::cuda_memory_resource mr_cuda;
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // Create a buffer resource that limits available device memory to 10 KiB.
     auto br = BufferResource::create(
@@ -310,7 +310,7 @@ TEST(BufferResource, AllocStatistics) {
         std::make_shared<rmm::cuda_stream_pool>(1, rmm::cuda_stream::flags::non_blocking),
         stats
     );
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     constexpr std::size_t device_size = 4_KiB;
     constexpr std::size_t pinned_size = 8_KiB;
@@ -431,7 +431,7 @@ class BaseBufferResourceCopyTest : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
 
         // initialize the host pattern
         host_pattern.resize(buffer_size);
@@ -459,7 +459,7 @@ class BaseBufferResourceCopyTest : public ::testing::Test {
     static constexpr std::size_t buffer_size = 1024;  // 1 KiB
 
     std::shared_ptr<BufferResource> br;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
 
     std::vector<std::uint8_t> host_pattern;  // a predefined pattern for testing
 };
@@ -642,7 +642,7 @@ class BufferResourceDifferentResourcesTest : public ::testing::Test {
   protected:
     void SetUp() override {
         buffer_size = 1_KiB;
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
 
         // Host pattern for initialization and verification
         host_pattern.resize(buffer_size);
@@ -688,7 +688,7 @@ class BufferResourceDifferentResourcesTest : public ::testing::Test {
     }
 
     std::size_t buffer_size;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::vector<std::uint8_t> host_pattern;
 
     std::shared_ptr<BufferResource> br1;
@@ -806,7 +806,7 @@ TEST(BufferResource, DeviceMrKeepsBufferResourceAlive) {
 
     auto br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
     std::weak_ptr<BufferResource> weak_br = br;
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // Construct a device_buffer using the BR memory resource. Internally,
     // `rmm::device_buffer` stores the resource as an owning `cuda::mr::any_resource`,
@@ -833,7 +833,7 @@ TEST(BufferResource, HostMrKeepsBufferResourceAlive) {
 
     auto br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
     std::weak_ptr<BufferResource> weak_br = br;
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // Allocate a HOST buffer. The underlying `HostBuffer` stores the host memory
     // resource as an owning `any_resource`, which copies the `HostMemoryResource`.
@@ -861,7 +861,7 @@ TEST(BufferResource, PinnedMrKeepsBufferResourceAlive) {
         rmm::mr::get_current_device_resource_ref(), PinnedPoolProperties{}
     );
     std::weak_ptr<BufferResource> weak_br = br;
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // Allocate a PINNED_HOST buffer. The underlying `HostBuffer` stores the pinned
     // memory resource as an owning `any_resource`, which copies the
@@ -911,7 +911,7 @@ TEST(BufferResource, DeviceMrIsAddressableByMemoryRecorder) {
     {
         auto rec = stats->create_memory_recorder(br->device_mr(), "br-scope");
         rmm::device_buffer buf{
-            kAllocBytes, cuda::stream_ref{cudaStream_t{nullptr}}, br->device_mr()
+            kAllocBytes, cuda::stream_ref{cudaStreamLegacy}, br->device_mr()
         };
     }
 

--- a/cpp/tests/test_chunk.cpp
+++ b/cpp/tests/test_chunk.cpp
@@ -27,11 +27,11 @@ class ChunkTest : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
     }
 
     std::shared_ptr<BufferResource> br;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
 };
 
 TEST_F(ChunkTest, FromFinishedPartition) {
@@ -69,7 +69,7 @@ TEST_P(ChunkFromPackedDataTest, RoundTrip) {
     );
 
     auto data = std::make_unique<rmm::device_buffer>(
-        data_size, cuda::stream_ref{cudaStream_t{nullptr}}
+        data_size, cuda::stream_ref{cudaStreamLegacy}
     );
     if (data_size > 0) {
         std::vector<std::uint8_t> host_data(data_size);

--- a/cpp/tests/test_chunk.cpp
+++ b/cpp/tests/test_chunk.cpp
@@ -9,7 +9,8 @@
 #include <driver_types.h>
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -26,11 +27,11 @@ class ChunkTest : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = rmm::cuda_stream_view{};
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
     }
 
     std::shared_ptr<BufferResource> br;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
 };
 
 TEST_F(ChunkTest, FromFinishedPartition) {
@@ -67,7 +68,9 @@ TEST_P(ChunkFromPackedDataTest, RoundTrip) {
         std::vector<std::uint8_t>{1, 2, 3, 4}
     );
 
-    auto data = std::make_unique<rmm::device_buffer>(data_size, rmm::cuda_stream_view{});
+    auto data = std::make_unique<rmm::device_buffer>(
+        data_size, cuda::stream_ref{cudaStream_t{nullptr}}
+    );
     if (data_size > 0) {
         std::vector<std::uint8_t> host_data(data_size);
         std::iota(host_data.begin(), host_data.end(), std::uint8_t{5});

--- a/cpp/tests/test_communicator.cpp
+++ b/cpp/tests/test_communicator.cpp
@@ -27,14 +27,14 @@ class BaseCommunicatorTest : public ::testing::Test {
         comm = GlobalEnvironment->comm_.get();
         mr = std::make_unique<rmm::mr::cuda_memory_resource>();
         br = rapidsmpf::BufferResource::create(*mr);
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
     }
 
     void TearDown() override {}
 
     rapidsmpf::Communicator* comm;
     std::unique_ptr<rmm::mr::cuda_memory_resource> mr;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 

--- a/cpp/tests/test_communicator.cpp
+++ b/cpp/tests/test_communicator.cpp
@@ -8,6 +8,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -25,14 +27,14 @@ class BaseCommunicatorTest : public ::testing::Test {
         comm = GlobalEnvironment->comm_.get();
         mr = std::make_unique<rmm::mr::cuda_memory_resource>();
         br = rapidsmpf::BufferResource::create(*mr);
-        stream = rmm::cuda_stream_default;
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
     }
 
     void TearDown() override {}
 
     rapidsmpf::Communicator* comm;
     std::unique_ptr<rmm::mr::cuda_memory_resource> mr;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 
@@ -80,19 +82,19 @@ TEST_P(BasicCommunicatorTest, SendToSelf) {
     constexpr int nelems{10};
     auto send_data_h = iota_vector<std::uint8_t>(nelems);
     auto send_buf = br->make_buffer(stream, br->reserve_or_fail(nelems, memory_type()));
-    send_buf->write_access([&](std::byte* send_buf_data, rmm::cuda_stream_view stream) {
+    send_buf->write_access([&](std::byte* send_buf_data, cuda::stream_ref stream) {
         RAPIDSMPF_CUDA_TRY(
             rapidsmpf::cuda_memcpy_async(
                 send_buf_data, send_data_h.data(), nelems, stream
             )
         );
     });
-    send_buf->stream().synchronize();
+    send_buf->stream().sync();
     rapidsmpf::Tag tag{0, 0};
     auto send_fut = comm->send(std::move(send_buf), comm->rank(), tag);
 
     auto recv_buf = br->make_buffer(stream, br->reserve_or_fail(nelems, memory_type()));
-    recv_buf->stream().synchronize();
+    recv_buf->stream().sync();
     auto recv_fut = comm->recv(comm->rank(), tag, std::move(recv_buf));
     std::ignore = comm->wait(std::move(send_fut));
     recv_buf = comm->wait(std::move(recv_fut));
@@ -100,6 +102,6 @@ TEST_P(BasicCommunicatorTest, SendToSelf) {
         rapidsmpf::MemoryType::HOST, nelems, rapidsmpf::AllowOverbooking::YES
     );
     auto recv_data_h = br->move_to_host_buffer(std::move(recv_buf), host_reservation);
-    stream.synchronize();
+    stream.sync();
     EXPECT_EQ(send_data_h, recv_data_h->copy_to_uint8_vector());
 }

--- a/cpp/tests/test_cuda_stream.cpp
+++ b/cpp/tests/test_cuda_stream.cpp
@@ -52,8 +52,13 @@ TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
     // Streams and their views (created with explicit priorities).
     std::array<cudaStream_t, num_slices> upstream_raw{};
     std::array<cudaStream_t, num_slices> downstream_raw{};
-    std::array<cuda::stream_ref, num_slices> upstreams{};
-    std::array<cuda::stream_ref, num_slices> downstreams{};
+    auto const default_stream = cuda::stream_ref{cudaStreamLegacy};
+    std::array<cuda::stream_ref, num_slices> upstreams{
+        default_stream, default_stream, default_stream
+    };
+    std::array<cuda::stream_ref, num_slices> downstreams{
+        default_stream, default_stream, default_stream
+    };
 
     int least_priority = 0;  // numerically larger (often 0) => lower priority
     int greatest_priority = 0;  // numerically smaller (often negative) => higher priority

--- a/cpp/tests/test_cuda_stream.cpp
+++ b/cpp/tests/test_cuda_stream.cpp
@@ -8,8 +8,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <rapidsmpf/cuda_event.hpp>
@@ -51,8 +52,8 @@ TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
     // Streams and their views (created with explicit priorities).
     std::array<cudaStream_t, num_slices> upstream_raw{};
     std::array<cudaStream_t, num_slices> downstream_raw{};
-    std::array<rmm::cuda_stream_view, num_slices> upstreams{};
-    std::array<rmm::cuda_stream_view, num_slices> downstreams{};
+    std::array<cuda::stream_ref, num_slices> upstreams{};
+    std::array<cuda::stream_ref, num_slices> downstreams{};
 
     int least_priority = 0;  // numerically larger (often 0) => lower priority
     int greatest_priority = 0;  // numerically smaller (often negative) => higher priority
@@ -67,8 +68,8 @@ TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
         RAPIDSMPF_CUDA_TRY(cudaStreamCreateWithPriority(
             &downstream_raw[i], cudaStreamNonBlocking, greatest_priority
         ));  // high priority
-        upstreams[i] = rmm::cuda_stream_view{upstream_raw[i]};
-        downstreams[i] = rmm::cuda_stream_view{downstream_raw[i]};
+        upstreams[i] = cuda::stream_ref{upstream_raw[i]};
+        downstreams[i] = cuda::stream_ref{downstream_raw[i]};
     }
 
     // One large device buffer, initialize to 0x00 and sync once for known base state.
@@ -86,7 +87,7 @@ TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
         unsigned char* slice_dev_ptr = dptr + safe_cast<std::size_t>(i) * slice_bytes;
         for (int r = 0; r < upstream_repeats; ++r) {
             RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(
-                slice_dev_ptr, upstream_values[i], slice_bytes, upstreams[i]
+                slice_dev_ptr, upstream_values[i], slice_bytes, upstreams[i].get()
             ));
         }
     }
@@ -98,7 +99,7 @@ TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
     for (int i = 0; i < num_slices; ++i) {
         unsigned char* slice_dev_ptr = dptr + safe_cast<std::size_t>(i) * slice_bytes;
         RAPIDSMPF_CUDA_TRY(cudaMemsetAsync(
-            slice_dev_ptr, downstream_value(i), slice_bytes, downstreams[i]
+            slice_dev_ptr, downstream_value(i), slice_bytes, downstreams[i].get()
         ));
     }
 

--- a/cpp/tests/test_cupti_monitor.cpp
+++ b/cpp/tests/test_cupti_monitor.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,6 +12,8 @@
 #include <cuda_runtime.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <cuda/stream>
 
 #ifdef RAPIDSMPF_HAVE_CUPTI
 #include <rapidsmpf/cupti.hpp>
@@ -45,7 +47,7 @@ class CuptiMonitorTest : public ::testing::Test {
         // Allocate memory using rmm::device_buffer
         for (int i = 0; i < num_operations; ++i) {
             try {
-                buffers.emplace_back(size_bytes, rmm::cuda_stream_default);
+                buffers.emplace_back(size_bytes, cuda::stream_ref{cudaStream_t{nullptr}});
             } catch (const rmm::bad_alloc& e) {
                 FAIL() << "rmm::device_buffer allocation failed: " << e.what();
             }

--- a/cpp/tests/test_cupti_monitor.cpp
+++ b/cpp/tests/test_cupti_monitor.cpp
@@ -47,7 +47,7 @@ class CuptiMonitorTest : public ::testing::Test {
         // Allocate memory using rmm::device_buffer
         for (int i = 0; i < num_operations; ++i) {
             try {
-                buffers.emplace_back(size_bytes, cuda::stream_ref{cudaStream_t{nullptr}});
+                buffers.emplace_back(size_bytes, cuda::stream_ref{cudaStreamLegacy});
             } catch (const rmm::bad_alloc& e) {
                 FAIL() << "rmm::device_buffer allocation failed: " << e.what();
             }

--- a/cpp/tests/test_host_buffer.cpp
+++ b/cpp/tests/test_host_buffer.cpp
@@ -13,7 +13,8 @@
 
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 
@@ -35,7 +36,7 @@ void test_buffer(auto&& buffer, std::vector<std::uint8_t> const& source_data) {
     ASSERT_NE(nullptr, buffer.data());
 
     // Synchronize on stream to ensure copy is complete
-    buffer.stream().synchronize();
+    buffer.stream().sync();
 
     const auto* data = buffer.data();
     // Check the contents using std::equal
@@ -90,7 +91,7 @@ class HostMemoryResource : public ::testing::TestWithParam<std::size_t> {
             rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
     }
 
-    rmm::cuda_stream_view stream{};
+    cuda::stream_ref stream{};
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 
@@ -152,7 +153,7 @@ class PinnedResource : public ::testing::TestWithParam<std::size_t> {
                  ->try_pinned_mr();
     }
 
-    rmm::cuda_stream_view stream{};
+    cuda::stream_ref stream{};
     std::optional<rapidsmpf::PinnedMemoryResource> mr;
 };
 
@@ -246,7 +247,7 @@ TEST(PinnedResource, transient_mr) {
         rmm::mr::get_current_device_resource_ref(), rapidsmpf::PinnedPoolProperties{}
     );
     auto mr = br->try_pinned_mr();
-    rmm::cuda_stream_view stream{};
+    cuda::stream_ref stream{};
 
     auto source_data = random_vector<std::uint8_t>(0, 1024);
 
@@ -274,7 +275,7 @@ namespace {
 /// Creates a pool with \p requested_max_pool_size (e.g. 1 MiB), then uses recursive
 /// doubling of allocation size until allocation fails; returns the last successful size.
 std::size_t discover_pinned_pool_actual_size(
-    rmm::cuda_stream_view stream, std::size_t requested_max_pool_size = 1_MiB
+    cuda::stream_ref stream, std::size_t requested_max_pool_size = 1_MiB
 ) {
     auto br = rapidsmpf::BufferResource::create(
         rmm::mr::get_current_device_resource_ref(),
@@ -323,7 +324,7 @@ std::size_t discover_pinned_pool_actual_size(
 TEST(PinnedResource, max_pool_size_limit) {
     // Ensure CUDA device context is initialized (required for pinned memory pools).
     RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // Create a PinnedMemoryResource with max pool size of 1 MiB; driver may round up.
     if (!rapidsmpf::is_pinned_memory_resources_supported()) {
@@ -346,7 +347,7 @@ TEST(PinnedResource, max_pool_size_limit) {
     // Find the actual pool size (driver may round up, e.g. to 32 MiB) experimentally.
     std::size_t const actual_pool_size = discover_pinned_pool_actual_size(stream, 1_MiB);
     EXPECT_THROW(alloc_and_dealloc(actual_pool_size + 1), cuda::cuda_error);
-    stream.synchronize();
+    stream.sync();
 }
 
 TEST(PinnedResource, from_default_options) {

--- a/cpp/tests/test_host_buffer.cpp
+++ b/cpp/tests/test_host_buffer.cpp
@@ -91,7 +91,7 @@ class HostMemoryResource : public ::testing::TestWithParam<std::size_t> {
             rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
     }
 
-    cuda::stream_ref stream{};
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 
@@ -153,7 +153,7 @@ class PinnedResource : public ::testing::TestWithParam<std::size_t> {
                  ->try_pinned_mr();
     }
 
-    cuda::stream_ref stream{};
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::optional<rapidsmpf::PinnedMemoryResource> mr;
 };
 
@@ -247,7 +247,7 @@ TEST(PinnedResource, transient_mr) {
         rmm::mr::get_current_device_resource_ref(), rapidsmpf::PinnedPoolProperties{}
     );
     auto mr = br->try_pinned_mr();
-    cuda::stream_ref stream{};
+    cuda::stream_ref stream{cudaStreamLegacy};
 
     auto source_data = random_vector<std::uint8_t>(0, 1024);
 
@@ -324,7 +324,7 @@ std::size_t discover_pinned_pool_actual_size(
 TEST(PinnedResource, max_pool_size_limit) {
     // Ensure CUDA device context is initialized (required for pinned memory pools).
     RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // Create a PinnedMemoryResource with max pool size of 1 MiB; driver may round up.
     if (!rapidsmpf::is_pinned_memory_resources_supported()) {

--- a/cpp/tests/test_metadata_payload_exchange.cpp
+++ b/cpp/tests/test_metadata_payload_exchange.cpp
@@ -30,7 +30,7 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
         comm = GlobalEnvironment->comm_.get();
         mr = std::make_unique<rmm::mr::cuda_memory_resource>();
         br = BufferResource::create(*mr);
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
         statistics = Statistics::create();
 
         auto allocate_fn = [this](std::size_t size) {
@@ -102,7 +102,7 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
 
     Communicator* comm;
     std::unique_ptr<rmm::mr::cuda_memory_resource> mr;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::shared_ptr<BufferResource> br;
     std::shared_ptr<Statistics> statistics;
     std::unique_ptr<TagMetadataPayloadExchange> comm_interface;

--- a/cpp/tests/test_metadata_payload_exchange.cpp
+++ b/cpp/tests/test_metadata_payload_exchange.cpp
@@ -6,6 +6,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -28,7 +30,7 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
         comm = GlobalEnvironment->comm_.get();
         mr = std::make_unique<rmm::mr::cuda_memory_resource>();
         br = BufferResource::create(*mr);
-        stream = rmm::cuda_stream_default;
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
         statistics = Statistics::create();
 
         auto allocate_fn = [this](std::size_t size) {
@@ -58,13 +60,13 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
             std::vector<std::uint8_t> test_data(data_size);
             std::iota(test_data.begin(), test_data.end(), 0);
             data_buffer->write_access(
-                [&test_data](std::byte* ptr, rmm::cuda_stream_view stream) {
+                [&test_data](std::byte* ptr, cuda::stream_ref stream) {
                     RAPIDSMPF_CUDA_TRY(
                         cuda_memcpy_async(ptr, test_data.data(), test_data.size(), stream)
                     );
                 }
             );
-            data_buffer->stream().synchronize();
+            data_buffer->stream().sync();
         }
 
         return std::make_unique<MetadataPayloadExchange::Message>(
@@ -91,7 +93,7 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
         RAPIDSMPF_CUDA_TRY(
             cuda_memcpy_async(received_data.data(), buffer->data(), expected_size, stream)
         );
-        stream.synchronize();
+        stream.sync();
 
         for (std::size_t i = 0; i < expected_size; ++i) {
             EXPECT_EQ(received_data[i], static_cast<std::uint8_t>(i % 256));
@@ -100,7 +102,7 @@ class MetadataPayloadExchangeTest : public ::testing::Test {
 
     Communicator* comm;
     std::unique_ptr<rmm::mr::cuda_memory_resource> mr;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     std::shared_ptr<BufferResource> br;
     std::shared_ptr<Statistics> statistics;
     std::unique_ptr<TagMetadataPayloadExchange> comm_interface;

--- a/cpp/tests/test_rmm_resource_adaptor.cpp
+++ b/cpp/tests/test_rmm_resource_adaptor.cpp
@@ -14,8 +14,8 @@
 #include <gtest/gtest.h>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -50,7 +50,7 @@ TEST(ReceivedChunks, spill_skips_control_messages) {
 TEST(ReceivedChunks, spill_respects_amount) {
     auto mr = rmm::mr::get_current_device_resource_ref();
     auto br = rapidsmpf::BufferResource::create(mr);
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     rapidsmpf::shuffler::detail::ReceivedChunks received;
     constexpr std::size_t chunk_size = 100;
@@ -73,7 +73,7 @@ TEST(ReceivedChunks, spill_respects_amount) {
 }
 
 TEST(MetadataMessage, round_trip) {
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
     auto mr = rmm::mr::get_current_device_resource_ref();
     auto br = rapidsmpf::BufferResource::create(mr);
 
@@ -311,7 +311,7 @@ class MemoryLimits_NumPartition
           std::tuple<MemoryLimitsMap, rapidsmpf::shuffler::PartID, std::size_t>> {
   public:
     void SetUp() override {
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
         std::tie(memory_limits, total_num_partitions, total_num_rows) = GetParam();
         br = rapidsmpf::BufferResource::create(
             rmm::mr::get_current_device_resource_ref(),
@@ -335,7 +335,7 @@ class MemoryLimits_NumPartition
     MemoryLimitsMap memory_limits;
     rapidsmpf::shuffler::PartID total_num_partitions;
     std::size_t total_num_rows;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::shared_ptr<rapidsmpf::BufferResource> br;
     std::unique_ptr<rapidsmpf::shuffler::Shuffler> shuffler;
 };
@@ -383,7 +383,7 @@ TEST(Shuffler, payload_statistics) {
         chunks.emplace(
             pid,
             generate_packed_data(
-                n_elements, offset, cuda::stream_ref{cudaStream_t{nullptr}}, *br
+                n_elements, offset, cuda::stream_ref{cudaStreamLegacy}, *br
             )
         );
     }
@@ -426,7 +426,7 @@ class ConcurrentShuffleTest : public ::testing::TestWithParam<
         // these resources will be used by multiple threads to instantiate shufflers
         br =
             rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
     }
 
     void TearDown() override {}
@@ -469,7 +469,7 @@ class ConcurrentShuffleTest : public ::testing::TestWithParam<
     std::size_t num_shufflers;
     rapidsmpf::shuffler::PartID total_num_partitions;
 
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 
@@ -497,7 +497,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(Shuffler, SpillOnInsertAndExtraction) {
     rapidsmpf::shuffler::PartID const total_num_partitions = 2;
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // Control spilling by adjusting the DEVICE memory limit at runtime.
     // `memory_available(DEVICE)` is computed as `limit - current_allocated()`, so a
@@ -592,7 +592,7 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
 }
 
 TEST(Shuffler, SpillOnInsertAccountsForReservations) {
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // A limit large enough that `memory_available(DEVICE)` stays positive throughout,
     // so only the reservation can drive spilling.
@@ -829,7 +829,7 @@ class ExtractEmptyPartitionsTest : public ::testing::Test {
     static constexpr auto wait_timeout = std::chrono::seconds(30);
 
     void SetUp() override {
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
         br =
             rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
 
@@ -880,7 +880,7 @@ class ExtractEmptyPartitionsTest : public ::testing::Test {
         };
     }
 
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
     std::shared_ptr<rapidsmpf::BufferResource> br;
     std::unique_ptr<rapidsmpf::shuffler::Shuffler> shuffler;
 };
@@ -1012,7 +1012,7 @@ TEST(Shuffler, opid_reuse) {
         GTEST_SKIP() << "OpID reuse test requires multiple ranks";
     }
 
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
     auto const total_num_partitions =
         rapidsmpf::safe_cast<rapidsmpf::shuffler::PartID>(comm->nranks());
     constexpr std::size_t total_num_rows = 1000;
@@ -1079,7 +1079,7 @@ TEST(Shuffler, opid_reuse_with_empty_partitions) {
         GTEST_SKIP() << "OpID reuse test requires multiple ranks";
     }
 
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
     constexpr rapidsmpf::shuffler::PartID total_num_partitions = 1;
     constexpr std::size_t total_num_rows = 1000;
     constexpr rapidsmpf::OpID op_id = 0;

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -13,7 +13,8 @@
 
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/per_device_resource.hpp>
 
 #include <rapidsmpf/memory/buffer.hpp>
@@ -49,7 +50,7 @@ TEST(ReceivedChunks, spill_skips_control_messages) {
 TEST(ReceivedChunks, spill_respects_amount) {
     auto mr = rmm::mr::get_current_device_resource_ref();
     auto br = rapidsmpf::BufferResource::create(mr);
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     rapidsmpf::shuffler::detail::ReceivedChunks received;
     constexpr std::size_t chunk_size = 100;
@@ -72,7 +73,7 @@ TEST(ReceivedChunks, spill_respects_amount) {
 }
 
 TEST(MetadataMessage, round_trip) {
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
     auto mr = rmm::mr::get_current_device_resource_ref();
     auto br = rapidsmpf::BufferResource::create(mr);
 
@@ -175,7 +176,7 @@ make_partition_data(
     rapidsmpf::shuffler::PartID total_num_partitions,
     std::size_t total_num_rows,
     rapidsmpf::shuffler::PartID local_pidx,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rapidsmpf::BufferResource& br,
     std::int64_t base = 0
 ) {
@@ -274,7 +275,7 @@ void test_shuffler(
     rapidsmpf::shuffler::Shuffler& shuffler,
     rapidsmpf::shuffler::PartID total_num_partitions,
     std::size_t total_num_rows,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rapidsmpf::BufferResource* br,
     std::int64_t base = 0
 ) {
@@ -310,7 +311,7 @@ class MemoryLimits_NumPartition
           std::tuple<MemoryLimitsMap, rapidsmpf::shuffler::PartID, std::size_t>> {
   public:
     void SetUp() override {
-        stream = rmm::cuda_stream_default;
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
         std::tie(memory_limits, total_num_partitions, total_num_rows) = GetParam();
         br = rapidsmpf::BufferResource::create(
             rmm::mr::get_current_device_resource_ref(),
@@ -334,7 +335,7 @@ class MemoryLimits_NumPartition
     MemoryLimitsMap memory_limits;
     rapidsmpf::shuffler::PartID total_num_partitions;
     std::size_t total_num_rows;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     std::shared_ptr<rapidsmpf::BufferResource> br;
     std::unique_ptr<rapidsmpf::shuffler::Shuffler> shuffler;
 };
@@ -380,7 +381,10 @@ TEST(Shuffler, payload_statistics) {
             static_cast<int>(comm->rank()) * static_cast<int>(total_num_partitions)
             + static_cast<int>(pid);
         chunks.emplace(
-            pid, generate_packed_data(n_elements, offset, rmm::cuda_stream_default, *br)
+            pid,
+            generate_packed_data(
+                n_elements, offset, cuda::stream_ref{cudaStream_t{nullptr}}, *br
+            )
         );
     }
     shuffler.insert(std::move(chunks));
@@ -422,7 +426,7 @@ class ConcurrentShuffleTest : public ::testing::TestWithParam<
         // these resources will be used by multiple threads to instantiate shufflers
         br =
             rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = rmm::cuda_stream_default;
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
     }
 
     void TearDown() override {}
@@ -465,7 +469,7 @@ class ConcurrentShuffleTest : public ::testing::TestWithParam<
     std::size_t num_shufflers;
     rapidsmpf::shuffler::PartID total_num_partitions;
 
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     std::shared_ptr<rapidsmpf::BufferResource> br;
 };
 
@@ -493,7 +497,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(Shuffler, SpillOnInsertAndExtraction) {
     rapidsmpf::shuffler::PartID const total_num_partitions = 2;
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // Control spilling by adjusting the DEVICE memory limit at runtime.
     // `memory_available(DEVICE)` is computed as `limit - current_allocated()`, so a
@@ -588,7 +592,7 @@ TEST(Shuffler, SpillOnInsertAndExtraction) {
 }
 
 TEST(Shuffler, SpillOnInsertAccountsForReservations) {
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // A limit large enough that `memory_available(DEVICE)` stays positive throughout,
     // so only the reservation can drive spilling.
@@ -825,7 +829,7 @@ class ExtractEmptyPartitionsTest : public ::testing::Test {
     static constexpr auto wait_timeout = std::chrono::seconds(30);
 
     void SetUp() override {
-        stream = rmm::cuda_stream_default;
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
         br =
             rapidsmpf::BufferResource::create(rmm::mr::get_current_device_resource_ref());
 
@@ -876,7 +880,7 @@ class ExtractEmptyPartitionsTest : public ::testing::Test {
         };
     }
 
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
     std::shared_ptr<rapidsmpf::BufferResource> br;
     std::unique_ptr<rapidsmpf::shuffler::Shuffler> shuffler;
 };
@@ -972,7 +976,7 @@ TEST(Shuffler, concurrent_wait) {
                     total_num_partitions,
                     total_num_rows,
                     local_pidx,
-                    br->stream_pool()->get_stream(),
+                    cuda::stream_ref{br->stream_pool()->get_stream().value()},
                     *br
                 ));
             }));
@@ -1008,7 +1012,7 @@ TEST(Shuffler, opid_reuse) {
         GTEST_SKIP() << "OpID reuse test requires multiple ranks";
     }
 
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
     auto const total_num_partitions =
         rapidsmpf::safe_cast<rapidsmpf::shuffler::PartID>(comm->nranks());
     constexpr std::size_t total_num_rows = 1000;
@@ -1075,7 +1079,7 @@ TEST(Shuffler, opid_reuse_with_empty_partitions) {
         GTEST_SKIP() << "OpID reuse test requires multiple ranks";
     }
 
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
     constexpr rapidsmpf::shuffler::PartID total_num_partitions = 1;
     constexpr std::size_t total_num_rows = 1000;
     constexpr rapidsmpf::OpID op_id = 0;

--- a/cpp/tests/test_shuffler.cpp
+++ b/cpp/tests/test_shuffler.cpp
@@ -976,7 +976,7 @@ TEST(Shuffler, concurrent_wait) {
                     total_num_partitions,
                     total_num_rows,
                     local_pidx,
-                    cuda::stream_ref{br->stream_pool()->get_stream().value()},
+                    br->stream_pool()->get_stream(),
                     *br
                 ));
             }));

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -16,7 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/coll/sparse_alltoall.hpp>
@@ -56,13 +57,13 @@ rapidsmpf::PackedData make_payload(
     int payload_value,
     rapidsmpf::MemoryType mem_type,
     rapidsmpf::BufferResource& br,
-    rmm::cuda_stream_view stream
+    cuda::stream_ref stream
 ) {
     auto metadata = std::make_unique<std::vector<std::uint8_t>>(sizeof(int));
     std::memcpy(metadata->data(), &metadata_value, sizeof(int));
 
     auto data = br.make_buffer(stream, br.reserve_or_fail(sizeof(int), mem_type));
-    data->write_access([&](std::byte* ptr, rmm::cuda_stream_view op_stream) {
+    data->write_access([&](std::byte* ptr, cuda::stream_ref op_stream) {
         if (mem_type == rapidsmpf::MemoryType::DEVICE) {
             RAPIDSMPF_CUDA_TRY(
                 rapidsmpf::cuda_memcpy_async(
@@ -96,7 +97,7 @@ int decode_payload(rapidsmpf::PackedData const& packed_data) {
                 packed_data.data->stream()
             )
         );
-        packed_data.data->stream().synchronize();
+        packed_data.data->stream().sync();
     } else {
         std::memcpy(&result, packed_data.data->data(), sizeof(result));
     }
@@ -187,7 +188,7 @@ TEST_P(SparseAlltoallMemoryTest, basic_ring_exchange) {
                     comm->rank() * 100 + i,
                     mem_type,
                     *br,
-                    br->stream_pool()->get_stream()
+                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
                 )
             );
         }
@@ -225,7 +226,7 @@ TEST_F(SparseAlltoallTest, payload_statistics) {
                     comm->rank() * 100 + i,
                     rapidsmpf::MemoryType::HOST,
                     *br,
-                    br->stream_pool()->get_stream()
+                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
                 )
             );
         }
@@ -315,7 +316,7 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
                 comm->rank() * 100 + dst,
                 rapidsmpf::MemoryType::DEVICE,
                 *br,
-                br->stream_pool()->get_stream()
+                cuda::stream_ref{br->stream_pool()->get_stream().value()}
             )
         );
     }
@@ -330,7 +331,7 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
                     1,
                     rapidsmpf::MemoryType::HOST,
                     *br,
-                    br->stream_pool()->get_stream()
+                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
                 )
             ),
             std::logic_error
@@ -356,10 +357,11 @@ TEST_F(SparseAlltoallTest, ordered_by_sender_insertion_with_stream_reordering) {
     auto [srcs, dsts] = ring_peers(comm);
     rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts);
 
-    auto const delayed_stream = br->stream_pool()->get_stream(1);
-    auto const fast_stream = br->stream_pool()->get_stream(2);
+    auto const delayed_stream =
+        cuda::stream_ref{br->stream_pool()->get_stream(1).value()};
+    auto const fast_stream = cuda::stream_ref{br->stream_pool()->get_stream(2).value()};
     RAPIDSMPF_CUDA_TRY(cudaLaunchHostFunc(
-        delayed_stream.value(), sleep_on_stream, new std::chrono::milliseconds(100)
+        delayed_stream.get(), sleep_on_stream, new std::chrono::milliseconds(100)
     ));
 
     exchange.insert(
@@ -423,7 +425,7 @@ TEST_F(SparseAlltoallTest, concurrent_insertions) {
                         comm->rank() * total_messages + sequence,
                         rapidsmpf::MemoryType::HOST,
                         *br,
-                        br->stream_pool()->get_stream()
+                        cuda::stream_ref{br->stream_pool()->get_stream().value()}
                     )
                 );
             }
@@ -458,7 +460,11 @@ TEST_F(SparseAlltoallTest, invalid_usage) {
         exchange.insert(
             comm->rank(),
             make_payload(
-                1, 2, rapidsmpf::MemoryType::DEVICE, *br, br->stream_pool()->get_stream()
+                1,
+                2,
+                rapidsmpf::MemoryType::DEVICE,
+                *br,
+                cuda::stream_ref{br->stream_pool()->get_stream().value()}
             )
         ),
         std::logic_error
@@ -490,7 +496,7 @@ TEST_F(SparseAlltoallTest, tag_reuse_after_wait) {
                     comm->rank() * 1000 + iteration,
                     rapidsmpf::MemoryType::DEVICE,
                     *br,
-                    br->stream_pool()->get_stream()
+                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
                 )
             );
         }
@@ -525,7 +531,7 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     comm->rank() * 1000 + 100 + i,
                     rapidsmpf::MemoryType::DEVICE,
                     *br,
-                    br->stream_pool()->get_stream()
+                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
                 )
             );
             exchange1.insert(
@@ -535,7 +541,7 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     comm->rank() * 1000 + 200 + i,
                     rapidsmpf::MemoryType::DEVICE,
                     *br,
-                    br->stream_pool()->get_stream()
+                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
                 )
             );
         }

--- a/cpp/tests/test_sparse_alltoall.cpp
+++ b/cpp/tests/test_sparse_alltoall.cpp
@@ -188,7 +188,7 @@ TEST_P(SparseAlltoallMemoryTest, basic_ring_exchange) {
                     comm->rank() * 100 + i,
                     mem_type,
                     *br,
-                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                    br->stream_pool()->get_stream()
                 )
             );
         }
@@ -226,7 +226,7 @@ TEST_F(SparseAlltoallTest, payload_statistics) {
                     comm->rank() * 100 + i,
                     rapidsmpf::MemoryType::HOST,
                     *br,
-                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                    br->stream_pool()->get_stream()
                 )
             );
         }
@@ -316,7 +316,7 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
                 comm->rank() * 100 + dst,
                 rapidsmpf::MemoryType::DEVICE,
                 *br,
-                cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                br->stream_pool()->get_stream()
             )
         );
     }
@@ -331,7 +331,7 @@ TEST_F(SparseAlltoallTest, asymmetric_peer_sets) {
                     1,
                     rapidsmpf::MemoryType::HOST,
                     *br,
-                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                    br->stream_pool()->get_stream()
                 )
             ),
             std::logic_error
@@ -357,9 +357,8 @@ TEST_F(SparseAlltoallTest, ordered_by_sender_insertion_with_stream_reordering) {
     auto [srcs, dsts] = ring_peers(comm);
     rapidsmpf::coll::SparseAlltoall exchange(comm, 0, br.get(), srcs, dsts);
 
-    auto const delayed_stream =
-        cuda::stream_ref{br->stream_pool()->get_stream(1).value()};
-    auto const fast_stream = cuda::stream_ref{br->stream_pool()->get_stream(2).value()};
+    cuda::stream_ref const delayed_stream = br->stream_pool()->get_stream(1);
+    cuda::stream_ref const fast_stream = br->stream_pool()->get_stream(2);
     RAPIDSMPF_CUDA_TRY(cudaLaunchHostFunc(
         delayed_stream.get(), sleep_on_stream, new std::chrono::milliseconds(100)
     ));
@@ -425,7 +424,7 @@ TEST_F(SparseAlltoallTest, concurrent_insertions) {
                         comm->rank() * total_messages + sequence,
                         rapidsmpf::MemoryType::HOST,
                         *br,
-                        cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                        br->stream_pool()->get_stream()
                     )
                 );
             }
@@ -460,11 +459,7 @@ TEST_F(SparseAlltoallTest, invalid_usage) {
         exchange.insert(
             comm->rank(),
             make_payload(
-                1,
-                2,
-                rapidsmpf::MemoryType::DEVICE,
-                *br,
-                cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                1, 2, rapidsmpf::MemoryType::DEVICE, *br, br->stream_pool()->get_stream()
             )
         ),
         std::logic_error
@@ -496,7 +491,7 @@ TEST_F(SparseAlltoallTest, tag_reuse_after_wait) {
                     comm->rank() * 1000 + iteration,
                     rapidsmpf::MemoryType::DEVICE,
                     *br,
-                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                    br->stream_pool()->get_stream()
                 )
             );
         }
@@ -531,7 +526,7 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     comm->rank() * 1000 + 100 + i,
                     rapidsmpf::MemoryType::DEVICE,
                     *br,
-                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                    br->stream_pool()->get_stream()
                 )
             );
             exchange1.insert(
@@ -541,7 +536,7 @@ TEST_F(SparseAlltoallTest, simultaneous_different_tags) {
                     comm->rank() * 1000 + 200 + i,
                     rapidsmpf::MemoryType::DEVICE,
                     *br,
-                    cuda::stream_ref{br->stream_pool()->get_stream().value()}
+                    br->stream_pool()->get_stream()
                 )
             );
         }

--- a/cpp/tests/test_spilling.cpp
+++ b/cpp/tests/test_spilling.cpp
@@ -9,7 +9,8 @@
 
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/per_device_resource.hpp>
 
 #include <rapidsmpf/memory/buffer.hpp>
@@ -25,11 +26,11 @@ class SpillingTest : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = rmm::cuda_stream_default;
+        stream = cuda::stream_ref{cudaStream_t{nullptr}};
     }
 
     std::shared_ptr<BufferResource> br;
-    rmm::cuda_stream_view stream;
+    cuda::stream_ref stream;
 };
 
 TEST_F(SpillingTest, SpillUnspillRoundtripPreservesDataAndMetadata) {

--- a/cpp/tests/test_spilling.cpp
+++ b/cpp/tests/test_spilling.cpp
@@ -26,11 +26,11 @@ class SpillingTest : public ::testing::Test {
   protected:
     void SetUp() override {
         br = BufferResource::create(rmm::mr::get_current_device_resource_ref());
-        stream = cuda::stream_ref{cudaStream_t{nullptr}};
+        stream = cuda::stream_ref{cudaStreamLegacy};
     }
 
     std::shared_ptr<BufferResource> br;
-    cuda::stream_ref stream;
+    cuda::stream_ref stream{cudaStreamLegacy};
 };
 
 TEST_F(SpillingTest, SpillUnspillRoundtripPreservesDataAndMetadata) {

--- a/cpp/tests/test_statistics.cpp
+++ b/cpp/tests/test_statistics.cpp
@@ -190,7 +190,7 @@ TEST_F(StatisticsTest, MemoryProfiler) {
     auto mr = br->device_mr_adaptor();
     auto pinned_mr = br->try_pinned_mr();
     auto stats = rapidsmpf::Statistics::create();
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
 
     // Outer scope
     {

--- a/cpp/tests/test_statistics.cpp
+++ b/cpp/tests/test_statistics.cpp
@@ -12,7 +12,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
+
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -189,7 +190,7 @@ TEST_F(StatisticsTest, MemoryProfiler) {
     auto mr = br->device_mr_adaptor();
     auto pinned_mr = br->try_pinned_mr();
     auto stats = rapidsmpf::Statistics::create();
-    auto stream = rmm::cuda_stream_view{};
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
 
     // Outer scope
     {
@@ -215,7 +216,7 @@ TEST_F(StatisticsTest, MemoryProfiler) {
             pinned_mr->deallocate(stream, ptr4, 2_MiB);  // -2 MiB
             pinned_mr->deallocate(stream, ptr3, 1_MiB);  // -1 MiB
         }
-        stream.synchronize();
+        stream.sync();
     }
     auto const& records = stats->get_memory_records();
 

--- a/cpp/tests/utils.hpp
+++ b/cpp/tests/utils.hpp
@@ -22,8 +22,8 @@
 #include <unistd.h>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <rapidsmpf/error.hpp>
@@ -115,7 +115,7 @@ template <typename T>
 [[nodiscard]] inline rapidsmpf::PackedData create_packed_data(
     std::span<std::uint8_t const> metadata,
     std::span<std::uint8_t const> data,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rapidsmpf::BufferResource* br
 ) {
     auto metadata_ptr =
@@ -126,7 +126,7 @@ template <typename T>
     );
     auto data_ptr =
         std::make_unique<rmm::device_buffer>(data.data(), data.size(), stream);
-    stream.synchronize();
+    stream.sync();
     return rapidsmpf::PackedData{
         std::move(metadata_ptr), br->move(std::move(data_ptr), stream)
     };
@@ -148,7 +148,7 @@ template <typename T = int>
 [[nodiscard]] inline rapidsmpf::PackedData generate_packed_data(
     std::size_t n_elements,
     T offset,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rapidsmpf::BufferResource& br,
     rapidsmpf::AllowOverbooking allow_overbooking = rapidsmpf::AllowOverbooking::YES
 ) {
@@ -163,7 +163,7 @@ template <typename T = int>
     auto data = br.make_buffer(stream, std::move(reservation));
 
     data->write_access([d_ptr = metadata->data(), m_size = metadata->size()](
-                           std::byte* ptr, rmm::cuda_stream_view op_stream
+                           std::byte* ptr, cuda::stream_ref op_stream
                        ) {
         RAPIDSMPF_CUDA_TRY(rapidsmpf::cuda_memcpy_async(ptr, d_ptr, m_size, op_stream));
     });
@@ -187,7 +187,7 @@ inline void validate_packed_data(
     rapidsmpf::PackedData&& packed_data,
     std::size_t n_elements,
     T offset,
-    rmm::cuda_stream_view stream,
+    cuda::stream_ref stream,
     rapidsmpf::BufferResource& br
 ) {
     auto const& metadata = *packed_data.metadata;
@@ -203,7 +203,7 @@ inline void validate_packed_data(
 
     auto res = br.reserve_or_fail(packed_data.data->size, rapidsmpf::MemoryType::HOST);
     auto data_on_host = br.move_to_host_buffer(std::move(packed_data.data), res);
-    RAPIDSMPF_CUDA_TRY(cudaStreamSynchronize(stream));
+    RAPIDSMPF_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     EXPECT_EQ(metadata, data_on_host->copy_to_uint8_vector());
 }
 
@@ -232,21 +232,21 @@ class DelayedMemoryResource {
     }
 
     void* allocate(
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         std::size_t size,
         std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT
     ) {
         void* ptr = upstream_.allocate(stream, size, alignment);
         if (size > 0) {
             RAPIDSMPF_CUDA_TRY(cudaLaunchHostFunc(
-                stream.value(), sleep_on_stream, new std::chrono::milliseconds(delay_)
+                stream.get(), sleep_on_stream, new std::chrono::milliseconds(delay_)
             ));
         }
         return ptr;
     }
 
     void deallocate(
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         void* ptr,
         std::size_t size,
         std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT

--- a/python/rapidsmpf/rapidsmpf/_detail/cuda_stream_ref.pxd
+++ b/python/rapidsmpf/rapidsmpf/_detail/cuda_stream_ref.pxd
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from cuda.bindings.cyruntime cimport cudaStream_t
+
+
+cdef extern from "<cuda/stream>" namespace "cuda" nogil:
+    cdef cppclass stream_ref:
+        stream_ref()
+        stream_ref(cudaStream_t)
+        cudaStream_t get()
+        void wait() except +

--- a/python/rapidsmpf/rapidsmpf/coll/allgather.pxd
+++ b/python/rapidsmpf/rapidsmpf/coll/allgather.pxd
@@ -1,12 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stdint cimport int32_t, int64_t, uint64_t
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.vector cimport vector
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.pylibrmm.stream cimport Stream
 
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.communicator.communicator cimport Communicator, cpp_Communicator

--- a/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pxd
+++ b/python/rapidsmpf/rapidsmpf/coll/sparse_alltoall.pxd
@@ -1,12 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stdint cimport int32_t, int64_t, uint64_t
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.vector cimport vector
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.pylibrmm.stream cimport Stream
 
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.communicator.communicator cimport (Communicator, Rank,

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
@@ -8,12 +8,12 @@ from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.optional cimport optional
 from libcpp.unordered_map cimport unordered_map
 from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.memory_resource cimport (any_resource, device_accessible,
                                          device_async_resource_ref)
 from rmm.pylibrmm.cuda_stream_pool cimport CudaStreamPool
 from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource
 
+from rapidsmpf._detail.cuda_stream_ref cimport stream_ref
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.config cimport Options, cpp_Options
 from rapidsmpf.memory.buffer cimport Buffer, MemoryType, cpp_Buffer
@@ -58,7 +58,7 @@ cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
         optional[cpp_PinnedMemoryResource] try_pinned_mr() except +ex_handler
         unique_ptr[cpp_Buffer] make_buffer(
             size_t size,
-            cuda_stream_view stream,
+            stream_ref stream,
             cpp_MemoryReservation& reservation,
         ) except +ex_handler
 

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -46,6 +46,7 @@ cdef extern from *:
         any_resource[device_accessible]&
     ) except +ex_handler
 
+from rapidsmpf._detail.cuda_stream_ref cimport stream_ref
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.memory.memory_reservation cimport MemoryReservation
 from rapidsmpf.memory.pinned_memory_resource cimport (
@@ -592,10 +593,11 @@ cdef class BufferResource:
             If ``size`` exceeds the reservation size.
         """
         cdef unique_ptr[cpp_Buffer] handle
+        cdef stream_ref cpp_stream = stream_ref(stream.view().value())
         with nogil:
             handle = move(
                 deref(self._handle).make_buffer(
-                    size, stream.view(), deref(reservation._handle)
+                    size, cpp_stream, deref(reservation._handle)
                 )
             )
         return Buffer.from_handle(move(handle), self, stream)

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
@@ -44,7 +44,7 @@ cdef extern from *:
         // Allocate host buffer and copy data into it
         auto reservation = br->reserve_or_fail(size, rapidsmpf::MemoryType::HOST);
         auto buffer = br->make_buffer(
-            cuda::stream_ref{cudaStream_t{nullptr}}, std::move(reservation)
+            cuda::stream_ref{cudaStreamLegacy}, std::move(reservation)
         );
 
         // Copy data into the buffer

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
@@ -1,15 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stdint cimport uint8_t
 from libcpp.memory cimport make_unique, unique_ptr
 from libcpp.utility cimport move
 from libcpp.vector cimport vector
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.pylibrmm.device_buffer cimport DeviceBuffer
 from rmm.pylibrmm.stream cimport Stream
 
+from rapidsmpf._detail.cuda_stream_ref cimport stream_ref
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.memory.buffer_resource cimport (BufferResource,
                                                cpp_BufferResource)
@@ -25,7 +25,7 @@ cdef extern from *:
     std::unique_ptr<rapidsmpf::PackedData> cpp_packed_data_from_buffers(
         std::unique_ptr<std::vector<std::uint8_t>> metadata,
         std::unique_ptr<rmm::device_buffer> gpu_data,
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         rapidsmpf::BufferResource* br
     ) {
         return std::make_unique<rapidsmpf::PackedData>(
@@ -44,12 +44,12 @@ cdef extern from *:
         // Allocate host buffer and copy data into it
         auto reservation = br->reserve_or_fail(size, rapidsmpf::MemoryType::HOST);
         auto buffer = br->make_buffer(
-            rmm::cuda_stream_default, std::move(reservation)
+            cuda::stream_ref{cudaStream_t{nullptr}}, std::move(reservation)
         );
 
         // Copy data into the buffer
         if (size > 0) {
-            buffer->write_access([&](std::byte* dst, rmm::cuda_stream_view) {
+            buffer->write_access([&](std::byte* dst, cuda::stream_ref) {
                 std::memcpy(dst, data, size);
             });
         }
@@ -63,7 +63,7 @@ cdef extern from *:
         const std::uint8_t* metadata,
         std::size_t metadata_size,
         std::unique_ptr<rmm::device_buffer> gpu_data,
-        rmm::cuda_stream_view stream,
+        cuda::stream_ref stream,
         rapidsmpf::BufferResource* br
     ) {
         auto meta = std::make_unique<std::vector<std::uint8_t>>(
@@ -85,7 +85,7 @@ cdef extern from *:
             RAPIDSMPF_CUDA_TRY(rapidsmpf::cuda_memcpy_async(
                 result.data(), buf->data(), nbytes, buf->stream()
             ));
-            buf->stream().synchronize();
+            buf->stream().sync();
         }
         return result;
     }
@@ -93,7 +93,7 @@ cdef extern from *:
     unique_ptr[cpp_PackedData] cpp_packed_data_from_buffers(
         unique_ptr[vector[uint8_t]] metadata,
         unique_ptr[device_buffer] gpu_data,
-        cuda_stream_view stream,
+        stream_ref stream,
         cpp_BufferResource* br,
     ) except +ex_handler nogil
 
@@ -107,7 +107,7 @@ cdef extern from *:
         const uint8_t* metadata,
         size_t metadata_size,
         unique_ptr[device_buffer] gpu_data,
-        cuda_stream_view stream,
+        stream_ref stream,
         cpp_BufferResource* br,
     ) except +ex_handler nogil
 
@@ -201,7 +201,7 @@ cdef class PackedData:
         cdef const uint8_t* meta_ptr = NULL
         if meta_size > 0:
             meta_ptr = <const uint8_t*>&metadata[0]
-        cdef cuda_stream_view sv = stream.view()
+        cdef stream_ref sv = stream_ref(stream.view().value())
         cdef unique_ptr[device_buffer] gpu = move(gpu_data.c_obj)
         cdef PackedData ret = cls.__new__(cls)
         with nogil:

--- a/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pxd
+++ b/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pxd
@@ -4,16 +4,16 @@
 from libc.stddef cimport size_t
 from libcpp cimport bool as bool_t
 from libcpp.optional cimport optional
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 
+from rapidsmpf._detail.cuda_stream_ref cimport stream_ref
 from rapidsmpf._detail.exception_handling cimport ex_handler
 from rapidsmpf.config cimport cpp_Options
 
 
 cdef extern from "<rapidsmpf/memory/pinned_memory_resource.hpp>" nogil:
     cdef cppclass cpp_PinnedMemoryResource"rapidsmpf::PinnedMemoryResource":
-        void* allocate(cuda_stream_view, size_t) except +ex_handler
-        void deallocate(cuda_stream_view, void*, size_t)
+        void* allocate(stream_ref, size_t) except +ex_handler
+        void deallocate(stream_ref, void*, size_t)
 
     cdef cppclass cpp_PinnedPoolProperties"rapidsmpf::PinnedPoolProperties":
         size_t initial_pool_size

--- a/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pyx
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from libcpp.optional cimport optional
 from rmm.pylibrmm.stream cimport Stream
 
+from rapidsmpf._detail.cuda_stream_ref cimport stream_ref
 from rapidsmpf._detail.exception_handling cimport ex_handler
 
 
@@ -144,8 +145,9 @@ cdef class PinnedMemoryResource:
         Integer address of the allocated memory.
         """
         cdef void* ptr
+        cdef stream_ref cpp_stream = stream_ref(stream.view().value())
         with nogil:
-            ptr = self._handle.value().allocate(stream.view(), nbytes)
+            ptr = self._handle.value().allocate(cpp_stream, nbytes)
         return <size_t>ptr
 
     def deallocate(self, size_t ptr, size_t nbytes, Stream stream not None) -> None:
@@ -161,8 +163,9 @@ cdef class PinnedMemoryResource:
         stream
             CUDA stream associated with the allocation.
         """
+        cdef stream_ref cpp_stream = stream_ref(stream.view().value())
         with nogil:
-            self._handle.value().deallocate(stream.view(), <void*>ptr, nbytes)
+            self._handle.value().deallocate(cpp_stream, <void*>ptr, nbytes)
 
     @staticmethod
     cdef PinnedMemoryResource from_handle(


### PR DESCRIPTION
## Summary
- migrate public and internal stream parameters from `rmm::cuda_stream_view` to `cuda::stream_ref`
- use `<cuda/stream>` and `stream_ref::sync()`
- pass raw CUDA stream handles with `.get()` at CUDA runtime API boundaries
- update Cython bindings to expose `cuda::stream_ref`