### PR TITLE
CUDA context in PausableThreadLoop's spawned thread

### DIFF
--- a/cpp/include/rapidsmpf/progress_thread.hpp
+++ b/cpp/include/rapidsmpf/progress_thread.hpp
@@ -193,7 +193,6 @@ class ProgressThread {
     void event_loop();
 
     std::shared_ptr<Statistics> statistics_;
-    bool is_thread_initialized_{false};
     bool active_{false};
     mutable std::mutex mutex_;
     std::condition_variable cv_;

--- a/cpp/src/pausable_thread_loop.cpp
+++ b/cpp/src/pausable_thread_loop.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/pausable_thread_loop.cpp
+++ b/cpp/src/pausable_thread_loop.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cuda_runtime_api.h>
+
 #include <rapidsmpf/error.hpp>
 #include <rapidsmpf/pausable_thread_loop.hpp>
 
@@ -10,6 +12,12 @@ namespace rapidsmpf::detail {
 
 PausableThreadLoop::PausableThreadLoop(std::function<void()> func, Duration sleep) {
     thread_ = std::thread([this, f = std::move(func), sleep]() {
+        // Establish a CUDA context on this thread before any user code runs. A
+        // freshly spawned std::thread does not inherit the constructing thread's
+        // CUDA context, and low-level driver-API calls (unlike the CUDA Runtime
+        // API) do not lazily establish one on first use.
+        RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
+
         while (true) {
             // wait until the thread is not paused
             state_.wait(State::Paused, std::memory_order_acquire);

--- a/cpp/src/pausable_thread_loop.cpp
+++ b/cpp/src/pausable_thread_loop.cpp
@@ -12,11 +12,7 @@ namespace rapidsmpf::detail {
 
 PausableThreadLoop::PausableThreadLoop(std::function<void()> func, Duration sleep) {
     thread_ = std::thread([this, f = std::move(func), sleep]() {
-        // Establish a CUDA context on this thread before any user code runs. A
-        // freshly spawned std::thread does not inherit the constructing thread's
-        // CUDA context, and low-level driver-API calls (unlike the CUDA Runtime
-        // API) do not lazily establish one on first use.
-        RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
+        bool is_thread_initialized = false;
 
         while (true) {
             // wait until the thread is not paused
@@ -46,6 +42,17 @@ PausableThreadLoop::PausableThreadLoop(std::function<void()> func, Duration slee
             {
                 state_.notify_all();
                 return;
+            }
+
+            if (!is_thread_initialized) {
+                // Establish a CUDA context on this thread before the first user callback.
+                // A freshly spawned std::thread does not inherit the constructing
+                // thread's CUDA context, and low-level driver-API calls (unlike the CUDA
+                // Runtime API) do not lazily establish one on first use. Defer
+                // initialization until the loop is resumed so construction does not
+                // contend with CUDA setup by the calling thread.
+                RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
+                is_thread_initialized = true;
             }
 
             f();

--- a/cpp/src/progress_thread.cpp
+++ b/cpp/src/progress_thread.cpp
@@ -25,18 +25,7 @@ void ProgressThread::FunctionState::operator()() {
 
 ProgressThread::ProgressThread(std::shared_ptr<Statistics> statistics, Duration sleep)
     : statistics_(std::move(statistics)),
-      thread_(
-          [this]() {
-              if (!is_thread_initialized_) {
-                  // This thread needs to have a cuda context associated with it.
-                  // For now, do so by calling cudaFree to initialise the driver.
-                  RAPIDSMPF_CUDA_TRY(cudaFree(nullptr));
-                  is_thread_initialized_ = true;
-              }
-              return event_loop();
-          },
-          sleep
-      ) {
+      thread_([this]() { return event_loop(); }, sleep) {
     RAPIDSMPF_EXPECTS(statistics_ != nullptr, "the statistics pointer cannot be NULL");
 }
 

--- a/cpp/tests/test_pausable_thread_loop.cpp
+++ b/cpp/tests/test_pausable_thread_loop.cpp
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <cuda/stream>
+
 #include <rmm/mr/cuda_memory_resource.hpp>
 
 #include <rapidsmpf/memory/buffer_resource.hpp>

--- a/cpp/tests/test_pausable_thread_loop.cpp
+++ b/cpp/tests/test_pausable_thread_loop.cpp
@@ -15,7 +15,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+#include <rmm/mr/cuda_memory_resource.hpp>
+
+#include <rapidsmpf/memory/buffer_resource.hpp>
 #include <rapidsmpf/pausable_thread_loop.hpp>
+#include <rapidsmpf/utils/misc.hpp>
 
 using rapidsmpf::detail::PausableThreadLoop;
 
@@ -84,4 +89,45 @@ TEST(PausableThreadLoop, MultiplePauseAndResume) {
     // loop could be running/paused. But all calls should have completed.
     loop.stop();
     EXPECT_FALSE(loop.is_running());
+}
+
+// Regression test for a bug where PausableThreadLoop's spawned std::thread never
+// established a CUDA context before running the caller's function. Low-level CUDA
+// driver-API calls (unlike the Runtime API) do not lazily establish a context on
+// first use, so a thread's first real CUDA touch could fail with "invalid device
+// context". This is exactly what happened to SpillManager's periodic spill thread:
+// it ticks constantly but, before this fix, only crashed the first time real memory
+// pressure actually forced it to spill (i.e. the first time its loop body did real
+// CUDA work). This test reproduces the same call chain (BufferResource::reserve +
+// BufferResource::make_buffer, allocating pinned-host memory, which goes through an
+// async CUDA memory pool at the driver-API level) directly from a freshly spawned
+// PausableThreadLoop thread that has never touched CUDA before.
+TEST(PausableThreadLoop, CanDoRealCudaWorkOnFirstTick) {
+    using namespace rapidsmpf;
+
+    if (!is_pinned_memory_resources_supported()) {
+        GTEST_SKIP() << "Pinned memory not supported on this system";
+    }
+
+    rmm::mr::cuda_memory_resource cuda_mr;
+    auto br = BufferResource::create(cuda_mr, PinnedPoolProperties{});
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
+
+    std::exception_ptr eptr;
+    PausableThreadLoop loop([&]() {
+        try {
+            auto [reservation, _] =
+                br->reserve(MemoryType::PINNED_HOST, 1024, AllowOverbooking::YES);
+            auto buf = br->make_buffer(1024, stream, reservation);
+        } catch (...) {
+            eptr = std::current_exception();
+        }
+    });
+    loop.resume();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    loop.stop();
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
 }

--- a/cpp/tests/test_pausable_thread_loop.cpp
+++ b/cpp/tests/test_pausable_thread_loop.cpp
@@ -92,18 +92,7 @@ TEST(PausableThreadLoop, MultiplePauseAndResume) {
     EXPECT_FALSE(loop.is_running());
 }
 
-// Regression test for a bug where PausableThreadLoop's spawned std::thread never
-// established a CUDA context before running the caller's function. Low-level CUDA
-// driver-API calls (unlike the Runtime API) do not lazily establish a context on
-// first use, so a thread's first real CUDA touch could fail with "invalid device
-// context". This is exactly what happened to SpillManager's periodic spill thread:
-// it ticks constantly but, before this fix, only crashed the first time real memory
-// pressure actually forced it to spill (i.e. the first time its loop body did real
-// CUDA work). This test reproduces the same call chain (BufferResource::reserve +
-// BufferResource::make_buffer, allocating pinned-host memory, which goes through an
-// async CUDA memory pool at the driver-API level) directly from a freshly spawned
-// PausableThreadLoop thread that has never touched CUDA before.
-TEST(PausableThreadLoop, CanDoRealCudaWorkOnFirstTick) {
+TEST(PausableThreadLoop, CanDoCudaWorkOnFirstTick) {
     using namespace rapidsmpf;
 
     if (!is_pinned_memory_resources_supported()) {

--- a/cpp/tests/test_progress_thread.cpp
+++ b/cpp/tests/test_progress_thread.cpp
@@ -8,8 +8,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cuda/stream>
+
+#include <rmm/mr/cuda_memory_resource.hpp>
+
+#include <rapidsmpf/memory/buffer_resource.hpp>
 #include <rapidsmpf/progress_thread.hpp>
 #include <rapidsmpf/statistics.hpp>
+#include <rapidsmpf/utils/misc.hpp>
 
 #include "environment.hpp"
 
@@ -106,4 +112,40 @@ TEST(ProgressThreadTests, RemoveFunctionWithDelayedPause) {
     progress_thread.remove_function(id);
 
     future.get();
+}
+
+// Regression test for a bug where ProgressThread's spawned thread had not established
+// a CUDA context before calling a registered function. Low-level CUDA driver-API calls
+// (unlike the Runtime API) do not lazily establish a context on first use, so a
+// function's first real CUDA touch could fail with "invalid device context". Exercise
+// the public ProgressThread API with the same pinned-host allocation path used by the
+// PausableThreadLoop regression test.
+TEST(ProgressThreadTests, CanDoRealCudaWorkOnFirstTick) {
+    using namespace rapidsmpf;
+
+    if (!is_pinned_memory_resources_supported()) {
+        GTEST_SKIP() << "Pinned memory not supported on this system";
+    }
+
+    rmm::mr::cuda_memory_resource cuda_mr;
+    auto br = BufferResource::create(cuda_mr, PinnedPoolProperties{});
+    auto stream = cuda::stream_ref{cudaStreamLegacy};
+
+    std::exception_ptr eptr;
+    ProgressThread progress_thread;
+    auto id = progress_thread.add_function([&]() {
+        try {
+            auto [reservation, _] =
+                br->reserve(MemoryType::PINNED_HOST, 1024, AllowOverbooking::YES);
+            auto buf = br->make_buffer(1024, stream, reservation);
+        } catch (...) {
+            eptr = std::current_exception();
+        }
+        return ProgressThread::ProgressState::Done;
+    });
+    progress_thread.remove_function(id);
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
 }

--- a/cpp/tests/test_progress_thread.cpp
+++ b/cpp/tests/test_progress_thread.cpp
@@ -114,13 +114,7 @@ TEST(ProgressThreadTests, RemoveFunctionWithDelayedPause) {
     future.get();
 }
 
-// Regression test for a bug where ProgressThread's spawned thread had not established
-// a CUDA context before calling a registered function. Low-level CUDA driver-API calls
-// (unlike the Runtime API) do not lazily establish a context on first use, so a
-// function's first real CUDA touch could fail with "invalid device context". Exercise
-// the public ProgressThread API with the same pinned-host allocation path used by the
-// PausableThreadLoop regression test.
-TEST(ProgressThreadTests, CanDoRealCudaWorkOnFirstTick) {
+TEST(ProgressThreadTests, CanDoCudaWorkOnFirstCallback) {
     using namespace rapidsmpf;
 
     if (!is_pinned_memory_resources_supported()) {


### PR DESCRIPTION
This PR was largely generated by Claude

I think this resolves https://github.com/rapidsai/rapidsmpf/issues/1202.  

What I think is happening is that rapidsmpf's PausableThreadLoop spawns a background thread that never establishes a CUDA ctx. Agent seems to believe that we never really hit this problem problem as most of the time we aren't spilling loads of data.  Issue #1202 specifically tests spilling loads of data.  Additionally, I asked the agent to also write a test which specifically attempts to spill data using Periodic Spill Check.  Test fails without the patch included in this PR

I find the documentation here quite verbose but left it for now to provide additional ctx -- heh