### PR TITLE
Enable public docs features in CI

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 
 from enum import IntEnum, IntFlag
 from typing import Any
@@ -66,6 +67,7 @@ html_css_files = ["custom.css"]
 
 
 html_theme_options = {
+    "public_docs_features": os.environ.get("CI") == "true",
     "external_links": [],
     "icon_links": [
         {


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/319

Enable the Sphinx theme's `public_docs_features` option when `CI=true`, while leaving local documentation builds unchanged.
