### PR TITLE
Add `MemoryReservation::split()`

### DIFF
--- a/cpp/include/rapidsmpf/memory/memory_reservation.hpp
+++ b/cpp/include/rapidsmpf/memory/memory_reservation.hpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,6 +35,23 @@ class MemoryReservation {
      * @brief Clear the remaining size of the reservation.
      */
     void clear() noexcept;
+
+    /**
+     * @brief Split off a sub-reservation of @p size bytes.
+     *
+     * Reduces this reservation by @p size and returns a new reservation of that size
+     * on the same buffer resource and memory type. The total reserved by the buffer
+     * resource is unchanged, the bytes are only moved between the two reservations.
+     *
+     * Useful for scoping part of a reservation to the allocation it covers, since the
+     * returned reservation releases its bytes when it goes out of scope.
+     *
+     * @param size The number of bytes to split off.
+     * @return The new reservation.
+     *
+     * @throws rapidsmpf::reservation_error if @p size exceeds the remaining size.
+     */
+    [[nodiscard]] MemoryReservation split(std::size_t size);
 
     /**
      * @brief Move constructor for MemoryReservation.

--- a/cpp/src/memory/memory_reservation.cpp
+++ b/cpp/src/memory/memory_reservation.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,6 +18,17 @@ void MemoryReservation::clear() noexcept {
     if (size_ > 0) {
         br_->release(*this, size_);
     }
+}
+
+MemoryReservation MemoryReservation::split(std::size_t size) {
+    RAPIDSMPF_EXPECTS(
+        size <= size_,
+        "MemoryReservation(" + format_nbytes(size_) + ") isn't big enough ("
+            + format_nbytes(size) + ")",
+        rapidsmpf::reservation_error
+    );
+    size_ -= size;
+    return {mem_type_, br_, size};
 }
 
 MemoryReservation::MemoryReservation(MemoryReservation&& o)

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -403,6 +403,26 @@ TEST_F(BufferResourceReserveOrFailTest, DeviceType) {
     );
 }
 
+TEST_F(BufferResourceReserveOrFailTest, Split) {
+    auto res = br->reserve_or_fail(5_KiB, MemoryType::DEVICE);
+    EXPECT_EQ(reserved_bytes(*br, MemoryType::DEVICE), 5_KiB);
+
+    {
+        auto sub = res.split(2_KiB);
+        EXPECT_EQ(sub.size(), 2_KiB);
+        EXPECT_EQ(sub.mem_type(), MemoryType::DEVICE);
+        EXPECT_EQ(sub.br(), br.get());
+        EXPECT_EQ(res.size(), 3_KiB);
+        // Splitting only moves bytes between the two reservations.
+        EXPECT_EQ(reserved_bytes(*br, MemoryType::DEVICE), 5_KiB);
+
+        EXPECT_THROW(std::ignore = res.split(4_KiB), rapidsmpf::reservation_error);
+        EXPECT_EQ(res.size(), 3_KiB);  // The failed split changed nothing.
+    }
+    // The sub-reservation released its bytes when it went out of scope.
+    EXPECT_EQ(reserved_bytes(*br, MemoryType::DEVICE), 3_KiB);
+}
+
 TEST_F(BufferResourceReserveOrFailTest, HostType) {
     // Test reserve_or_fail with single host memory type
     auto res = br->reserve_or_fail(5_KiB, MemoryType::HOST);


### PR DESCRIPTION
`MemoryReservation::split(size)` reduces a reservation by `size` and returns a new reservation of that size on the same buffer resource and memory type. The total reserved by the buffer resource is unchanged, the bytes only move between the two reservations.

This lets a caller scope part of a reservation to the allocation it covers. The returned reservation releases its bytes when it goes out of scope, so the reservation is never counted on top of memory that has already been allocated, and there is no size argument at the release point to disagree with what was allocated.

The alternative is `BufferResource::release(reservation, size)`, which works but leaves the caller to pick the release point and to repeat the size. `split()` also composes with a caller-provided reservation: a function can carve off what it needs without caring whether the caller supplied the reservation or it made one itself.

Adopted by cudf's `partition_and_pack()` and friends, which take a caller-provided reservation and split off one sub-reservation per allocation phase: https://github.com/NVIDIA/cudf/pull/23833
