### PR TITLE
Remove obsolete devcontainer dependency list

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -30,30 +30,6 @@ files:
       - test_cpp
       - test_python
       - docs
-  devcontainers:
-    output: none
-    includes:
-      # "devcontainers" includes everything in "all" except "depends_on_ray"
-      - build-universal
-      - build-cpp
-      - build-python
-      - build-mpi
-      - build-nvml
-      - build-pmix
-      - checks
-      - clang_tidy
-      - cuda
-      - cuda_version
-      - depends_on_cupy
-      - depends_on_librmm
-      - depends_on_libucxx
-      - depends_on_rmm
-      - depends_on_ucxx
-      - py_version
-      - rapids_build_skbuild
-      - test_cpp
-      - test_python
-      - docs
   test_cpp:
     output: none
     includes:


### PR DESCRIPTION
Remove the redundant `devcontainers` dependency file list. Development containers can use the default `all` key now that the Ray and PyTorch dependencies resolve together.

Depends on rapidsai/devcontainers#761.
