### PR TITLE
Adopt CUDA stream compatibility accessors

### DIFF
--- a/cpp/src/memory/buffer_resource.cpp
+++ b/cpp/src/memory/buffer_resource.cpp
@@ -321,7 +321,7 @@ std::unique_ptr<rmm::device_buffer> BufferResource::move_to_device_buffer(
     auto stream = buffer->stream();
     auto ret = move(std::move(buffer), reservation)->release_device_buffer();
     RAPIDSMPF_EXPECTS(
-        ret->stream().value() == stream.get(),
+        ret->stream().get() == stream.get(),
         "something went wrong, the Buffer's stream and the device_buffer's stream "
         "don't match"
     );

--- a/python/rapidsmpf/rapidsmpf/cuda_stream.pyx
+++ b/python/rapidsmpf/rapidsmpf/cuda_stream.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from rmm.pylibrmm.stream cimport Stream
@@ -19,4 +19,4 @@ def is_equal_streams(Stream s1 not None, Stream s2 not None):
     -------
     ``True`` if both inputs reference the same stream; ``False`` otherwise.
     """
-    return s1.view().value() == s2.view().value()
+    return s1.view().get() == s2.view().get()

--- a/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/buffer_resource.pyx
@@ -595,7 +595,7 @@ cdef class BufferResource:
             If ``size`` exceeds the reservation size.
         """
         cdef unique_ptr[cpp_Buffer] handle
-        cdef stream_ref cpp_stream = stream_ref(stream.view().value())
+        cdef stream_ref cpp_stream = stream_ref(stream.view().get())
         with nogil:
             handle = move(
                 deref(self._handle).make_buffer(

--- a/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/packed_data.pyx
@@ -201,7 +201,7 @@ cdef class PackedData:
         cdef const uint8_t* meta_ptr = NULL
         if meta_size > 0:
             meta_ptr = <const uint8_t*>&metadata[0]
-        cdef stream_ref sv = stream_ref(stream.view().value())
+        cdef stream_ref sv = stream_ref(stream.view().get())
         cdef unique_ptr[device_buffer] gpu = move(gpu_data.c_obj)
         cdef PackedData ret = cls.__new__(cls)
         with nogil:

--- a/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pyx
+++ b/python/rapidsmpf/rapidsmpf/memory/pinned_memory_resource.pyx
@@ -145,7 +145,7 @@ cdef class PinnedMemoryResource:
         Integer address of the allocated memory.
         """
         cdef void* ptr
-        cdef stream_ref cpp_stream = stream_ref(stream.view().value())
+        cdef stream_ref cpp_stream = stream_ref(stream.view().get())
         with nogil:
             ptr = self._handle.value().allocate(cpp_stream, nbytes)
         return <size_t>ptr
@@ -163,7 +163,7 @@ cdef class PinnedMemoryResource:
         stream
             CUDA stream associated with the allocation.
         """
-        cdef stream_ref cpp_stream = stream_ref(stream.view().value())
+        cdef stream_ref cpp_stream = stream_ref(stream.view().get())
         with nogil:
             self._handle.value().deallocate(cpp_stream, <void*>ptr, nbytes)
 


### PR DESCRIPTION
## Summary

Use the `get()` compatibility alias added in [RMM #2537](https://github.com/rapidsai/rmm/pull/2537). This spelling is shared by `rmm::cuda_stream_view` and `cuda::stream_ref`.

This preserves existing stream types and public APIs while extracting mechanical accessor updates from the broader [stream migration](https://github.com/rapidsai/build-planning/issues/318). It is independently buildable without [RMM #2372](https://github.com/rapidsai/rmm/pull/2372) and leaves the migration PR focused on actual type and signature changes.

This updates C++ and Cython raw-stream access to the compatibility spelling without changing the underlying stream-view APIs. Direct `cuda::stream_ref` forwarding remains in [RapidsMPF #1181](https://github.com/rapidsai/rapidsmpf/pull/1181).
