### PR TITLE
CI: Migrate custom jobs to RTX PRO 6000

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -302,7 +302,7 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_cpp_memcheck.sh"
-      node_type: "gpu-l4-latest-1"
+      node_type: "gpu-rtxpro6000-latest-1"
   conda-python-build:
     needs: [build-details, conda-cpp-build]
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,7 @@ jobs:
       branch: ${{ inputs.branch }}
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       date: ${{ inputs.date }}
-      node_type: "gpu-l4-latest-1"
+      node_type: "gpu-rtxpro6000-latest-1"
       script: ci/test_cpp_memcheck.sh
       sha: ${{ inputs.sha }}
   conda-python-tests:


### PR DESCRIPTION
Migrates custom amd64 CI jobs from L4 to RTX PRO 6000 runners. This change helps rebalance CI capacity and uses the fastest hardware available for these jobs.

Documentation builds and ARM64 jobs remain on L4.

xref: https://github.com/rapidsai/build-planning/issues/322
