### PR TITLE
Expose stream pool streams as cuda::stream_ref

### DIFF
--- a/cpp/benchmarks/bench_comm.cpp
+++ b/cpp/benchmarks/bench_comm.cpp
@@ -10,7 +10,6 @@
 
 #include <cuda/stream>
 
-#include <rmm/cuda_stream_pool.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -328,9 +327,7 @@ int main(int argc, char** argv) {
         PinnedMemoryDisabled,
         {},
         std::chrono::milliseconds{1},
-        std::make_shared<rmm::cuda_stream_pool>(
-            16, rmm::cuda_stream::flags::non_blocking
-        ),
+        std::make_shared<StreamPool>(16),
         stats
     );
 

--- a/cpp/benchmarks/bench_memory_resources.cpp
+++ b/cpp/benchmarks/bench_memory_resources.cpp
@@ -11,7 +11,6 @@
 
 #include <cuda/stream>
 
-#include <rmm/cuda_stream_pool.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -110,7 +109,7 @@ std::shared_ptr<rapidsmpf::BufferResource> make_pinned_buffer_resource(
         std::move(props),
         {},
         std::nullopt,  // disable the periodic spill-check thread
-        std::make_shared<rmm::cuda_stream_pool>(1, rmm::cuda_stream::flags::non_blocking)
+        std::make_shared<rapidsmpf::StreamPool>(1)
     );
 }
 

--- a/cpp/include/rapidsmpf/memory/buffer_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer_resource.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -43,6 +44,43 @@ namespace rapidsmpf {
 enum class AllowOverbooking : bool {
     NO,  ///< Overbooking is not allowed.
     YES,  ///< Overbooking is allowed.
+};
+
+/**
+ * @brief Pool of non-blocking CUDA streams.
+ *
+ * The pool is backed by RMM until CUDA Core provides an owning stream-pool
+ * implementation. Its public interface returns CUDA Core stream references so
+ * callers do not need to bridge between stream abstractions.
+ */
+class StreamPool {
+  public:
+    explicit StreamPool(std::size_t num_streams)
+        : pool_{std::make_shared<rmm::cuda_stream_pool>(
+              num_streams, rmm::cuda_stream::flags::non_blocking
+          )} {}
+
+    explicit StreamPool(std::shared_ptr<rmm::cuda_stream_pool> pool)
+        : pool_{std::move(pool)} {
+        RAPIDSMPF_EXPECTS(pool_ != nullptr, "the stream pool pointer cannot be NULL");
+    }
+
+    [[nodiscard]] static std::shared_ptr<StreamPool> from_rmm(
+        std::shared_ptr<rmm::cuda_stream_pool> pool
+    ) {
+        return std::make_shared<StreamPool>(std::move(pool));
+    }
+
+    [[nodiscard]] cuda::stream_ref get_stream() const {
+        return cuda::stream_ref{pool_->get_stream().value()};
+    }
+
+    [[nodiscard]] cuda::stream_ref get_stream(std::size_t stream_id) const {
+        return cuda::stream_ref{pool_->get_stream(stream_id).value()};
+    }
+
+  private:
+    std::shared_ptr<rmm::cuda_stream_pool> pool_;
 };
 
 /**
@@ -114,8 +152,7 @@ class BufferResource : public std::enable_shared_from_this<BufferResource> {
         std::optional<PinnedPoolProperties> pinned_pool_properties = PinnedMemoryDisabled,
         std::unordered_map<MemoryType, std::int64_t> memory_limits = {},
         std::optional<Duration> periodic_spill_check = std::chrono::milliseconds{1},
-        std::shared_ptr<rmm::cuda_stream_pool> stream_pool = std::make_shared<
-            rmm::cuda_stream_pool>(16, rmm::cuda_stream::flags::non_blocking),
+        std::shared_ptr<StreamPool> stream_pool = std::make_shared<StreamPool>(16),
         std::shared_ptr<Statistics> statistics = Statistics::disabled()
     );
 
@@ -512,9 +549,9 @@ class BufferResource : public std::enable_shared_from_this<BufferResource> {
      *
      * Use this pool for operations that do not take an explicit CUDA stream.
      *
-     * @return Shared pointer to the underlying CUDA stream pool.
+     * @return Shared pointer to the CUDA stream pool.
      */
-    std::shared_ptr<rmm::cuda_stream_pool> const& stream_pool() const;
+    std::shared_ptr<StreamPool> const& stream_pool() const;
 
     /**
      * @brief Gets a reference to the spill manager used.
@@ -538,7 +575,7 @@ class BufferResource : public std::enable_shared_from_this<BufferResource> {
         std::optional<PinnedMemoryResource> pinned_mr,
         std::unordered_map<MemoryType, std::int64_t> memory_limits,
         std::optional<Duration> periodic_spill_check,
-        std::shared_ptr<rmm::cuda_stream_pool> stream_pool,
+        std::shared_ptr<StreamPool> stream_pool,
         std::shared_ptr<Statistics> statistics
     );
 
@@ -549,7 +586,7 @@ class BufferResource : public std::enable_shared_from_this<BufferResource> {
     std::array<std::atomic<std::int64_t>, MEMORY_TYPES.size()> memory_limits_;
     // Zero initialized reserved counters.
     std::array<std::size_t, MEMORY_TYPES.size()> memory_reserved_ = {};
-    std::shared_ptr<rmm::cuda_stream_pool> stream_pool_;
+    std::shared_ptr<StreamPool> stream_pool_;
     SpillManager spill_manager_;
     std::shared_ptr<Statistics> statistics_;
 };
@@ -586,7 +623,7 @@ std::optional<Duration> periodic_spill_check_from_options(config::Options option
  * @return Pool of CUDA streams used throughout RapidsMPF for operations that do
  * not take an explicit CUDA stream.
  */
-std::shared_ptr<rmm::cuda_stream_pool> stream_pool_from_options(config::Options options);
+std::shared_ptr<StreamPool> stream_pool_from_options(config::Options options);
 
 
 }  // namespace rapidsmpf

--- a/cpp/include/rapidsmpf/memory/buffer_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer_resource.hpp
@@ -73,6 +73,8 @@ class StreamPool {
         return cuda::stream_ref{pool_->get_stream(stream_id).value()};
     }
 
+    [[nodiscard]] std::size_t get_pool_size() const { return pool_->get_pool_size(); }
+
   private:
     std::shared_ptr<rmm::cuda_stream_pool> pool_;
 };

--- a/cpp/include/rapidsmpf/memory/buffer_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer_resource.hpp
@@ -65,12 +65,6 @@ class StreamPool {
         RAPIDSMPF_EXPECTS(pool_ != nullptr, "the stream pool pointer cannot be NULL");
     }
 
-    [[nodiscard]] static std::shared_ptr<StreamPool> from_rmm(
-        std::shared_ptr<rmm::cuda_stream_pool> pool
-    ) {
-        return std::make_shared<StreamPool>(std::move(pool));
-    }
-
     [[nodiscard]] cuda::stream_ref get_stream() const {
         return cuda::stream_ref{pool_->get_stream().value()};
     }

--- a/cpp/include/rapidsmpf/memory/buffer_resource.hpp
+++ b/cpp/include/rapidsmpf/memory/buffer_resource.hpp
@@ -55,25 +55,53 @@ enum class AllowOverbooking : bool {
  */
 class StreamPool {
   public:
+    /**
+     * @brief Construct a pool of non-blocking CUDA streams.
+     *
+     * @param num_streams Number of streams to create.
+     */
     explicit StreamPool(std::size_t num_streams)
         : pool_{std::make_shared<rmm::cuda_stream_pool>(
               num_streams, rmm::cuda_stream::flags::non_blocking
           )} {}
 
+    /**
+     * @brief Construct a stream pool backed by an existing RMM pool.
+     *
+     * @param pool RMM stream pool providing stream ownership.
+     */
     explicit StreamPool(std::shared_ptr<rmm::cuda_stream_pool> pool)
         : pool_{std::move(pool)} {
         RAPIDSMPF_EXPECTS(pool_ != nullptr, "the stream pool pointer cannot be NULL");
     }
 
+    /**
+     * @brief Get the next stream from the pool.
+     *
+     * @return A CUDA Core reference to the selected stream.
+     */
     [[nodiscard]] cuda::stream_ref get_stream() const {
         return cuda::stream_ref{pool_->get_stream().value()};
     }
 
+    /**
+     * @brief Get a stream from the pool by index.
+     *
+     * @param stream_id Index of the stream to retrieve.
+     * @return A CUDA Core reference to the selected stream.
+     */
     [[nodiscard]] cuda::stream_ref get_stream(std::size_t stream_id) const {
         return cuda::stream_ref{pool_->get_stream(stream_id).value()};
     }
 
-    [[nodiscard]] std::size_t get_pool_size() const { return pool_->get_pool_size(); }
+    /**
+     * @brief Get the number of streams in the pool.
+     *
+     * @return Number of streams in the pool.
+     */
+    [[nodiscard]] std::size_t get_pool_size() const {
+        return pool_->get_pool_size();
+    }
 
   private:
     std::shared_ptr<rmm::cuda_stream_pool> pool_;

--- a/cpp/include/rapidsmpf/memory/memory_reservation.hpp
+++ b/cpp/include/rapidsmpf/memory/memory_reservation.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <rmm/cuda_stream_pool.hpp>
-
 #include <rapidsmpf/memory/buffer.hpp>
 #include <rapidsmpf/memory/memory_reservation.hpp>
 

--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -27,7 +27,7 @@ BufferResource::BufferResource(
     std::optional<PinnedMemoryResource> pinned_mr,
     std::unordered_map<MemoryType, std::int64_t> memory_limits,
     std::optional<Duration> periodic_spill_check,
-    std::shared_ptr<rmm::cuda_stream_pool> stream_pool,
+    std::shared_ptr<StreamPool> stream_pool,
     std::shared_ptr<Statistics> statistics
 )
     : owning_mr_{std::move(device_mr)},
@@ -54,7 +54,7 @@ std::shared_ptr<BufferResource> BufferResource::create(
     std::optional<PinnedPoolProperties> pinned_pool_properties,
     std::unordered_map<MemoryType, std::int64_t> memory_limits,
     std::optional<Duration> periodic_spill_check,
-    std::shared_ptr<rmm::cuda_stream_pool> stream_pool,
+    std::shared_ptr<StreamPool> stream_pool,
     std::shared_ptr<Statistics> statistics
 ) {
     std::optional<PinnedMemoryResource> pinned_mr;
@@ -339,7 +339,7 @@ std::unique_ptr<HostBuffer> BufferResource::move_to_host_buffer(
     return move(std::move(buffer), reservation)->release_host_buffer();
 }
 
-std::shared_ptr<rmm::cuda_stream_pool> const& BufferResource::stream_pool() const {
+std::shared_ptr<StreamPool> const& BufferResource::stream_pool() const {
     return stream_pool_;
 }
 
@@ -371,7 +371,7 @@ std::optional<Duration> periodic_spill_check_from_options(config::Options option
     );
 }
 
-std::shared_ptr<rmm::cuda_stream_pool> stream_pool_from_options(config::Options options) {
+std::shared_ptr<StreamPool> stream_pool_from_options(config::Options options) {
     auto const num_streams =
         options.get<std::size_t>("num_streams", parse_string<std::size_t>);
     RAPIDSMPF_EXPECTS(
@@ -379,9 +379,7 @@ std::shared_ptr<rmm::cuda_stream_pool> stream_pool_from_options(config::Options 
         "The `num_streams` option must be greater than 0",
         std::invalid_argument
     );
-    return std::make_shared<rmm::cuda_stream_pool>(
-        num_streams, rmm::cuda_stream::flags::non_blocking
-    );
+    return std::make_shared<StreamPool>(num_streams);
 }
 
 }  // namespace rapidsmpf

--- a/cpp/tests/test_buffer.cpp
+++ b/cpp/tests/test_buffer.cpp
@@ -15,7 +15,6 @@
 #include <cuda/stream>
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_pool.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 
@@ -47,7 +46,7 @@ void checked_memset(
 class BufferRebindStreamTest : public ::testing::TestWithParam<MemoryType> {
   protected:
     void SetUp() override {
-        stream_pool = std::make_shared<rmm::cuda_stream_pool>(2);
+        stream_pool = std::make_shared<StreamPool>(2);
 
         if (GetParam() == MemoryType::PINNED_HOST
             && !is_pinned_memory_resources_supported())
@@ -77,7 +76,7 @@ class BufferRebindStreamTest : public ::testing::TestWithParam<MemoryType> {
     static constexpr std::size_t buffer_size = 32_MiB;
     static constexpr std::size_t chunk_size = 1_MiB;
 
-    std::shared_ptr<rmm::cuda_stream_pool> stream_pool;
+    std::shared_ptr<StreamPool> stream_pool;
     std::shared_ptr<BufferResource> br;
     std::vector<std::uint8_t> random_data;
 };

--- a/cpp/tests/test_buffer_resource.cpp
+++ b/cpp/tests/test_buffer_resource.cpp
@@ -307,7 +307,7 @@ TEST(BufferResource, AllocStatistics) {
         pinned_available ? PinnedPoolProperties{} : PinnedMemoryDisabled,
         {},
         std::nullopt,
-        std::make_shared<rmm::cuda_stream_pool>(1, rmm::cuda_stream::flags::non_blocking),
+        std::make_shared<StreamPool>(1),
         stats
     );
     auto stream = cuda::stream_ref{cudaStreamLegacy};

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
@@ -34,6 +34,10 @@ cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
         YES
 
 cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
+    cdef cppclass cpp_StreamPool "rapidsmpf::StreamPool":
+        @staticmethod
+        shared_ptr[cpp_StreamPool] from_rmm(shared_ptr[cuda_stream_pool])
+
     cdef cppclass cpp_BufferResource "rapidsmpf::BufferResource":
         @staticmethod
         shared_ptr[cpp_BufferResource] create(
@@ -41,7 +45,7 @@ cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
             optional[cpp_PinnedPoolProperties],
             unordered_map[MemoryType, int64_t],
             optional[cpp_Duration],
-            shared_ptr[cuda_stream_pool],
+            shared_ptr[cpp_StreamPool],
             shared_ptr[cpp_Statistics],
         ) except +ex_handler
         int64_t memory_available_for_reservation(
@@ -50,7 +54,6 @@ cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
         int64_t memory_available(MemoryType mem_type) except +ex_handler
         void set_memory_limit(MemoryType mem_type, int64_t limit) except +ex_handler
         cpp_SpillManager &spill_manager() except +ex_handler
-        const shared_ptr[cuda_stream_pool] &stream_pool() except +ex_handler
         size_t release(cpp_MemoryReservation&, size_t) except +ex_handler
         shared_ptr[cpp_Statistics] statistics() except +ex_handler
         device_async_resource_ref device_mr() noexcept

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pxd
@@ -35,8 +35,7 @@ cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
 
 cdef extern from "<rapidsmpf/memory/buffer_resource.hpp>" nogil:
     cdef cppclass cpp_StreamPool "rapidsmpf::StreamPool":
-        @staticmethod
-        shared_ptr[cpp_StreamPool] from_rmm(shared_ptr[cuda_stream_pool])
+        cpp_StreamPool(shared_ptr[cuda_stream_pool])
 
     cdef cppclass cpp_BufferResource "rapidsmpf::BufferResource":
         @staticmethod

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -235,7 +235,7 @@ cdef class BufferResource:
                 cpp_pinned_pool,
                 move(_mem_limits),
                 period,
-                stream_pool.c_obj,
+                cpp_StreamPool.from_rmm(stream_pool.c_obj),
                 stats_handle,
             )
         self.spill_manager = SpillManager._create(self)

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -5,7 +5,7 @@ from cython cimport no_gc_clear
 from cython.operator cimport dereference as deref
 from libc.stdint cimport int64_t
 from libcpp cimport bool as bool_t
-from libcpp.memory cimport shared_ptr, unique_ptr
+from libcpp.memory cimport make_shared, shared_ptr, unique_ptr
 from libcpp.optional cimport optional
 from libcpp.pair cimport pair
 from libcpp.unordered_map cimport unordered_map
@@ -237,7 +237,7 @@ cdef class BufferResource:
                 cpp_pinned_pool,
                 move(_mem_limits),
                 period,
-                cpp_StreamPool.from_rmm(stream_pool.c_obj),
+                make_shared[cpp_StreamPool](stream_pool.c_obj),
                 stats_handle,
             )
         self.spill_manager = SpillManager._create(self)

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -230,8 +230,8 @@ cdef class BufferResource:
                 _props.numa_id = <int>pinned_pool_properties.numa_id
             cpp_pinned_pool = _props
         with nogil:
-            # TODO: Replace this RMM pool with a cuda-python stream pool once one is
-            # available.
+            # TODO: Replace this RMM pool with a cuda-python stream pool once a suitable
+            # one is available with all the necessary CCCL interop.
             self._handle = cpp_BufferResource.create(
                 any_resource[device_accessible](device_mr.get_mr()),
                 cpp_pinned_pool,

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -230,6 +230,8 @@ cdef class BufferResource:
                 _props.numa_id = <int>pinned_pool_properties.numa_id
             cpp_pinned_pool = _props
         with nogil:
+            # TODO: Replace this RMM pool with a cuda-python stream pool once one is
+            # available.
             self._handle = cpp_BufferResource.create(
                 any_resource[device_accessible](device_mr.get_mr()),
                 cpp_pinned_pool,


### PR DESCRIPTION
## Summary
- wrap the RMM-backed stream pool behind an MPF `StreamPool` API
- return `cuda::stream_ref` from stream-pool accessors, including indexed access
- retain Python compatibility by converting supplied RMM pools at the binding boundary