### PR TITLE
Avoid spilling during memory reservation admission

### DIFF
--- a/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
@@ -10,7 +10,6 @@
 
 #include <coro/task.hpp>
 
-#include <rapidsmpf/communicator/logger.hpp>
 #include <rapidsmpf/config.hpp>
 #include <rapidsmpf/memory/buffer_resource.hpp>
 #include <rapidsmpf/streaming/core/actor.hpp>
@@ -59,14 +58,12 @@ class MemoryReserveOrWait {
      * still cannot be satisfied.
      *
      * @param options Configuration options.
-     * @param logger Shared pointer to a logger.
      * @param mem_type The memory type for which reservations are requested.
      * @param executor Shared pointer to a coroutine executor.
      * @param br Buffer resource for memory allocation.*
      */
     MemoryReserveOrWait(
         config::Options options,
-        std::shared_ptr<Logger> logger,
         MemoryType mem_type,
         std::shared_ptr<CoroThreadPoolExecutor> executor,
         std::shared_ptr<BufferResource> br
@@ -291,7 +288,6 @@ class MemoryReserveOrWait {
     mutable std::mutex mutex_;
     std::uint64_t sequence_counter{0};
     MemoryType const mem_type_;
-    std::shared_ptr<Logger> logger_;
     std::shared_ptr<CoroThreadPoolExecutor> executor_;
     std::shared_ptr<BufferResource> br_;
     Duration const timeout_;

--- a/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
+++ b/cpp/include/rapidsmpf/streaming/core/memory_reserve_or_wait.hpp
@@ -32,9 +32,8 @@ class Context;
  * progress must be forced.
  *
  * While requests are pending and none of them fit into the available memory,
- * spilling is triggered on the caller's behalf. This applies to `MemoryType::DEVICE`
- * only, since `SpillManager` measures headroom against device memory. Requests of
- * other memory types wait without spilling.
+ * they wait for a reservation release or for the progress timeout. The timeout
+ * path attempts a reservation without spilling queued data.
  */
 class MemoryReserveOrWait {
   public:
@@ -44,8 +43,7 @@ class MemoryReserveOrWait {
      *
      * This value is used when a reasonable estimate of the net memory delta is not
      * yet available. Any use of this sentinel should be treated as a TODO, since
-     * providing a concrete estimate enables better spilling and scheduling
-     * decisions.
+     * providing a concrete estimate enables better scheduling decisions.
      *
      * @see reserve_or_wait()
      */
@@ -59,8 +57,6 @@ class MemoryReserveOrWait {
      * progress by selecting the smallest pending request and attempting to reserve
      * memory for it. This attempt may result in an empty reservation if the request
      * still cannot be satisfied.
-     *
-     * Spilling is attempted before that timeout is reached, see the class docs.
      *
      * @param options Configuration options.
      * @param logger Shared pointer to a logger.
@@ -94,19 +90,16 @@ class MemoryReserveOrWait {
      * (including other pending requests) makes progress within the configured
      * timeout.
      *
-     * While no pending request fits, spilling is attempted to free the memory the
-     * highest-priority one needs, and again just before progress is forced. Both are
-     * limited to `MemoryType::DEVICE`.
+     * While no pending request fits, it remains pending until another reservation
+     * releases memory or the progress timeout expires.
      *
      * The timeout does not apply specifically to this request. Instead, it bounds
      * when a final recovery attempt begins, not when it completes: if no pending
      * reservation request can be satisfied within the timeout, `MemoryReserveOrWait`
-     * forces progress by selecting the smallest pending request, spilling to make
-     * room for it, and attempting to reserve memory. That spill waits for any
-     * in-flight spill to finish, so the call can return later than the timeout. The
-     * forced reservation attempt may result in an empty `MemoryReservation` if the
-     * selected request still cannot be satisfied, for example when nothing is
-     * spillable.
+     * forces progress by selecting the smallest pending request and attempting to
+     * reserve memory without spilling queued data. The forced reservation attempt
+     * may result in an empty `MemoryReservation` if the selected request still
+     * cannot be satisfied.
      *
      * When multiple reservation requests are eligible, `MemoryReserveOrWait` uses
      * @p net_memory_delta as a heuristic to prefer requests that are expected to

--- a/cpp/src/streaming/core/context.cpp
+++ b/cpp/src/streaming/core/context.cpp
@@ -87,9 +87,7 @@ Context::Context(
 
     for (auto mem_type : MEMORY_TYPES) {
         memory_[static_cast<std::size_t>(mem_type)] =
-            std::make_shared<MemoryReserveOrWait>(
-                options_, mem_type, executor_, br_
-            );
+            std::make_shared<MemoryReserveOrWait>(options_, mem_type, executor_, br_);
     }
 }
 

--- a/cpp/src/streaming/core/context.cpp
+++ b/cpp/src/streaming/core/context.cpp
@@ -88,7 +88,7 @@ Context::Context(
     for (auto mem_type : MEMORY_TYPES) {
         memory_[static_cast<std::size_t>(mem_type)] =
             std::make_shared<MemoryReserveOrWait>(
-                options_, logger_, mem_type, executor_, br_
+                options_, mem_type, executor_, br_
             );
     }
 }

--- a/cpp/src/streaming/core/memory_reserve_or_wait.cpp
+++ b/cpp/src/streaming/core/memory_reserve_or_wait.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <algorithm>
-#include <atomic>
 #include <memory>
 #include <mutex>
 #include <ranges>
@@ -203,36 +202,6 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
         RAPIDSMPF_EXPECTS(err, "cannot spawn push-into-queue task");
     };
 
-    // Helper that spills until `headroom` bytes are reservable, swallowing a spill
-    // function that throws and logging it once per task. Returns false only when a
-    // non-blocking spill found the spill lock held.
-    bool spill_failure_logged = false;
-    auto make_headroom = [&](std::size_t headroom, bool blocking) -> bool {
-        // Only device memory is supported, see `spill_to_make_headroom()`.
-        if (mem_type_ != MemoryType::DEVICE) {
-            return true;
-        }
-        try {
-            auto const target = safe_cast<std::int64_t>(headroom);
-            if (blocking) {
-                br_->spill_manager().spill_to_make_headroom(target);
-                return true;
-            }
-            return br_->spill_manager().try_spill_to_make_headroom(target).has_value();
-        } catch (...) {
-            if (!std::exchange(spill_failure_logged, true)) {
-                try {
-                    logger_->warn(
-                        "a spill function threw while making headroom for ",
-                        format_nbytes(headroom)
-                    );
-                } catch (...) {  // NOLINT(bugprone-empty-catch)
-                }
-            }
-            return true;
-        }
-    };
-
     // RAII helper that releases `periodic_task_running_` when this task exits without
     // reaching one of the `co_return` paths below, such as on an exception. Those paths
     // release the flag under the same lock acquisition that observes the empty request
@@ -256,9 +225,6 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
 
     while (true) {
         auto last_reservation_success = Clock::now();
-        // Spilling is attempted once per timeout window, re-armed by each served
-        // request.
-        bool spill_attempted = false;
         while (true) {
             // Exit if no more pending requests remain.
             {
@@ -283,18 +249,9 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
             std::unique_lock lock(mutex_);
             auto eligibles = eligible_requests(max_size);
             if (eligibles.empty()) {
-                // Nothing fits. Spill enough to admit the request with the smallest
-                // net_memory_delta, then re-poll.
-                if (!spill_attempted && !reservation_requests_.empty()) {
-                    auto const target = std::ranges::min_element(
-                        reservation_requests_, std::less<>{}, &Request::net_memory_delta
-                    );
-                    auto const headroom = target->size;
-                    // Spill without holding the mutex, the spill functions take the
-                    // buffer resource's lock.
-                    lock.unlock();
-                    spill_attempted = make_headroom(headroom, /* blocking = */ false);
-                }
+                // Nothing currently fits. Preserve resident data while ordinary
+                // admission waits for a reservation release; the timeout path
+                // below remains responsible for bounded progress.
                 continue;  // No eligible requests.
             }
 
@@ -313,12 +270,13 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
             lock.unlock();
             push_into_queue(request.queue, std::move(res));
             last_reservation_success = Clock::now();
-            spill_attempted = false;
         }
 
-        // Reaching this point means we hit the timeout. We force progress by selecting
-        // among the smallest pending requests, preferring the one with the smallest
-        // net_memory_delta.
+        // Reaching this point means we hit the timeout. Force bounded progress by
+        // selecting among the smallest pending requests, preferring the one with the
+        // smallest net_memory_delta. Do not spill queued data here: callers that
+        // permit overbooking receive the zero-size reservation below and decide how
+        // to proceed, while non-overbooking callers retain the existing failure path.
         std::unique_lock lock(mutex_);
         if (reservation_requests_.empty()) {
             periodic_task_running_ = false;
@@ -346,9 +304,6 @@ coro::task<void> MemoryReserveOrWait::periodic_memory_check() {
 
         Request request = reservation_requests_.extract(it).value();
         lock.unlock();
-
-        // Last chance before handing back a zero-size reservation.
-        make_headroom(request.size, /* blocking = */ true);
 
         // Reserve memory and accept a zero-size result if it does not fit into the
         // currently available memory.

--- a/cpp/src/streaming/core/memory_reserve_or_wait.cpp
+++ b/cpp/src/streaming/core/memory_reserve_or_wait.cpp
@@ -22,17 +22,14 @@ namespace rapidsmpf::streaming {
 
 MemoryReserveOrWait::MemoryReserveOrWait(
     config::Options options,
-    std::shared_ptr<Logger> logger,
     MemoryType mem_type,
     std::shared_ptr<CoroThreadPoolExecutor> executor,
     std::shared_ptr<BufferResource> br
 )
     : mem_type_{mem_type},
-      logger_{std::move(logger)},
       executor_{std::move(executor)},
       br_{std::move(br)},
       timeout_{options.get<Duration>("memory_reserve_timeout", parse_duration)} {
-    RAPIDSMPF_EXPECTS(logger_ != nullptr, "logger cannot be NULL");
     RAPIDSMPF_EXPECTS(executor_ != nullptr, "executor cannot be NULL");
     RAPIDSMPF_EXPECTS(br_ != nullptr, "br cannot be NULL");
 }

--- a/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
+++ b/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
@@ -73,9 +73,7 @@ TEST_P(StreamingMemoryReserveOrWait, AccessorsReturnExpectedValues) {
         {{"memory_reserve_timeout", config::OptionValue("12345 ms")}}
     };
 
-    MemoryReserveOrWait mrow{
-        options, MemoryType::DEVICE, ctx->executor(), ctx->br()
-    };
+    MemoryReserveOrWait mrow{options, MemoryType::DEVICE, ctx->executor(), ctx->br()};
 
     // Executor and buffer resource should match the context.
     EXPECT_EQ(mrow.executor(), ctx->executor());
@@ -357,16 +355,18 @@ TEST_P(StreamingMemoryReserveOrWait, DoesNotSpillBeforeProgressTimeout) {
             // `shutdown()` closes the pending request queue.
         }
     }(mrow));
-    actors.push_back([](MemoryReserveOrWait& waiter, SpillRecorder const& spills) -> Actor {
-        // The counter increments before each yield. Reaching two iterations proves
-        // the first no-fit admission pass completed without relying on wall-clock
-        // sleeps or a scheduling deadline.
-        while (waiter.periodic_memory_check_counter() < 2) {
-            co_await waiter.executor()->yield();
-        }
-        EXPECT_TRUE(spills.amounts().empty());
-        co_await waiter.shutdown();
-    }(mrow, spills));
+    actors.push_back(
+        [](MemoryReserveOrWait& waiter, SpillRecorder const& spills) -> Actor {
+            // The counter increments before each yield. Reaching two iterations proves
+            // the first no-fit admission pass completed without relying on wall-clock
+            // sleeps or a scheduling deadline.
+            while (waiter.periodic_memory_check_counter() < 2) {
+                co_await waiter.executor()->yield();
+            }
+            EXPECT_TRUE(spills.amounts().empty());
+            co_await waiter.shutdown();
+        }(mrow, spills)
+    );
     run_actor_network(std::move(actors));
 }
 

--- a/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
+++ b/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <chrono>
 #include <thread>
 
 #include <gmock/gmock.h>
@@ -341,8 +340,7 @@ TEST_P(StreamingMemoryReserveOrWait, DoesNotSpillBeforeProgressTimeout) {
     }
 
     MemoryReserveOrWait mrow{
-        // A queued request must wait for the progress timeout before it can trigger
-        // the expensive spill path.
+        // Keep the timeout far away so the test exercises ordinary admission polling.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
         ctx->logger(),
         MemoryType::DEVICE,
@@ -350,34 +348,31 @@ TEST_P(StreamingMemoryReserveOrWait, DoesNotSpillBeforeProgressTimeout) {
         ctx->br()
     };
 
-    // The available memory covers the request on its own, but an outstanding
-    // reservation consumes all of it, so only spilling can unblock the waiter.
+    // An outstanding reservation consumes all available memory. Before the fix, the
+    // ordinary admission loop calls this spill function to unblock the waiter.
     SpillRecorder spills{br.get(), /* available = */ 10, /* spillable = */ 10};
     auto [outstanding, _] = br->reserve(MemoryType::DEVICE, 10, AllowOverbooking::NO);
     ASSERT_EQ(outstanding.size(), 10);
 
     std::vector<Actor> actors;
-    actors.push_back([&](MemoryReserveOrWait& waiter) -> Actor {
+    actors.push_back([](MemoryReserveOrWait& waiter) -> Actor {
         try {
             std::ignore = co_await waiter.reserve_or_wait(10, 0);
         } catch (std::runtime_error const&) {
             // `shutdown()` closes the pending request queue.
         }
     }(mrow));
-    std::thread thd(run_actor_network, std::move(actors));
-
-    // Let the poller observe the pending request several times while the timeout
-    // remains far away. The current eager #1164 path spills here; the desired path
-    // leaves the request pending.
-    auto const deadline = Clock::now() + std::chrono::seconds(1);
-    while (mrow.size() < 1 && spills.amounts().empty() && Clock::now() < deadline) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    EXPECT_TRUE(spills.amounts().empty());
-
-    coro::sync_wait(mrow.shutdown());
-    thd.join();
+    actors.push_back([](MemoryReserveOrWait& waiter, SpillRecorder const& spills) -> Actor {
+        // The counter increments before each yield. Reaching two iterations proves
+        // the first no-fit admission pass completed without relying on wall-clock
+        // sleeps or a scheduling deadline.
+        while (waiter.periodic_memory_check_counter() < 2) {
+            co_await waiter.executor()->yield();
+        }
+        EXPECT_TRUE(spills.amounts().empty());
+        co_await waiter.shutdown();
+    }(mrow, spills));
+    run_actor_network(std::move(actors));
 }
 
 TEST_P(StreamingMemoryReserveOrWait, ProgressTimeoutReturnsWithoutSpilling) {

--- a/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
+++ b/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
@@ -74,7 +74,7 @@ TEST_P(StreamingMemoryReserveOrWait, AccessorsReturnExpectedValues) {
     };
 
     MemoryReserveOrWait mrow{
-        options, ctx->logger(), MemoryType::DEVICE, ctx->executor(), ctx->br()
+        options, MemoryType::DEVICE, ctx->executor(), ctx->br()
     };
 
     // Executor and buffer resource should match the context.
@@ -92,7 +92,6 @@ TEST_P(StreamingMemoryReserveOrWait, ShutdownEarly) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
-        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -143,7 +142,6 @@ TEST_P(StreamingMemoryReserveOrWait, CheckPriority) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
-        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -209,7 +207,6 @@ TEST_P(StreamingMemoryReserveOrWait, RestartPeriodicTask) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
-        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -261,7 +258,6 @@ TEST_P(StreamingMemoryReserveOrWait, NoDeadlockWhenSpawningWithStaleHandle) {
     MemoryReserveOrWait mrow{
         // Use a very high timeout to effectively disable timeout in this test.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
-        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -342,7 +338,6 @@ TEST_P(StreamingMemoryReserveOrWait, DoesNotSpillBeforeProgressTimeout) {
     MemoryReserveOrWait mrow{
         // Keep the timeout far away so the test exercises ordinary admission polling.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
-        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -383,7 +378,6 @@ TEST_P(StreamingMemoryReserveOrWait, ProgressTimeoutReturnsWithoutSpilling) {
     MemoryReserveOrWait mrow{
         // Short timeout, the waiter can only make progress via the timeout path.
         config::Options({{"memory_reserve_timeout", config::OptionValue("100ms")}}),
-        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -406,7 +400,6 @@ TEST_P(StreamingMemoryReserveOrWait, ProgressTimeoutReturnsWithoutSpilling) {
 TEST_P(StreamingMemoryReserveOrWait, NoSpillWhenMemoryIsAvailable) {
     MemoryReserveOrWait mrow{
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
-        ctx->logger(),
         MemoryType::DEVICE,
         ctx->executor(),
         ctx->br()
@@ -430,7 +423,6 @@ TEST_P(StreamingMemoryReserveOrWait, OverbookOnTimeoutReportsOverbookingBytes) {
         MemoryReserveOrWait mrow{
             // Use a very small timeout to trigger timeout immediately.
             config::Options({{"memory_reserve_timeout", config::OptionValue("1ns")}}),
-            ctx->logger(),
             MemoryType::DEVICE,
             ctx->executor(),
             ctx->br()
@@ -449,7 +441,6 @@ TEST_P(StreamingMemoryReserveOrWait, FailOnTimeoutThrowsOverflowError) {
         MemoryReserveOrWait mrow{
             // Use a very small timeout to trigger timeout immediately.
             config::Options({{"memory_reserve_timeout", config::OptionValue("1ns")}}),
-            ctx->logger(),
             MemoryType::DEVICE,
             ctx->executor(),
             ctx->br()

--- a/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
+++ b/cpp/tests/streaming/test_memory_reserve_or_wait.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <chrono>
 #include <thread>
 
 #include <gmock/gmock.h>
@@ -334,13 +335,14 @@ class SpillRecorder {
     std::vector<std::size_t> amounts_;
 };
 
-TEST_P(StreamingMemoryReserveOrWait, SpillingUnblocksWaiter) {
+TEST_P(StreamingMemoryReserveOrWait, DoesNotSpillBeforeProgressTimeout) {
     if (is_running_under_valgrind()) {
         GTEST_SKIP() << "Test runs very slow in valgrind";
     }
 
     MemoryReserveOrWait mrow{
-        // Use a very high timeout, so only spilling can satisfy the request.
+        // A queued request must wait for the progress timeout before it can trigger
+        // the expensive spill path.
         config::Options({{"memory_reserve_timeout", config::OptionValue("1 min")}}),
         ctx->logger(),
         MemoryType::DEVICE,
@@ -355,13 +357,30 @@ TEST_P(StreamingMemoryReserveOrWait, SpillingUnblocksWaiter) {
     ASSERT_EQ(outstanding.size(), 10);
 
     std::vector<Actor> actors;
-    actors.push_back(waiter(mrow, 10, 0, 10));
-    run_actor_network(std::move(actors));
+    actors.push_back([&](MemoryReserveOrWait& waiter) -> Actor {
+        try {
+            std::ignore = co_await waiter.reserve_or_wait(10, 0);
+        } catch (std::runtime_error const&) {
+            // `shutdown()` closes the pending request queue.
+        }
+    }(mrow));
+    std::thread thd(run_actor_network, std::move(actors));
 
-    EXPECT_THAT(spills.amounts(), ::testing::Contains(10u));
+    // Let the poller observe the pending request several times while the timeout
+    // remains far away. The current eager #1164 path spills here; the desired path
+    // leaves the request pending.
+    auto const deadline = Clock::now() + std::chrono::seconds(1);
+    while (mrow.size() < 1 && spills.amounts().empty() && Clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    EXPECT_TRUE(spills.amounts().empty());
+
+    coro::sync_wait(mrow.shutdown());
+    thd.join();
 }
 
-TEST_P(StreamingMemoryReserveOrWait, ThrowingSpillFunctionDoesNotStrandWaiter) {
+TEST_P(StreamingMemoryReserveOrWait, ProgressTimeoutReturnsWithoutSpilling) {
     if (is_running_under_valgrind()) {
         GTEST_SKIP() << "Test runs very slow in valgrind";
     }
@@ -375,26 +394,18 @@ TEST_P(StreamingMemoryReserveOrWait, ThrowingSpillFunctionDoesNotStrandWaiter) {
         ctx->br()
     };
 
-    br->set_memory_limit(
-        MemoryType::DEVICE,
-        safe_cast<std::int64_t>(br->device_mr_adaptor().current_allocated())
-    );
+    // A timeout must preserve its bounded-progress contract by handing back a
+    // zero-size reservation. It must not evict queued device data merely to turn
+    // that timeout into an immediate full reservation.
+    SpillRecorder spills{br.get(), /* available = */ 0, /* spillable = */ 10};
     ASSERT_EQ(get_mem_avail(), 0);
-
-    std::atomic<bool> spill_called{false};
-    SpillManager::SpillFunction func = [&](std::size_t) -> std::size_t {
-        spill_called = true;
-        throw std::runtime_error("spill function failed");
-    };
-    auto fid = br->spill_manager().add_spill_function(func, /* priority = */ 1);
 
     // The waiter completes via the timeout instead of hanging on its queue.
     std::vector<Actor> actors;
     actors.push_back(waiter(mrow, 10, 0, 0));
     run_actor_network(std::move(actors));
 
-    br->spill_manager().remove_spill_function(fid);
-    EXPECT_TRUE(spill_called.load());
+    EXPECT_TRUE(spills.amounts().empty());
 }
 
 TEST_P(StreamingMemoryReserveOrWait, NoSpillWhenMemoryIsAvailable) {

--- a/python/rapidsmpf/rapidsmpf/communicator/ucxx.pyx
+++ b/python/rapidsmpf/rapidsmpf/communicator/ucxx.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """ucxx-based implementation of a RapidsMPF Communicator."""
 
@@ -10,12 +10,12 @@ from libcpp.optional cimport nullopt, nullopt_t
 from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.utility cimport move
-from ucxx._lib.libucxx cimport Address, UCXAddress, UCXWorker, Worker
 
 from rapidsmpf.communicator.communicator cimport *
 from rapidsmpf.communicator.ucxx cimport *
 from rapidsmpf.config cimport Options, cpp_Options
 from rapidsmpf.progress_thread cimport ProgressThread, cpp_ProgressThread
+from ucxx._lib.libucxx cimport Address, UCXAddress, UCXWorker, Worker
 
 
 cdef extern from "<variant>" namespace "std" nogil:

--- a/python/rapidsmpf/rapidsmpf/communicator/ucxx.pyx
+++ b/python/rapidsmpf/rapidsmpf/communicator/ucxx.pyx
@@ -10,12 +10,12 @@ from libcpp.optional cimport nullopt, nullopt_t
 from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.utility cimport move
+from ucxx._lib.libucxx cimport Address, UCXAddress, UCXWorker, Worker
 
 from rapidsmpf.communicator.communicator cimport *
 from rapidsmpf.communicator.ucxx cimport *
 from rapidsmpf.config cimport Options, cpp_Options
 from rapidsmpf.progress_thread cimport ProgressThread, cpp_ProgressThread
-from ucxx._lib.libucxx cimport Address, UCXAddress, UCXWorker, Worker
 
 
 cdef extern from "<variant>" namespace "std" nogil:

--- a/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
+++ b/python/rapidsmpf/rapidsmpf/streaming/core/memory_reserve_or_wait.pyx
@@ -42,7 +42,7 @@ cdef extern from * nogil:
         rapidsmpf::streaming::Context &ctx
     ) {
         return std::make_shared<rapidsmpf::streaming::MemoryReserveOrWait>(
-            std::move(options), ctx.logger(), mem_type, ctx.executor(), ctx.br()
+            std::move(options), mem_type, ctx.executor(), ctx.br()
         );
     }
     }  // namespace
@@ -357,11 +357,9 @@ cdef class MemoryReserveOrWait:
         when a final recovery attempt begins, not when it completes. If no pending
         reservation request can be satisfied within the timeout,
         ``MemoryReserveOrWait`` forces progress by selecting the smallest pending
-        request, spilling to make room for it, and attempting to reserve memory. That
-        spill waits for any in-flight spill to finish, so the call can return later
-        than the timeout. The forced reservation attempt may result in an empty
-        :class:`MemoryReservation` if the selected request still cannot be satisfied,
-        for example when nothing is spillable.
+        request and attempting to reserve memory without spilling queued data. The
+        forced reservation attempt may result in an empty :class:`MemoryReservation`
+        if the selected request still cannot be satisfied.
 
         When multiple reservation requests are eligible, ``MemoryReserveOrWait`` uses
         ``net_memory_delta`` as a heuristic to prefer requests that are expected to


### PR DESCRIPTION
## Summary

Avoid spilling queued streaming data from `MemoryReserveOrWait` when a device-memory reservation cannot be admitted immediately, partially reverting changes from #1164 .

The reservation flow continues to use reservation-aware availability, request ordering, smallest-net-delta selection, and the existing progress timeout implemented in #1164 . When no request fits, it now waits for a reservation release. At the timeout, it preserves the existing bounded-progress behavior: callers that allow overbooking receive a zero-size reservation and decide how to proceed, while non-overbooking callers retain their established failure path.

The change adds regression coverage that verifies neither ordinary polling nor the progress-timeout path invokes a spill function.

## Motivation and observations

In an isolated SF1000 TPC-H Q1 in an AWS g7e.8xlarge instance, admission-triggered spilling was associated with substantially higher device-memory residency and slower execution. Spilling queued messages can cause their rematerialization to overlap with incoming Parquet reads, increasing peak residency under this high-concurrency workload.

| Configuration | Q1 wall time | Peak observed device use | Result |
|---|---:|---:|---|
| Before this change | 32.84 s | 100.91 GB | Success with low headroom |
| Before this change, repeat | N/A | 102.63 GB | CUDA OOM |
| With this change | 10.64 s | 75.91 GB (70.70 GiB) | Success |

Relative to the successful before-change observation, this reduced observed runtime by 67.6% and peak device use by 25.0 GB (24.8%).

The experiment used one SPMD worker on SF1000 TPC-H Q1 with S3 input, pinned memory and a zero-byte initial pool, four streaming threads, a 4.2-GB Parquet target/pass limit, eight concurrent I/O tasks, and periodic spill checking disabled.

This is targeted at preventing `MemoryReserveOrWait` from directly evicting queued streaming data, it does not imply that reservation-aware availability accounting is incorrect or prescribe broader spill-policy defaults.