### PR TITLE
Add range constraints on cuda_stream_join

### DIFF
--- a/cpp/include/rapidsmpf/cuda_stream.hpp
+++ b/cpp/include/rapidsmpf/cuda_stream.hpp
@@ -15,9 +15,17 @@
 namespace rapidsmpf {
 
 namespace detail {
+
+/**
+ * @brief Internal concept for identifying ranges of a given type.
+ *
+ * @tparam R Range type.
+ * @tparam T Expected content type.
+ */
 template <typename R, typename T>
 concept input_range_of = std::ranges::input_range<R>
                          && std::convertible_to<std::ranges::range_reference_t<R>, T>;
+
 }  // namespace detail
 
 /**

--- a/cpp/include/rapidsmpf/cuda_stream.hpp
+++ b/cpp/include/rapidsmpf/cuda_stream.hpp
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <concepts>
 #include <memory>
 #include <ranges>
 
@@ -13,6 +14,11 @@
 
 namespace rapidsmpf {
 
+namespace detail {
+template <typename R, typename T>
+concept input_range_of = std::ranges::input_range<R>
+                         && std::convertible_to<std::ranges::range_reference_t<R>, T>;
+}  // namespace detail
 
 /**
  * @brief Make downstream CUDA streams wait on upstream CUDA streams.
@@ -32,7 +38,9 @@ namespace rapidsmpf {
  *
  * @note If all upstream and downstream streams are identical, this function is a no-op.
  */
-template <typename Range1, typename Range2>
+template <
+    detail::input_range_of<cuda::stream_ref> Range1,
+    detail::input_range_of<cuda::stream_ref> Range2>
 void cuda_stream_join(
     Range1 const& downstreams, Range2 const& upstreams, CudaEvent* event = nullptr
 ) {

--- a/cpp/tests/test_cuda_stream.cpp
+++ b/cpp/tests/test_cuda_stream.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <ranges>
 #include <utility>
 
 #include <gmock/gmock.h>
@@ -136,4 +137,20 @@ TEST(CudaStreamJoinCppOnly, MultiUpstreamsMultiDownstreams) {
             RAPIDSMPF_CUDA_TRY(cudaStreamDestroy(downstream_raw[i]));
         }
     }
+}
+
+TEST(CudaStreamJoinCppOnly, AcceptsNonRangeStreamTypes) {
+    // Types that convert to `cuda::stream_ref` but are not ranges must select the
+    // stream/stream overload. If the range template wins, this stops compiling
+    // with "'begin' was not declared in this scope". The invocation is vacuous:
+    // regression coverage comes from instantiating the selected overload.
+    static_assert(!std::ranges::range<rmm::cuda_stream_view>);
+    static_assert(!std::ranges::range<cudaStream_t>);
+
+    CudaEvent event;
+    rmm::cuda_stream stream;
+
+    cuda_stream_join(stream.view(), stream.view(), &event);
+    cuda_stream_join(cudaStreamLegacy, cudaStreamLegacy, &event);
+    cuda_stream_join(cuda::stream_ref{cudaStreamLegacy}, stream.view(), &event);
 }


### PR DESCRIPTION
Constrains the template version of `cuda_stream_join` to ensure that both type arguments are ranges of `cuda::stream_ref`. Also adds a compile-only test case.

A follow-on to #1175.

Fixes #1178.