### PR TITLE
Add C++ API reference to Sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,10 @@
 from __future__ import annotations
 
 import datetime
+import glob
 import os
+import re
+import xml.etree.ElementTree as ET
 
 from enum import IntEnum, IntFlag
 from typing import Any
@@ -51,6 +54,53 @@ extensions = [
 # Breathe Configuration
 breathe_projects = {"librapidsmpf": "../../cpp/doxygen/xml"}
 breathe_default_project = "librapidsmpf"
+
+
+def clean_doxygen_xml(path: str) -> None:
+    # Doxygen 1.9.1 misparses concepts and requires clauses in its XML output.
+    return_types = {
+        "rapidsmpf::BufferResource::reserve_or_fail": "MemoryReservation",
+        "rapidsmpf::ContentDescription::ContentDescription": "",
+        "rapidsmpf::owner_equal": "bool",
+        "rapidsmpf::safe_cast": "To",
+    }
+
+    for filename in glob.glob(os.path.join(path, "*.xml")):
+        tree = ET.parse(filename)
+        changed = False
+        for section in tree.findall(".//sectiondef"):
+            for member in list(section.findall("./memberdef")):
+                type_node = member.find("type")
+                type_text = "".join(type_node.itertext()) if type_node is not None else ""
+                if type_text == "concept":
+                    section.remove(member)
+                    changed = True
+                    continue
+
+                definition = member.find("definition")
+                if type_text.startswith("requires ") and definition is not None:
+                    qualified_name = "".join(definition.itertext()).rsplit(" ", 1)[-1]
+                    if qualified_name in return_types:
+                        return_type = return_types[qualified_name]
+                        type_node.clear()
+                        type_node.text = return_type
+                        definition.clear()
+                        definition.text = f"{return_type} {qualified_name}".lstrip()
+                        changed = True
+
+                args = member.find("argsstring")
+                if args is not None and args.text is not None:
+                    cleaned_args = re.sub(r"\) requires.*", ")", args.text)
+                    if cleaned_args != args.text:
+                        args.text = cleaned_args
+                        changed = True
+
+        if changed:
+            tree.write(filename, encoding="UTF-8", xml_declaration=True)
+
+
+for project_path in breathe_projects.values():
+    clean_doxygen_xml(project_path)
 
 templates_path = ["_templates"]
 exclude_patterns = []
@@ -148,7 +198,51 @@ class CythonIntEnumDocumenter(ClassDocumenter):
             self.add_line("", source_name)
 
 
+def on_missing_reference(app, env, node, contnode):
+    if (refid := node.get("refid")) is not None and "hpp" in refid:
+        return contnode
+
+    if node["refdomain"] in ("std", "cpp") and (
+        reftarget := node.get("reftarget")
+    ) is not None:
+        if match := re.search("(.*)<.*>", reftarget):
+            reftarget = match.group(1)
+
+        prefixes = [
+            "rapidsmpf::",
+            "rapidsmpf::bootstrap::",
+            "rapidsmpf::coll::",
+            "rapidsmpf::communicator::",
+            "rapidsmpf::config::",
+            "rapidsmpf::mpi::",
+            "rapidsmpf::rrun::",
+            "rapidsmpf::shuffler::",
+            "rapidsmpf::streaming::",
+            "rapidsmpf::streaming::actor::",
+            "",
+        ]
+        for name, _, _, _, _, _ in env.domains["cpp"].get_objects():
+            for prefix in prefixes:
+                if name == f"{prefix}{reftarget}" or f"{prefix}{name}" == reftarget:
+                    if (
+                        ref := env.domains["cpp"].resolve_xref(
+                            env,
+                            node.get("refdoc"),
+                            app.builder,
+                            node["reftype"],
+                            name,
+                            node,
+                            contnode,
+                        )
+                    ) is not None:
+                        return ref
+        return contnode
+
+    return None
+
+
 def setup(app):
+    app.connect("missing-reference", on_missing_reference)
     app.registry.add_documenter("enum", CythonIntEnumDocumenter)
 
     # Prevent Sphinx from replacing native Cython modules with .pyi stubs.

--- a/docs/source/cpp/bootstrap.md
+++ b/docs/source/cpp/bootstrap.md
@@ -1,0 +1,6 @@
+# Bootstrap
+
+```{doxygennamespace} rapidsmpf::bootstrap
+:members:
+:content-only:
+```

--- a/docs/source/cpp/collectives.md
+++ b/docs/source/cpp/collectives.md
@@ -1,0 +1,6 @@
+# Collectives
+
+```{doxygennamespace} rapidsmpf::coll
+:members:
+:content-only:
+```

--- a/docs/source/cpp/configuration.md
+++ b/docs/source/cpp/configuration.md
@@ -1,0 +1,6 @@
+# Configuration
+
+```{doxygennamespace} rapidsmpf::config
+:members:
+:content-only:
+```

--- a/docs/source/cpp/core.md
+++ b/docs/source/cpp/core.md
@@ -1,0 +1,13 @@
+# Core API
+
+```{doxygennamespace} rapidsmpf
+:members:
+:content-only:
+```
+
+## MPI Utilities
+
+```{doxygennamespace} rapidsmpf::mpi
+:members:
+:content-only:
+```

--- a/docs/source/cpp/index.md
+++ b/docs/source/cpp/index.md
@@ -4,8 +4,20 @@ RapidsMPF exposes a full C++ API for building high-performance distributed GPU
 workloads without a Python runtime. The C++ layer is the foundation on which the
 Python bindings are built.
 
-The C++ API reference is available at
-[docs.rapids.ai/api/librapidsmpf/nightly](https://docs.rapids.ai/api/librapidsmpf/nightly/).
+## API Reference
+
+```{toctree}
+:maxdepth: 2
+
+core
+bootstrap
+collectives
+configuration
+metadata-payload-exchange
+shuffler
+streaming
+rrun
+```
 
 ## Coverage
 

--- a/docs/source/cpp/metadata-payload-exchange.md
+++ b/docs/source/cpp/metadata-payload-exchange.md
@@ -1,0 +1,6 @@
+# Metadata and Payload Exchange
+
+```{doxygennamespace} rapidsmpf::communicator
+:members:
+:content-only:
+```

--- a/docs/source/cpp/rrun.md
+++ b/docs/source/cpp/rrun.md
@@ -1,0 +1,6 @@
+# rrun
+
+```{doxygennamespace} rapidsmpf::rrun
+:members:
+:content-only:
+```

--- a/docs/source/cpp/shuffler.md
+++ b/docs/source/cpp/shuffler.md
@@ -1,0 +1,6 @@
+# Shuffler
+
+```{doxygennamespace} rapidsmpf::shuffler
+:members:
+:content-only:
+```

--- a/docs/source/cpp/streaming.md
+++ b/docs/source/cpp/streaming.md
@@ -1,0 +1,13 @@
+# Streaming Engine
+
+```{doxygennamespace} rapidsmpf::streaming
+:members:
+:content-only:
+```
+
+## Actors
+
+```{doxygennamespace} rapidsmpf::streaming::actor
+:members:
+:content-only:
+```


### PR DESCRIPTION
## Description

Expose the librapidsmpf C++ API in the Sphinx documentation through Breathe, organized by subsystem. Normalize Doxygen 1.9.1 XML that Breathe cannot parse and resolve generated C++ references so the documentation builds without warnings.

## API impact

No library API changes; this only changes generated documentation.